### PR TITLE
Lay disallowance emphasis on RFC2119 MUST NOT

### DIFF
--- a/requirements.md
+++ b/requirements.md
@@ -241,7 +241,7 @@ The user-defined build script:
   The build service:
 
 -   MUST fetch all artifacts in a trusted control plane.
--   MUST disallow mutable references.
+-   MUST NOT allow mutable references.
 -   MUST verify the integrity of each artifact.
     -   If the [immutable reference] includes a cryptographic hash, the service
         MUST verify the hash and reject the fetch if the verification fails.


### PR DESCRIPTION
This is a very minor stylistic change. Instead of using "MUST disallow" as the negative, I suggest using "MUST NOT allow". This places the emphasis onto the RFC 2119 term and makes visual scanning easier.