### PR TITLE
provenance: fix name of configSource in descriptions

### DIFF
--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -209,9 +209,9 @@ of the other top-level fields, such as `subject`, see [Statement]._
 `invocation.parameters` _object, optional_
 
 > Collection of all external inputs that influenced the build on top of
-> `invocation.sourceConfig`. For example, if the invocation
+> `invocation.configSource`. For example, if the invocation
 > type were "make", then this might be the flags passed to `make` aside from the
-> target, which is captured in `invocation.sourceConfig.entryPoint`.
+> target, which is captured in `invocation.configSource.entryPoint`.
 >
 > Consumers SHOULD accept only "safe" `invocation.parameters`. The simplest and
 > safest way to achieve this is to disallow any `parameters` altogether.
@@ -296,7 +296,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 `buildConfig` _object, optional_
 
 > Lists the steps in the build.
-> If `invocation.sourceConfig` is not available, `buildConfig` can be used
+> If `invocation.configSource` is not available, `buildConfig` can be used
 > to verify information about the build.
 >
 > This is an arbitrary JSON object with a schema defined by `buildType`.


### PR DESCRIPTION
There are several mentions of invocation.sourceConfig in the descriptions
of fields in the provenance format. However, the field name is
configSource.

Signed-off-by: Joshua Lock <jlock@vmware.com>