### PR TITLE
Add link to GitHub issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the software supply chain. The requirements are inspired by Google’s internal
 that is mandatory for all of Google's production workloads.
 
 **IMPORTANT:** SLSA is an evolving specification and we are looking for
-wide-ranging feedback via GitHub issues, [email][mailing list], or
+wide-ranging feedback via [GitHub issues], [email][mailing list], or
 [feedback form]. SLSA is being developed as part of the
 [OpenSSF Digital Identity WG](https://github.com/ossf/wg-digital-identity-attestation).
 
@@ -370,6 +370,7 @@ Other takes on provenance and CI/CD:
 <!-- Links -->
 
 [Binary Authorization for Borg]: https://cloud.google.com/security/binary-authorization-for-borg
+[GitHub issues]: https://github.com/slsa-framework/slsa/issues
 [Threats, Risks, and Mitigations in the Open Source Ecosystem]: https://github.com/Open-Source-Security-Coalition/Open-Source-Security-Coalition/blob/master/publications/threats-risks-mitigations/v1.1/Threats%2C%20Risks%2C%20and%20Mitigations%20in%20the%20Open%20Source%20Ecosystem%20-%20v1.1.pdf
 [curl-dev]: https://pkgs.alpinelinux.org/package/edge/main/x86/curl-dev
 [curlimages/curl]: https://hub.docker.com/r/curlimages/curl


### PR DESCRIPTION
This makes it easier to open an issue, especially from slsa.dev.
