### PR TITLE
Require config as code at levels L3+

### DIFF
--- a/docs/provenance/v0.1.md
+++ b/docs/provenance/v0.1.md
@@ -416,6 +416,7 @@ Here `entryPoint` references the `filename` from the CloudBuild
 ```
 
 #### Cloud Build RPC
+
 Here we list the steps defined in a trigger or over RPC:
 
 ```jsonc

--- a/docs/provenance/v0.1.md
+++ b/docs/provenance/v0.1.md
@@ -394,9 +394,10 @@ Custom worker: Not yet supported. We need to figure out a URI scheme that
 represents what system hosted the worker, or perhaps add additional properties
 in `builder`.
 
-Cloud Build config-as-code
-([BuildTrigger](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.triggers)
-with `filename`):
+#### Cloud Build config-as-code
+
+Here `entryPoint` references the `filename` from the CloudBuild
+[BuildTrigger](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.triggers).
 
 ```jsonc
 "recipe": {
@@ -414,7 +415,8 @@ with `filename`):
 }
 ```
 
-Cloud Build with steps defined in a trigger or over RPC:
+#### Cloud Build rpc
+Here we list the steps defined in a trigger or over RPC:
 
 ```jsonc
 "recipe": {
@@ -431,7 +433,7 @@ Cloud Build with steps defined in a trigger or over RPC:
 }
 ```
 
-### Manually run commands
+### Explicitly run commands
 
 WARNING: This is just a proof-of-concept. It is not yet standardized.
 

--- a/docs/provenance/v0.1.md
+++ b/docs/provenance/v0.1.md
@@ -415,7 +415,7 @@ Here `entryPoint` references the `filename` from the CloudBuild
 }
 ```
 
-#### Cloud Build rpc
+#### Cloud Build RPC
 Here we list the steps defined in a trigger or over RPC:
 
 ```jsonc

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -443,8 +443,8 @@ used to drive the build including what source repo the the configuration was
 read from.
 
 Example:
-source repo: git URL + branch/tag/ref + commit ID
-entrypoint: path to config file(s) (e.g. ./.zuul.yaml) + job name within config
+- source repo: git URL + branch/tag/ref + commit ID
+- entrypoint: path to config file(s) (e.g. ./.zuul.yaml) + job name within config
     (e.g. envoy-build-arm64)
 
 <td><td><td>✓<td>✓

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -199,6 +199,14 @@ workstation.
 Examples: GitHub Actions, Google Cloud Build, Travis CI.
 
 <td> <td>✓<td>✓<td>✓
+<tr id="config-as-code">
+<td>Config as code
+<td>
+
+The build service configuration is driven from files stored in source control.
+
+Examples: zuul.yaml, cloudbuild.yaml, .github/workflows
+<td> <td> <td>✓<td>✓
 <tr id="ephemeral-environment">
 <td>Ephemeral environment
 <td>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -203,7 +203,7 @@ Examples: GitHub Actions, Google Cloud Build, Travis CI.
 <td>Config as code
 <td>
 
-The build service configuration is driven from files stored in source control.
+The build service configuration is defined in files stored in source control.
 
 Examples: zuul.yaml, cloudbuild.yaml, .github/workflows
 <td> <td> <td>✓<td>✓

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -205,7 +205,15 @@ Examples: GitHub Actions, Google Cloud Build, Travis CI.
 
 The build service configuration is defined in files stored in source control.
 
-Examples: zuul.yaml, cloudbuild.yaml, .github/workflows
+When using config-as-code the <a href="identifies-entry-point">entry point</a>
+MUST identify the build service configuration.
+
+Examples:
+
+- cloudbuild.yaml:gcr.io/cloud-builders/docker
+- .github/workflows/build.yaml:build-npm
+- .zuul.yaml:envoy-build-arm64
+
 <td> <td> <td>✓<td>✓
 <tr id="ephemeral-environment">
 <td>Ephemeral environment

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -424,13 +424,13 @@ build does not use config-as-code it MAY list details of the build steps.
 
 Config-as-code example:
 
