### PR TITLE
Have dependabot keep npm modules up-to-date also

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 updates:
+
 - package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+
+- package-ecosystem: npm
   directory: "/"
   schedule:
     interval: daily


### PR DESCRIPTION
As we now keep npm packaging metadata in the repository, have dependabot monitor it and notify of updates.