### PR TITLE
Fix duplicate page title of provenance after #218

### DIFF
--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -1,7 +1,4 @@
----
-title: Provenance
----
-# SLSA Provenance
+# Provenance
 
 This page describes the "SLSA Provenance" predicate that fits within the larger
 [in-toto attestation] framework.


### PR DESCRIPTION
The `title` frontmatter attribute adds an additional title to the page due to our template. The simple solution is to rename the `h1` title to match what we want in the header.

The proper fix would be to update our template so that we can manually set the title in the navbar.

# Problem

![image](https://user-images.githubusercontent.com/58860/141214973-35d942f1-b553-4597-9862-97b6f30b29ee.png)

# Fixed

![image](https://user-images.githubusercontent.com/58860/141215202-3ea4239d-2d1a-428d-a29e-ea6fc3db2ebb.png)