-```json
+```json5
 "recipe": {
   "type": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
   // Identifies the source repo of the build config.
   "definedInMaterial": 0,
-  # Identifies the entrypoint within the source repo at the path
-  # .github/workflows/build.yaml, using the job "build".
+  // Identifies the entrypoint within the source repo at the path
+  // .github/workflows/build.yaml, using the job "build".
   "entryPoint": ".github/workflows/build.yaml:build",
 },
 …
@@ -442,10 +442,10 @@ Config-as-code example:
 
 Build steps example:
 
-```json
+```json5
 "recipe": {
-  # Build steps were provided as an argument. No `definedInMaterial` or
-  # `entryPoint`.
+  // Build steps were provided as an argument. No `definedInMaterial` or
+  // `entryPoint`.
   "type": "https://tekton.dev/chains/recipe/buildSteps@v1",
   "arguments": {
       "steps": [

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -425,11 +425,12 @@ If the build uses <a href="#config-as-code">config-as-code<a>, this SHOULD be th
 source repo and entry point of the build config (as in
 [the GitHub Actions example](https://slsa.dev/provenance/v0.1#github-actions)).
 
-If the build doesn't use config-as-code it MAY list the details of what it did
-as in
+If the build doesn't use config-as-code it MAY list the details of what it was
+asked to do (as in
 [the Google Cloud Build RPC example](https://slsa.dev/provenance/v0.1#cloud-build-rpc)
 or
-[the Explicitly Run Commands example](https://slsa.dev/provenance/v0.1#explicitly-run-commands).
+[the Explicitly Run Commands example](https://slsa.dev/provenance/v0.1#explicitly-run-commands)
+).
 
 <td>✓<td>✓<td>✓<td>✓
 <tr id="identifies-entry-point">

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -433,7 +433,7 @@ Build steps example:
 ```
 TODO
 ```
-
+<td>✓<td>✓<td>✓<td>✓
 <tr id="identifies-entry-point">
 <td>Identifies entry point
 <td>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -415,10 +415,10 @@ provenance. This represents the entity that the consumer must trust. Examples:
 <td>Identifies build instructions
 <td>
 
-Identifies the top-level instructions used to execute the build.
+The provenance identifies the top-level instructions used to execute the build.
 
 The identified instructions SHOULD be at the highest level available to the build
-(e.g. if the build it told to run build.sh it should list build.sh and NOT the
+(e.g. if the build is told to run build.sh it should list build.sh and NOT the
 individual instructions in build.sh).
 
 If the build uses <a href="#config-as-code">config-as-code<a>, this SHOULD be the

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -424,14 +424,51 @@ build does not use config-as-code it MAY list details of the build steps.
 
 Config-as-code example:
 
-```
-TODO
+```json
+"recipe": {
+  "type": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
+  // Identifies the source repo of the build config.
+  "definedInMaterial": 0,
+  // Identifies the entrypoint within the source repo at the path
+  // .github/workflows/build.yaml, using the job "build".
+  "entryPoint": ".github/workflows/build.yaml:build",
+},
+…
+"materials": [{
+   "uri": "git+https://the.repo/foo",
+   "digest": {"sha1": "abc123..."}
+}]
 ```
 
 Build steps example:
 
-```
-TODO
+```json
+"recipe": {
+  // Build steps were provided as an argument. No `definedInMaterial` or
+  // `entryPoint`.
+  "type": "https://tekton.dev/chains/recipe/buildSteps@v1",
+  "arguments": {
+      steps: [
+          {
+            "entryPoint": "",
+            "arguments": null,
+            "environment": {
+              "container": "git-source-repo-jwqcl",
+              "image": "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247"
+            },
+            "annotations": null
+          },
+          {
+            "entryPoint": "#!/usr/bin/env bash\nset -x\n\ncd $(inputs.resources.repo.path)\n\nbazel build --host_force_python=PY2 //package_manager:dpkg_parser.par\ncp bazel-bin/package_manager/dpkg_parser.par .\n\nbazel build //base:static_root_amd64_debian10.tar\n\ncp bazel-bin/base/static_root_amd64_debian10.tar .\n\nfind /workspace/repo\npwd\n\necho \"gcr.io/foo/bar\" > $(results.IMAGE_URL.path)\n",
+            "arguments": null,
+            "environment": {
+              "container": "build",
+              "image": "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964"
+            },
+            "annotations": null
+          }
+    ]
+}
 ```
 <td>✓<td>✓<td>✓<td>✓
 <tr id="identifies-entry-point">
@@ -439,8 +476,8 @@ TODO
 <td>
 
 The provenance identifies the "entry point" of the build service configuration
-used to drive the build including what source repo the the configuration was
-read from.
+used to drive the build including what source repo the configuration was read
+from.
 
 Example:
 - source repo: git URL + branch/tag/ref + commit ID

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -429,8 +429,7 @@ If the build doesn't use config-as-code it MAY list the details of what it was
 asked to do (as in
 [the Google Cloud Build RPC example](https://slsa.dev/provenance/v0.1#cloud-build-rpc)
 or
-[the Explicitly Run Commands example](https://slsa.dev/provenance/v0.1#explicitly-run-commands)
-).
+[the Explicitly Run Commands example](https://slsa.dev/provenance/v0.1#explicitly-run-commands)).
 
 <td>✓<td>✓<td>✓<td>✓
 <tr id="identifies-entry-point">

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -418,9 +418,10 @@ provenance. This represents the entity that the consumer must trust. Examples:
 Identifies the top-level instructions used to execute the build.
 
 The identified instructions SHOULD be at the highest level available to the build. 
-If the build uses config-as-code, this SHOULD be the source repo and entry point
-of the build config and NOT the build steps within the build config.  If the
-build does not use config-as-code it MAY list details of the build steps.
+If the build uses <a href="#config-as-code">config-as-code<a>, this SHOULD be the
+source repo and entry point of the build config and NOT the build steps within the
+build config.  If the build does not use config-as-code it MAY list details of the
+build steps.
 
 Config-as-code example:
 
@@ -476,8 +477,8 @@ Build steps example:
 <td>
 
 The provenance identifies the "entry point" of the build service configuration
-used to drive the build including what source repo the configuration was read
-from.
+(see <a href="#config-as-code">config-as-code</a>) used to drive the build
+including what source repo the configuration was read from.
 
 Example:
 - source repo: git URL + branch/tag/ref + commit ID

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -417,7 +417,10 @@ provenance. This represents the entity that the consumer must trust. Examples:
 
 Identifies the top-level instructions used to execute the build.
 
-The identified instructions SHOULD be at the highest level available to the build.
+The identified instructions SHOULD be at the highest level available to the build
+(e.g. if the build it told to run build.sh it should list build.sh and NOT the
+individual instructions in build.sh).
+
 If the build uses <a href="#config-as-code">config-as-code<a>, this SHOULD be the
 source repo and entry point of the build config and NOT the build steps within the
 build config.  If the build does not use config-as-code it MAY list details of the

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -447,28 +447,27 @@ Build steps example:
 "recipe": {
   // Build steps were provided as an argument. No `definedInMaterial` or
   // `entryPoint`.
-  "type": "https://tekton.dev/chains/recipe/buildSteps@v1",
+  "type": "https://foobuilder.dev/recipe/buildSteps@v1",
   "arguments": {
-      "steps": [
-          {
-            "entryPoint": "",
-            "arguments": null,
-            "environment": {
-              "container": "git-source-repo-jwqcl",
-              "image": "gcr.io/tekton-releases/..."
-            },
-            "annotations": null
-          },
-          {
-            "entryPoint": "#!/usr/bin/env bash\nset -x\n\ncd ...",
-            "arguments": null,
-            "environment": {
-              "container": "build",
-              "image": "gcr.io/cloud-marketplace-containers/..."
-            },
-            "annotations": null
-          }
+    "steps": [
+      {
+        "entryPoint": "",
+        "arguments": null,
+        "image":
+            "gcr.io/foo-releases/github.com/foobuilder/pipeline/cmd/git-init@sha256:b963...",
+      },
+      {
+        "entryPoint":
+            "#!/usr/bin/env bash\nset -x\n\ncd src\n\nbuild.sh",
+        "arguments": [
+          "-c",
+          "set -x; cd /workspace/repo && crane digest --tarball=static_root_amd64_debian10.tar > $(results.IMAGE_DIGEST.path) && cat $(results.IMAGE_DIGEST.path)"
+        ],
+        "image":
+            "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1e..."",
+      }
     ]
+  }
 }
 ```
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -203,7 +203,7 @@ Examples: GitHub Actions, Google Cloud Build, Travis CI.
 <td>Config as code
 <td>
 
-The build service configuration is defined in source control and drives the build automatically.
+The build service configuration is defined in source control and is executed by the build service.
 
 Examples: cloudbuild.yaml, ./github/workflows/build.yaml, zuul.yaml.
 <td> <td> <td>✓<td>✓

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -422,57 +422,14 @@ The identified instructions SHOULD be at the highest level available to the buil
 individual instructions in build.sh).
 
 If the build uses <a href="#config-as-code">config-as-code<a>, this SHOULD be the
-source repo and entry point of the build config and NOT the build steps within the
-build config.  If the build does not use config-as-code it MAY list details of the
-build steps.
+source repo and entry point of the build config (as in
+[the GitHub Actions example](https://slsa.dev/provenance/v0.1#github-actions)).
 
-Config-as-code example:
-
-```json5
-"recipe": {
-  "type": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
-  // Identifies the source repo of the build config.
-  "definedInMaterial": 0,
-  // Identifies the entrypoint within the source repo at the path
-  // .github/workflows/build.yaml, using the job "build".
-  "entryPoint": ".github/workflows/build.yaml:build",
-},
-…
-"materials": [{
-   "uri": "git+https://the.repo/foo",
-   "digest": {"sha1": "abc123..."}
-}]
-```
-
-Build steps example:
-
-```json5
-"recipe": {
-  // Build steps were provided as an argument. No `definedInMaterial` or
-  // `entryPoint`.
-  "type": "https://foobuilder.dev/recipe/buildSteps@v1",
-  "arguments": {
-    "steps": [
-      {
-        "entryPoint": "",
-        "arguments": null,
-        "image":
-            "gcr.io/foo-releases/github.com/foobuilder/pipeline/cmd/git-init@sha256:b963...",
-      },
-      {
-        "entryPoint":
-            "#!/usr/bin/env bash\nset -x\n\ncd src\n\nbuild.sh",
-        "arguments": [
-          "-c",
-          "set -x; cd /workspace/repo && crane digest --tarball=static_root_amd64_debian10.tar > $(results.IMAGE_DIGEST.path) && cat $(results.IMAGE_DIGEST.path)"
-        ],
-        "image":
-            "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1e..."",
-      }
-    ]
-  }
-}
-```
+If the build doesn't use config-as-code it MAY list the details of what it did
+as in
+[the Google Cloud Build RPC example](https://slsa.dev/provenance/v0.1#cloud-build-rpc)
+or
+[the Explicitly Run Commands example](https://slsa.dev/provenance/v0.1#explicitly-run-commands).
 
 <td>✓<td>✓<td>✓<td>✓
 <tr id="identifies-entry-point">

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -203,17 +203,9 @@ Examples: GitHub Actions, Google Cloud Build, Travis CI.
 <td>Config as code
 <td>
 
-The build service configuration is defined in files stored in source control.
+The build service configuration is defined in source control and drives the build automatically.
 
-When using config-as-code the <a href="identifies-entry-point">entry point</a>
-MUST identify the build service configuration.
-
-Examples:
-
-- cloudbuild.yaml:gcr.io/cloud-builders/docker
-- .github/workflows/build.yaml:build-npm
-- .zuul.yaml:envoy-build-arm64
-
+Examples: cloudbuild.yaml, ./github/workflows/build.yaml, zuul.yaml.
 <td> <td> <td>✓<td>✓
 <tr id="ephemeral-environment">
 <td>Ephemeral environment
@@ -419,22 +411,43 @@ provenance. This represents the entity that the consumer must trust. Examples:
 "GitHub Actions with a GitHub-hosted worker", "jdoe@example.com's machine".
 
 <td>✓<td>✓<td>✓<td>✓
-<tr id="identifies-source">
-<td>Identifies source
+<tr id="identifies-build-instructions">
+<td>Identifies build instructions
 <td>
 
-The provenance identifies the source containing the top-level build script, via
-an [immutable reference]. Example: git URL + branch/tag/ref + commit ID.
+Identifies the top-level instructions used to execute the build.
 
-<td>✓<td>✓<td>✓<td>✓
+The identified instructions SHOULD be at the highest level available to the build. 
+If the build uses config-as-code, this SHOULD be the source repo and entry point
+of the build config and NOT the build steps within the build config.  If the
+build does not use config-as-code it MAY list details of the build steps.
+
+Config-as-code example:
+
+```
+TODO
+```
+
+Build steps example:
+
+```
+TODO
+```
+
 <tr id="identifies-entry-point">
 <td>Identifies entry point
 <td>
 
-The provenance identifies the "entry point" or command that was used to invoke
-the build script. Example: `make all`.
+The provenance identifies the "entry point" of the build service configuration
+used to drive the build including what source repo the the configuration was
+read from.
 
-<td>✓<td>✓<td>✓<td>✓
+Example:
+source repo: git URL + branch/tag/ref + commit ID
+entrypoint: path to config file(s) (e.g. ./.zuul.yaml) + job name within config
+    (e.g. envoy-build-arm64)
+
+<td><td><td>✓<td>✓
 <tr id="includes-all-params">
 <td>Includes all build parameters
 <td>

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -417,7 +417,7 @@ provenance. This represents the entity that the consumer must trust. Examples:
 
 Identifies the top-level instructions used to execute the build.
 
-The identified instructions SHOULD be at the highest level available to the build. 
+The identified instructions SHOULD be at the highest level available to the build.
 If the build uses <a href="#config-as-code">config-as-code<a>, this SHOULD be the
 source repo and entry point of the build config and NOT the build steps within the
 build config.  If the build does not use config-as-code it MAY list details of the
@@ -471,6 +471,7 @@ Build steps example:
     ]
 }
 ```
+
 <td>✓<td>✓<td>✓<td>✓
 <tr id="identifies-entry-point">
 <td>Identifies entry point
@@ -481,8 +482,9 @@ The provenance identifies the "entry point" of the build service configuration
 including what source repo the configuration was read from.
 
 Example:
-- source repo: git URL + branch/tag/ref + commit ID
-- entrypoint: path to config file(s) (e.g. ./.zuul.yaml) + job name within config
+
+-   source repo: git URL + branch/tag/ref + commit ID
+-   entrypoint: path to config file(s) (e.g. ./.zuul.yaml) + job name within config
     (e.g. envoy-build-arm64)
 
 <td><td><td>✓<td>✓

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -429,8 +429,8 @@ Config-as-code example:
   "type": "https://github.com/Attestations/GitHubActionsWorkflow@v1",
   // Identifies the source repo of the build config.
   "definedInMaterial": 0,
-  // Identifies the entrypoint within the source repo at the path
-  // .github/workflows/build.yaml, using the job "build".
+  # Identifies the entrypoint within the source repo at the path
+  # .github/workflows/build.yaml, using the job "build".
   "entryPoint": ".github/workflows/build.yaml:build",
 },
 …
@@ -444,26 +444,26 @@ Build steps example:
 
 ```json
 "recipe": {
-  // Build steps were provided as an argument. No `definedInMaterial` or
-  // `entryPoint`.
+  # Build steps were provided as an argument. No `definedInMaterial` or
+  # `entryPoint`.
   "type": "https://tekton.dev/chains/recipe/buildSteps@v1",
   "arguments": {
-      steps: [
+      "steps": [
           {
             "entryPoint": "",
             "arguments": null,
             "environment": {
               "container": "git-source-repo-jwqcl",
-              "image": "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init@sha256:b963f6e7a69617db57b685893256f978436277094c21d43b153994acd8a01247"
+              "image": "gcr.io/tekton-releases/..."
             },
             "annotations": null
           },
           {
-            "entryPoint": "#!/usr/bin/env bash\nset -x\n\ncd $(inputs.resources.repo.path)\n\nbazel build --host_force_python=PY2 //package_manager:dpkg_parser.par\ncp bazel-bin/package_manager/dpkg_parser.par .\n\nbazel build //base:static_root_amd64_debian10.tar\n\ncp bazel-bin/base/static_root_amd64_debian10.tar .\n\nfind /workspace/repo\npwd\n\necho \"gcr.io/foo/bar\" > $(results.IMAGE_URL.path)\n",
+            "entryPoint": "#!/usr/bin/env bash\nset -x\n\ncd ...",
             "arguments": null,
             "environment": {
               "container": "build",
-              "image": "gcr.io/cloud-marketplace-containers/google/bazel@sha256:010a1ecd1a8c3610f12039a25b823e3a17bd3e8ae455a53e340dcfdd37a49964"
+              "image": "gcr.io/cloud-marketplace-containers/..."
             },
             "annotations": null
           }


### PR DESCRIPTION
* Require build instructions to be tracked at **all** levels.
  * Lets people know how a build was produced.
  * Should support all build methods without requiring architectural changes.
  * If we adopt [this document](https://docs.google.com/document/d/1fLtR5-AfauKlgTvQ1yRrupIZVnX3YqBhAjO_2X3d4qE/edit#heading=h.q2vn2vj1ydg5) as level motivation (#111) then we may only need to require build instructions at level 2+ or 3+.  We can easily relax this requirement later, while making the requirement more strict would be more difficult.
* Require config-as-code at L3+.
  * Allows people to review the details of how builds are performed.
  * Can require changes to how builds are performed to be reviewed by additional parties.
  * Tracks changes to how builds are produced over time.
  * Provides an easier method of writing policy to make sure an artifact followed the build steps you expect (just point at the build config in source control)
  * May require architectural changes in some builders or changes to how users interface with their build service (e.g. Tekton, LUCI, Cloud Build)
* Combine "identifies source" with "identifies entry point".
  * The 'identifies source' requirement was _already_ specific to the top-level build script which was the 'entry point'.
    So there doesn't seem to be a reason to have these as separate requirements.
  * 'Identifies source' might have had an overly broad name since it was only talking about where the top-level build script was, but could have been interpreted to mean "identifies **all** source" (which it did not!).
* Only require "identifies entry point" at L3+.
  * As discussed with 'config-as-code' above, not all build architectures support  singular entry-points that are defined in a script.
  * Requiring 'identifies build instructions' at all levels should cover cases where folks aren't using config-as-code.
* Small updates to provenance examples to make linking easier.

This PR _does not_ take a position on how/if requiring all sources or dependencies be recorded in the provenance. That should
be handled in a different PR addressing  a different issue.

Note #115 suggested the language "require that the provenance identify the independent inputs", but I found "independent inputs" to be fairly broad.  The rest of the text of #115 indicated that this was really about tracking what the build did, so "build instructions" seems to cover the spirit of #115.

fixes #115 