### PR TITLE
Link to specific blob in GitHub.

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -12,7 +12,7 @@
       {%- include social.html -%}
     </div>
     <div>
-      <a href="{{ site.github.repository_url }}">View SLSA on GitHub </a>
+      <a href="{{site.github.repository_url}}/blob/{{site.github.source.branch}}{{site.github.source.path}}/{{page.path}}">View source on GitHub</a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
In the footer "View on GitHub" link, we now link to the specific
Markdown page rather than the top-level site. This makes it easier to
edit the page and view the source.

Signed-off-by: Mark Lodato <lodato@google.com>
