### PR TITLE
Mark provenance v0.2 as final (non-draft)

### DIFF
--- a/docs/provenance/v0.1.md
+++ b/docs/provenance/v0.1.md
@@ -27,7 +27,7 @@ To make this manageable, we recommend that:
 <details>
 <summary>Other versions of this spec</summary>
 
--   [0.2-draft][0.2]
+-   [0.2]
 -   **0.1**
 
 </details>
@@ -502,7 +502,7 @@ Execution of arbitrary commands:
 -   0.1: Initial version, named "in-toto.io/Provenance"
 
 [0.1]: v0.1.md
-[0.2]: v0.2-draft.md
+[0.2]: v0.2.md
 [DigestSet]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#DigestSet
 [GitHub Actions]: #github-actions
 [Reproducible]: https://reproducible-builds.org

--- a/docs/provenance/v0.2-draft.html
+++ b/docs/provenance/v0.2-draft.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <title>Redirecting&hellip;</title>
+  <meta http-equiv="refresh" content="0; url=v0.2">
+  <link rel="canonical" href="v0.2">
+  <meta name="robots" content="noindex">
+</html>

--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -1,15 +1,11 @@
 # SLSA Provenance
 
-> **IMPORTANT:** This is a DRAFT version of the spec that is **subject to
-> change.** Once this version is finalized, the "-draft" suffix will be removed.
-> For the latest stable version, see [v0.1][0.1].
-
 This page describes the "SLSA Provenance" predicate that fits within the larger
 [in-toto attestation] framework.
 
-Type URI: https://slsa.dev/provenance/v0.2-draft
+Type URI: https://slsa.dev/provenance/v0.2
 
-Version: 0.2-draft
+Version: 0.2
 
 <details>
 <summary>Note about 0.x versions</summary>
@@ -31,7 +27,7 @@ To make this manageable, we recommend that:
 <details>
 <summary>Other versions of this spec</summary>
 
--   **0.2-draft**
+-   **0.2**
 -   [0.1]
 
 </details>
@@ -76,7 +72,7 @@ See [Example](#example) for a concrete example.
   "subject": [{ ... }],
 
   // Predicate:
-  "predicateType": "https://slsa.dev/provenance/v0.2-draft",
+  "predicateType": "https://slsa.dev/provenance/v0.2",
   "predicate": {
     "builder": {
       "id": "<URI>"
@@ -343,7 +339,7 @@ provenance might look like this:
   "_type": "https://in-toto.io/Statement/v0.1",
   // Output file; name is "_" to indicate "not important".
   "subject": [{"name": "_", "digest": {"sha256": "5678..."}}],
-  "predicateType": "https://slsa.dev/provenance/v0.2-draft",
+  "predicateType": "https://slsa.dev/provenance/v0.2",
   "predicate": {
     "buildType": "https://example.com/Makefile",
     "builder": { "id": "mailto:person@example.com" },
@@ -591,7 +587,7 @@ To migrate from [version 0.1][0.1] (`old`):
 -   0.1: Initial version, named "in-toto.io/Provenance"
 
 [0.1]: v0.1.md
-[0.2]: v0.2-draft.md
+[0.2]: v0.2.md
 [DigestSet]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#DigestSet
 [GitHub Actions]: #github-actions
 [Reproducible]: https://reproducible-builds.org


### PR DESCRIPTION
Rename v0.2-draft to v0.2, and add a redirect from v0.2-draft to keep old links working.

Note: We use a raw HTML redirect rather than jekyll-redirect-from because `redirect_from` clutters up the top of v0.2.md and `redirect_to` would keep v0.2-draft.md, which in turn would break git's move file
detection.