### PR TITLE
Expand the v0.2 changelog entry.

### DIFF
--- a/docs/provenance/v0.2-draft.md
+++ b/docs/provenance/v0.2-draft.md
@@ -524,12 +524,14 @@ Execution of arbitrary commands:
 
 ## Change history
 
--   0.2: Refactored to aid clarity.
+-   0.2: Refactored to aid clarity and added `buidlConfig`. The model is the
+    unchanged.
     -   Replaced `definedInMaterial` and `entryPoint` with `configSource`.
     -   Renamed `recipe` to `invocation`.
     -   Moved `invocation.type` to top-level `buildType`.
-    -   Added `buildConfig`.
-    -   Renamed `arguments` to `parameters`
+    -   Renamed `arguments` to `parameters`.
+    -   Added `buildConfig`, which can be used as an alternative to
+        `configSource` to validate the configuration.
 -   Renamed to "slsa.dev/provenance".
 -   0.1.1: Added `metadata.buildInvocationId`.
 -   0.1: Initial version, named "in-toto.io/Provenance"


### PR DESCRIPTION
- Note the addition of build configuration in the summary. (It's not
  part of "refactor to aid clarity.)
- Add a brief rationale for adding build configuration.
- Note that the model has not changed.
- Fix typo.
- Keep all the "refactor" lines together.

Signed-off-by: Mark Lodato <lodato@google.com>
