### PR TITLE
Add git materials to examples.

### DIFF
--- a/docs/provenance/v0.1.md
+++ b/docs/provenance/v0.1.md
@@ -373,6 +373,13 @@ GitHub Actions Workflow:
     }
   }
 }
+"materials": [{
+  // The git repo that contains the build.yaml referenced above.
+  "uri": "git+https://github.com/foo/bar.git",
+  // The resolved git commit hash reflecting the version of the repo used
+  // for this build.
+  "digest": {"sha1": "abc..."}
+}]
 ```
 
 ### Google Cloud Build
@@ -412,6 +419,13 @@ with `filename`):
     "substitutions": {...}
   }
 }
+"materials": [{
+  // The git repo that contains the cloudbuild.yaml referenced above.
+  "uri": "git+https://source.developers.google.com/p/foo/r/bar",
+  // The resolved git commit hash reflecting the version of the repo used
+  // for this build.
+  "digest": {"sha1": "abc..."}
+}]
 ```
 
 Cloud Build with steps defined in a trigger or over RPC:


### PR DESCRIPTION
The examples previously only had 'recipe', now they also have
'materials'. Note that they are not complete and exclude 'metadata'.

Refs #143

Signed-off-by: Tom Hennen <tomhennen@google.com>