### PR TITLE
Small improvements to provenance v0.2 draft

### DIFF
--- a/docs/provenance/v0.2-draft.md
+++ b/docs/provenance/v0.2-draft.md
@@ -26,20 +26,25 @@ Describe how an artifact or set of artifacts was produced.
 This predicate is the recommended way to satisfy the SLSA [provenance
 requirements].
 
+## Prerequisite
+
+Understanding of SLSA [Software
+Attestations](https://github.com/slsa-framework/slsa/blob/main/controls/attestations.md)
+and the larger [in-toto attestation](https://github.com/in-toto/attestation) framework.
+
 ## Model
 
-Provenance is a claim that some entity (`builder`) produced one or more software
-artifacts ([Statement]'s `subject`) by executing some `invocation`, using some other
-artifacts as input (`materials`). The invocation in turn runs the `buildConfig`,
-which is a record of what was executed.
-The builder is trusted to have faithfully recorded the provenance;
-there is no option but to trust the builder. However,
-the builder may have performed this operation at the request of some external,
-possibly untrusted entity. These untrusted parameters are captured in the
-invocation's `parameters` and some of the `materials`. Finally, the
-build may have depended on various environmental parameters (`environment`) that
-are needed for [reproducing][reproducible] the build but that are not under
-external control.
+Provenance is an attestation that some entity (`builder`) produced one or more
+software artifacts (the `subject` of in-toto attestation '[Statement]) by
+executing some `invocation`, using some other artifacts as input (`materials`).
+The invocation in turn runs the `buildConfig`, which is a record of what was
+executed. The builder is trusted to have faithfully recorded the provenance;
+there is no option but to trust the builder. However, the builder may have
+performed this operation at the request of some external, possibly untrusted
+entity. These untrusted parameters are captured in the invocation's `parameters`
+and some of the `materials`. Finally, the build may have depended on various
+environmental parameters (`environment`) that are needed for
+[reproducing][reproducible] the build but that are not under external control.
 
 See [Example](#example) for a concrete example.
 

--- a/docs/provenance/v0.2-draft.md
+++ b/docs/provenance/v0.2-draft.md
@@ -30,12 +30,12 @@ requirements].
 
 Understanding of SLSA [Software
 Attestations](https://github.com/slsa-framework/slsa/blob/main/controls/attestations.md)
-and the larger [in-toto attestation](https://github.com/in-toto/attestation) framework.
+and the larger [in-toto attestation] framework.
 
 ## Model
 
 Provenance is an attestation that some entity (`builder`) produced one or more
-software artifacts (the `subject` of in-toto attestation '[Statement]) by
+software artifacts (the `subject` of an in-toto attestation [Statement]) by
 executing some `invocation`, using some other artifacts as input (`materials`).
 The invocation in turn runs the `buildConfig`, which is a record of what was
 executed. The builder is trusted to have faithfully recorded the provenance;
@@ -125,7 +125,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > perspective. Meanwhile, each self-hosted runner might have its own identity
 > because not all runners are trusted by all consumers.
 >
-> Consumers MUST accept only specific (signer, builder) pairs. For example, the
+> Consumers MUST accept only specific (signer, builder) pairs. For example,
 > "GitHub" can sign provenance for the "GitHub Actions" builder, and "Google"
 > can sign provenance for the "Google Cloud Build" builder, but "GitHub" cannot
 > sign for the "Google Cloud Build" builder.
@@ -265,8 +265,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 <a id="metadata.completeness.environment"></a>
 `metadata.completeness.environment` _boolean, optional_
 
-> If true, the `builder` claims that `invocation.environment` is claimed to be
-> complete.
+> If true, the `builder` claims that `invocation.environment` is complete.
 
 <a id="metadata.completeness.materials"></a>
 `metadata.completeness.materials` _boolean, optional_


### PR DESCRIPTION
This PR makes small language improvements, but mostly intends to clarify the text's use of "attestation" in the context of in-toto.

-  Switch ambiguous "claim" to "attestation": claim is one of the terms that [was considered](https://github.com/slsa-framework/slsa/blob/main/controls/attestations.md) in lieu of attestation, and i've understood to be synonymous here. I found seeing it here added confusion between attestation, claim, statement, etc.
-   Add pre-requisite section, to provide reference for the terminology:
    - in-toto attestations
    - slsa attestations
- Clarify what a "Statement" is, in this in-toto context.

I hope these are straightforward clarifications, they are not intended to open up a big conversation :)