### PR TITLE
Clean up steering committee list; clarify approval expectations for this repo.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,22 +23,20 @@ this is not currently enforced).
 
 All changes require peer review through GitHub's pull request feature.
 
-Significant changes to the SLSA requirements or provenance schema require
-approval from **two steering committee members**. (Excludes changes that only
-affect syntax or clarity without altering meaning.)
+-   Changes to the specification, such as [Requirements](docs/requirements.md)
+    or the [Provenance schema](docs/provenance/), require approval from **two
+    steering committee members**, unless the change does not affect the meaning
+    (e.g. typo fix or minor reformatting.)
 
--   Do an initial round of review with a single reviewer.
--   Add @slsa-framework/slsa-steering-committee as a reviewer and make it
-    clear you are looking for at least two approvers.
--   Wait at least a few days before submitting to give the community time to
-    comment.
+    -   Do an initial round of review with a single reviewer.
+    -   Add @slsa-framework/slsa-steering-committee as a reviewer and make it
+        clear that you are looking for at least two approvers.
+    -   Wait at least one week before submitting to give the community time to
+        comment.
 
-Otherwise, only a single approval is needed.
-
--   No requirement to include a steering committee member. In practice, several
-    members review all changes at least passively anyway.
--   No requirement for the author and reviewer to come from different
-    organizations.
+-   Other changes only require **one approver**. Any member of @slsa-framework
+    can approve. There is no requirement for the author and reviewer to
+    represent different companies/organizations.
 
 ### Signing your work
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,22 @@ this is not currently enforced).
 
 All changes require peer review through GitHub's pull request feature.
 
--   Changes generally require two approvals before being merged.
--   Minor changes that only affect clarity or syntax without changing the
-    meaning MAY be merged with a single approval.
--   Significant changes to the SLSA requirements or provenance schema SHOULD be
-    reviewed and approved from multiple steering committee members. Furthermore,
-    such changes SHOULD wait at least a few days after proposal before
-    submitting, to give the community time to review.
+Significant changes to the SLSA requirements or provenance schema require
+approval from **two steering committee members**. (Excludes changes that only
+affect syntax or clarity without altering meaning.)
+
+-   Do an initial round of review with a single reviewer.
+-   Add @slsa-framework/slsa-steering-committee as a reviewer and make it
+    clear you are looking for at least two approvers.
+-   Wait at least a few days before submitting to give the community time to
+    comment.
+
+Otherwise, only a single approval is needed.
+
+-   No requirement to include a steering committee member. In practice, several
+    members review all changes at least passively anyway.
+-   No requirement for the author and reviewer to come from different
+    organizations.
 
 ### Signing your work
 

--- a/README.md
+++ b/README.md
@@ -28,24 +28,22 @@ SLSA is currently in alpha. The framework is constantly being improved. We encou
 
 SLSA is currently led by an initial cross-organization, vendor-neutral steering committee. This committee is:
 
--   [Joshua Lock](https://github.com/joshuagl) - VMware
 -   [Bruno Domingues](https://github.com/brunodom) - Intel
 -   [David A. Wheeler](https://github.com/david-a-wheeler) - Linux Foundation
--   [Trishank Karthik Kuppusamy](https://github.com/trishankatdatadog) - Datadog
--   [Mike Lieberman](https://github.com/mlieberman85) - Citi/CNCF
--   [Zak Greant](https://github.com/zakgreant) - ActiveState
+-   [Joshua Lock](https://github.com/joshuagl) - VMware
 -   [Mark Lodato](https://github.com/MarkLodato) - Google
+-   [Mike Lieberman](https://github.com/mlieberman85) - Citi/CNCF
+-   [Trishank Karthik Kuppusamy](https://github.com/trishankatdatadog) - Datadog
+-   [Zak Greant](https://github.com/zakgreant) - ActiveState
 
 Shortcut to notify the steering committee on any issues/PRs:
 
-> @brunodom @david-a-wheeler @joshuagl @marklodato @mlieberman85 @trishankatdatadog @zakgreant
+> @slsa-framework/teams/slsa-steering-committee
 
 ## Contributors
 
 -   [Kim Lewandowski](https://github.com/kimsterv)
--   [Mark Lodato](https://github.com/MarkLodato)
 -   [Tom Hennen](https://github.com/TomHennen)
--   [Joshua Lock](https://github.com/joshuagl)
 -   [Jacques Chester](https://github.com/jchestershopify)
 -   And [many others](https://github.com/slsa-framework/slsa/graphs/contributors)
 

--- a/docs/getinvolved.md
+++ b/docs/getinvolved.md
@@ -24,19 +24,17 @@ We rely on feedback from other organizations to evolve SLSA and be more useful t
 
 SLSA is currently led by an initial cross-organization, vendor-neutral steering committee. This committee is:
 
--   [Joshua Lock](https://github.com/joshuagl) - VMware
 -   [Bruno Domingues](https://github.com/brunodom) - Intel
 -   [David A. Wheeler](https://github.com/david-a-wheeler) - Linux Foundation
--   [Trishank Karthik Kuppusamy](https://github.com/trishankatdatadog) - Datadog
--   [Mike Lieberman](https://github.com/mlieberman85) - Citi/CNCF
--   [Zak Greant](https://github.com/zakgreant) - ActiveState
+-   [Joshua Lock](https://github.com/joshuagl) - VMware
 -   [Mark Lodato](https://github.com/MarkLodato) - Google
+-   [Mike Lieberman](https://github.com/mlieberman85) - Citi/CNCF
+-   [Trishank Karthik Kuppusamy](https://github.com/trishankatdatadog) - Datadog
+-   [Zak Greant](https://github.com/zakgreant) - ActiveState
 
 ## Contributors
 
 -   [Kim Lewandowski](https://github.com/kimsterv)
--   [Mark Lodato](https://github.com/MarkLodato)
 -   [Tom Hennen](https://github.com/TomHennen)
--   [Joshua Lock](https://github.com/joshuagl)
 -   [Jacques Chester](https://github.com/jchestershopify)
 -   And [many others](https://github.com/slsa-framework/slsa/graphs/contributors)


### PR DESCRIPTION
Sort the steering committee list alphabetically.

Reference the new @slsa-framework/slsa-steering-committee alias.

In the contributor guide, clarify that only significant changes to the spec require two steering committee members to review, and that others can be approved by a single reviewer. In particular, document that it's OK for author and reviewer to be from the same org.

(This documents what was discussed in an email thread. It would be great if other steering committee members can weigh in, in case they disagree.)