### PR TITLE
Fix a typo in provenance definition.

### DIFF
--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -177,7 +177,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > This is effectively a pointer to the source where `buildConfig` came from.
 
 <a id="invocation.configSource.uri"></a>
-`invocation.configSource.uri` _string ([TypeURI]), optional_
+`invocation.configSource.uri` _string ([ResourceURI]), optional_
 
 > URI indicating the identity of the source of the config.
 


### PR DESCRIPTION
`invocation.configSource.uri` should be of type ResourceURI.