### PR TITLE
Add git materials to examples.

### DIFF
--- a/docs/provenance/v0.1.md
+++ b/docs/provenance/v0.1.md
@@ -373,6 +373,13 @@ GitHub Actions Workflow:
     }
   }
 }
+"materials": [{
+  // The git repo that contains the build.yaml referenced above.
+  "uri": "git+https://github.com/foo/bar.git",
+  // The resolved git commit hash reflecting the version of the repo used
+  // for this build.
+  "digest": {"sha1": "abc..."}
+}]
 ```
 
 ### Google Cloud Build
@@ -412,6 +419,13 @@ with `filename`):
     "substitutions": {...}
   }
 }
+"materials": [{
+  // The git repo that contains the cloudbuild.yaml referenced above.
+  "uri": "git+https://source.developers.google.com/p/foo/r/bar",
+  // The resolved git commit hash reflecting the version of the repo used
+  // for this build.
+  "digest": {"sha1": "abc..."}
+}]
 ```
 
 Cloud Build with steps defined in a trigger or over RPC:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -128,7 +128,7 @@ obliteration, such as a legal or policy requirement.
 -   **[Immutable history]** It must not be possible for persons to delete or
     modify the history, even with multi-party approval, except by trusted
     platform admins with two-party approval following the obliterate policy.
--   **[Limited retention for SLSA 2]** At SLSA 2 (but not 3), it is acceptable
+-   **[Limited retention for SLSA 3]** At SLSA 3 (but not 4), it is acceptable
     for the retention to be limited to 18 months, as attested by the source
     control platform.
     -   Example: If a commit is made on 2020-04-05 and then a retention


### PR DESCRIPTION
The examples previously only had 'recipe', now they also have
'materials'. Note that they are not complete and exclude 'metadata'.

Refs #143