### PR TITLE
Provenance v0.2: use enums instad of booleans.

### DIFF
--- a/docs/provenance/v0.2-draft.md
+++ b/docs/provenance/v0.2-draft.md
@@ -97,11 +97,11 @@ See [Example](#example) for a concrete example.
       "buildStartedOn": "<TIMESTAMP>",
       "buildFinishedOn": "<TIMESTAMP>",
       "completeness": {
-        "parameters": true/false,
-        "environment": true/false,
-        "materials": true/false
+        "parameters": "<ENUM>",
+        "environment": "<ENUM>",
+        "materials": "<ENUM>"
       },
-      "reproducible": true/false
+      "reproducible": "<ENUM>"
     },
     "materials": [
       {
@@ -222,8 +222,8 @@ of the other top-level fields, such as `subject`, see [Statement]._
 >
 > This is an arbitrary JSON object with a schema defined by `buildType`.
 >
-> This is considered to be incomplete unless `metadata.completeness.parameters`
-> is true. Unset or null is equivalent to empty.
+> Unset or null is equivalent to empty. Whether or not this is considered to be
+> complete is indicated by `metadata.completeness.parameters`.
 
 <a id="invocation.environment"></a>
 `invocation.environment` _object, optional_
@@ -241,8 +241,8 @@ of the other top-level fields, such as `subject`, see [Statement]._
 >
 > This is an arbitrary JSON object with a schema defined by `buildType`.
 >
-> This is considered to be incomplete unless `metadata.completeness.environment`
-> is true. Unset or null is equivalent to empty.
+> Unset or null is equivalent to empty. Whether or not this is considered to be
+> complete is indicated by `metadata.completeness.environment`.
 
 <a id="metadata"></a>
 `metadata` _object, optional_
@@ -274,27 +274,36 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > complete.
 
 <a id="metadata.completeness.parameters"></a>
-`metadata.completeness.parameters` _boolean, optional_
+`metadata.completeness.parameters` _string (enum), optional_
 
-> If true, the `builder` claims that `invocation.parameters` is complete, meaning
-> that all external inputs are propertly captured in `invocation.parameters`.
+> Indicates whether `builder` guarantees that all external inputs are captured
+> in `invocation.parameters`.
+>
+> One of: `KNOWN_COMPLETE`, `KNOWN_INCOMPLETE`, `UNKNOWN` (default).
 
 <a id="metadata.completeness.environment"></a>
-`metadata.completeness.environment` _boolean, optional_
+`metadata.completeness.environment` _string (enum), optional_
 
-> If true, the `builder` claims that `invocation.environment` is complete.
+> Indicates whether `builder` guarantees that `invocation.environment` is
+> complete.
+>
+> One of: `KNOWN_COMPLETE`, `KNOWN_INCOMPLETE`, `UNKNOWN` (default).
 
 <a id="metadata.completeness.materials"></a>
-`metadata.completeness.materials` _boolean, optional_
+`metadata.completeness.materials` _string (enum), optional_
 
-> If true, the `builder` claims that `materials` is complete, usually through
-> some controls to prevent network access. Sometimes called "hermetic".
+> Indicates whether `builder` guarantees that `materials` is complete, usually
+> through some controls to prevent network access. Sometimes called "hermetic".
+>
+> One of: `KNOWN_COMPLETE`, `KNOWN_INCOMPLETE`, `UNKNOWN` (default).
 
 <a id="metadata.reproducible"></a>
-`metadata.reproducible` _boolean, optional_
+`metadata.reproducible` _string (enum), optional_
 
-> If true, the `builder` claims that running `invocation` on `materials` will
-> produce bit-for-bit identical output.
+> Indicates whether `builder` claims that re-running `invocation` on `materials`
+> will produce bit-for-bit identical output.
+>
+> One of: `KNOWN_REPRODUCIBLE`, `KNOWN_IRREPRODUCIBLE`, `UNKNOWN` (default).
 
 <a id="buildConfig"></a>
 `buildConfig` _object, optional_
@@ -311,8 +320,8 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > The collection of artifacts that influenced the build including sources,
 > dependencies, build tools, base images, and so on.
 >
-> This is considered to be incomplete unless `metadata.completeness.materials`
-> is true. Unset or null is equivalent to empty.
+> Unset or null is equivalent to empty. Whether or not this is considered to be
+> complete is indicated by `metadata.completeness.materials`.
 
 <a id="materials.uri"></a>
 `materials[*].uri` _string ([ResourceURI]), optional_
@@ -551,6 +560,7 @@ Execution of arbitrary commands:
     -   Renamed `recipe` to `invocation`.
     -   Moved `invocation.type` to top-level `buildType`.
     -   Renamed `arguments` to `parameters`.
+    -   Converted `completeness.*` and `reproducibility` to enums.
     -   Added `buildConfig`, which can be used as an alternative to
         `configSource` to validate the configuration.
 -   Renamed to "slsa.dev/provenance".


### PR DESCRIPTION
Convert the existing `completeness.*` and `reproducibility` booleans into enums. This conveys more information, allows expressing "known incomplete" vs "unknown", allows future extensions, and aligns with SPDX 3.0.

Thanks @iamwillbar for the suggestion!

Design note: There is no standard term for "not reproducible". I went with IRREPRODUCIBLE because it mirrors INCOMPLETE (the other enum), it is the most common on [Google Books], and it doesn't risk typos between NON_REPRODUCIBLE and NOT_REPRODUCIBLE.

Any thoughts - does this increase usability? @marcofranssen FYI since you're looking as part of #209. @trishankatdatadog you brought this up in #179  - does this help?

[Google Books]: https://books.google.com/ngrams/graph?content=irreproducible%2Cnon-reproducible%2Cnonreproducible%2Cunreproducible&year_start=1800&year_end=2019&corpus=26&smoothing=3&direct_url=t1%3B%2Cirreproducible%3B%2Cc0%3B.t1%3B%2Cnon%20-%20reproducible%3B%2Cc0%3B.t1%3B%2Cnonreproducible%3B%2Cc0%3B.t1%3B%2Cunreproducible%3B%2Cc0