### PR TITLE
Make workflow permissions read only

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,6 @@
 name: Lint
 on: [pull_request]
+permissions: read-all
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As per the [GitHub doc](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions), let's follow the principle of least privilege and make the tokens read only.

Can be detected with:
```
scorecard --repo=github.com/slsa-framework/slsa/ --checks Token-Permissions --show-details
...
!! token-permissions/github-token - no permission defined in .github/workflows/lint.yml
```
AFAIK, the action used need not write access.