### PR TITLE
Fix link to in-toto provenance

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -297,7 +297,7 @@ Requirements on the process by which provenance is generated and consumed:
 <td>
 
 The provenance is available to the consumer in a format that the consumer
-accepts. The format SHOULD be in-toto [SLSA Provenance](provenance/index.md),
+accepts. The format SHOULD be in-toto [SLSA Provenance](provenance/index.html),
 but another format MAY be used if both producer and consumer agree and it meets
 all the other requirements.
 


### PR DESCRIPTION
The link at https://slsa.dev/requirements#provenance-requirements is broken.