### PR TITLE
Remove source & entrypoint reqs at SLSA 1/2

### DIFF
--- a/requirements.md
+++ b/requirements.md
@@ -392,7 +392,7 @@ provenance. This represents the entity that the consumer must trust. Examples:
 The provenance identifies the source containing the top-level build script, via
 an [immutable reference]. Example: git URL + branch/tag/ref + commit ID.
 
-<td>✓<td>✓<td>✓<td>✓
+<td><td><td>✓<td>✓
 <tr id="identifies-entry-point">
 <td>Identifies Entry Point
 <td>
@@ -400,7 +400,7 @@ an [immutable reference]. Example: git URL + branch/tag/ref + commit ID.
 The provenance identifies the "entry point" or command that was used to invoke
 the build script. Example: `make all`.
 
-<td>✓<td>✓<td>✓<td>✓
+<td><td><td>✓<td>✓
 <tr id="includes-all-params">
 <td>Includes All Build Parameters
 <td>


### PR DESCRIPTION
Many builders don't necessarily have this information available to populate the provenance.

In the interest of making the lower levels easier to adopt I propose we remove this requirement at
the lower levels so that builders can comply without having to make major architectural changes
or requiring that users use them in any particular manner.