### PR TITLE
Remove version comments from pinned actions.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f # v2.3.4
+      uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
     - name: Setup Node
-      uses: actions/setup-node@aa759c6c94d3800c55b8601f21ba4b2371704cb7 # v2.2.0
+      uses: actions/setup-node@aa759c6c94d3800c55b8601f21ba4b2371704cb7
     - run: npm ci --ignore-scripts
     - run: npm run lint --silent


### PR DESCRIPTION
Dependabot automated version bumps only update the hash, not the
comment, so the comment is likely to get stale. Example: #102.
