### PR TITLE
Enable Google Analytics on slsa.dev

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -12,6 +12,7 @@ header_pages:
   - getinvolved.md
 exclude:
   - README.md
+google_analytics: G-VNK063J3QF
 theme: minima
 permalink: :path/:basename
 markdown: CommonMarkGhPages

--- a/docs/_includes/google-analytics.html
+++ b/docs/_includes/google-analytics.html
@@ -1,0 +1,9 @@
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+<script>
+  window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', '{{ site.google_analytics }}');
+</script>


### PR DESCRIPTION
This requires upgrading to the latest google analytics code because the version on GitHub Pages is outdated.

Requested by @devmoran, who will use this to measure improvements to the site.

I believe I granted Analytics access to @devmoran, @trishankatdatadog, @inferno-chromium, and @joshuagl but please let me know if you do not have access.

