### PR TITLE
Provenance 0.2: add pseudocode to migrate from 0.1

### DIFF
--- a/docs/provenance/v0.2-draft.md
+++ b/docs/provenance/v0.2-draft.md
@@ -543,6 +543,39 @@ Execution of arbitrary commands:
 }
 ```
 
+## Migrating from 0.1
+
+To migrate from [version 0.1][0.1] (`old`):
+
+```javascript
+{
+  "builder": old.builder,  // (unchanged)
+  "buildType": old.recipe.type,
+  "invocation": {
+    "configSource": {
+      "uri": old.materials[old.recipe.definedInMaterial].uri,
+      "digest": old.materials[old.recipe.definedInMaterial].digest,
+      "entrypoint": old.recipe.entryPoint
+    },
+    "parameters": old.recipe.arguments,
+    "environment": old.recipe.environment   // (unchanged)
+  },
+  "buildConfig": null,  // no equivalent in 0.1
+  "metadata": {
+    "buildInvocationId": old.metadata.buildInvocationId,    // (unchanged)
+    "buildStartedOn": old.metadata.buildStartedOn,          // (unchanged)
+    "buildFinishedOn": old.metadata.buildFinishedOn,        // (unchanged)
+    "completeness": {
+      "arguments": old.metadata.completeness.parameters,
+      "environment": old.metadata.completeness.environment, // (unchanged)
+      "materials": old.metadata.completeness.materials,     // (unchanged)
+    },
+    "reproducible": old.metadata.reproducible               // (unchanged)
+  },
+  "materials": old.materials  // optionally removing the configSource
+}
+```
+
 ## Change history
 
 -   0.2: Refactored to aid clarity and added `buildConfig`. The model is


### PR DESCRIPTION
This makes it easier to understand the mapping between versions.

@marcofranssen Does this answer your question?