### PR TITLE
Fix typo: buidlConfig -> buildConfig, extra "the"

### DIFF
--- a/docs/provenance/v0.2-draft.md
+++ b/docs/provenance/v0.2-draft.md
@@ -524,7 +524,7 @@ Execution of arbitrary commands:
 
 ## Change history
 
--   0.2: Refactored to aid clarity and added `buidlConfig`. The model is the
+-   0.2: Refactored to aid clarity and added `buildConfig`. The model is
     unchanged.
     -   Replaced `definedInMaterial` and `entryPoint` with `configSource`.
     -   Renamed `recipe` to `invocation`.


### PR DESCRIPTION
Signed-off-by: Mark Lodato <lodato@google.com>
