### PR TITLE
Provenance spec: rename to 0.2-draft, add warning, link between versions

### DIFF
--- a/docs/provenance/v0.1.md
+++ b/docs/provenance/v0.1.md
@@ -1,21 +1,26 @@
 # SLSA Provenance
 
 This page describes the "SLSA Provenance" predicate that fits within the larger
-[in-toto attestation] framework. For more information about attestations, see
-that repo.
-
-This predicate is the recommended way to satisfy the SLSA [provenance
-requirements].
-
-## Metadata
+[in-toto attestation] framework.
 
 Type URI: https://slsa.dev/provenance/v0.1
 
 Version: 0.1.1
 
+<details>
+<summary>Other versions of this spec</summary>
+
+-   [0.2-draft][0.2]
+-   **0.1**
+
+</details>
+
 ## Purpose
 
 Describe how an artifact or set of artifacts was produced.
+
+This predicate is the recommended way to satisfy the SLSA [provenance
+requirements].
 
 ## Model
 
@@ -479,6 +484,8 @@ Execution of arbitrary commands:
 -   0.1.1: Added `metadata.buildInvocationId`.
 -   0.1: Initial version, named "in-toto.io/Provenance"
 
+[0.1]: v0.1.md
+[0.2]: v0.2-draft.md
 [DigestSet]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#DigestSet
 [GitHub Actions]: #github-actions
 [Reproducible]: https://reproducible-builds.org

--- a/docs/provenance/v0.2-draft.md
+++ b/docs/provenance/v0.2-draft.md
@@ -1,21 +1,30 @@
 # SLSA Provenance
 
+> **IMPORTANT:** This is a DRAFT version of the spec that is **subject to
+> change.** Once this version is finalized, the "-draft" suffix will be removed.
+> For the latest stable version, see [v0.1][0.1].
+
 This page describes the "SLSA Provenance" predicate that fits within the larger
-[in-toto attestation] framework. For more information about attestations, see
-that repo.
+[in-toto attestation] framework.
 
-This predicate is the recommended way to satisfy the SLSA [provenance
-requirements].
+Type URI: https://slsa.dev/provenance/v0.2-draft
 
-## Metadata
+Version: 0.2-draft
 
-Type URI: https://slsa.dev/provenance/v0.2-alpha
+<details>
+<summary>Other versions of this spec</summary>
 
-Version: 0.2-alpha
+-   **0.2-draft**
+-   [0.1]
+
+</details>
 
 ## Purpose
 
 Describe how an artifact or set of artifacts was produced.
+
+This predicate is the recommended way to satisfy the SLSA [provenance
+requirements].
 
 ## Model
 
@@ -45,7 +54,7 @@ See [Example](#example) for a concrete example.
   "subject": [{ ... }],
 
   // Predicate:
-  "predicateType": "https://slsa.dev/provenance/v0.2-alpha",
+  "predicateType": "https://slsa.dev/provenance/v0.2-draft",
   "predicate": {
     "builder": {
       "id": "<URI>"
@@ -313,7 +322,7 @@ provenance might look like this:
   "_type": "https://in-toto.io/Statement/v0.1",
   // Output file; name is "_" to indicate "not important".
   "subject": [{"name": "_", "digest": {"sha256": "5678..."}}],
-  "predicateType": "https://slsa.dev/provenance/v0.2-alpha",
+  "predicateType": "https://slsa.dev/provenance/v0.2-draft",
   "predicate": {
     "buildType": "https://example.com/Makefile",
     "builder": { "id": "mailto:person@example.com" },
@@ -525,6 +534,8 @@ Execution of arbitrary commands:
 -   0.1.1: Added `metadata.buildInvocationId`.
 -   0.1: Initial version, named "in-toto.io/Provenance"
 
+[0.1]: v0.1.md
+[0.2]: v0.2-draft.md
 [DigestSet]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#DigestSet
 [GitHub Actions]: #github-actions
 [Reproducible]: https://reproducible-builds.org


### PR DESCRIPTION
* Rename 0.2-alpha to 0.2-draft to make it more clear that it is unstable. (Suggested by @joshuagl.)
* Add an explicit warning that 0.2 draft spec is subject to change.
* Add links to the other versions of the spec to allow readers to easily jump between versions.
* Remove boilerplate from the introductory material so that it is easier to read.
