### PR TITLE
Add slsa v0.2 provenance spec CUEvalidator

### DIFF
--- a/schema/provenance-2.0.cue
+++ b/schema/provenance-2.0.cue
@@ -1,0 +1,109 @@
+package schema
+
+import (
+    "time"
+)
+
+#Subject: {
+    name: string
+    digest: #DigestSet
+}
+
+#DigestSet: {
+            sha256?: string
+            sha224?: string 
+            sha384?: string
+            sha512?: string
+            sha512_224?: string
+            sha512_256?: string
+            sha3_224?: string
+            sha3_256?: string
+            sha3_384?: string
+            sha3_512?: string
+            shake128?: string
+            shake256?: string
+            blake2b?: string
+            blake2s?: string
+            ripemd160?: string
+            sm3?: string 
+            gost?: string
+            sha1?: string
+            md5?: string
+}
+
+//TODO: This should probably live in a shared library.
+#Alpha: "[a-zA-Z]"
+#Digit: "[0-9]"
+#Hexdig: "[0-9a-fA-F]"
+#Scheme: "[a-z]*?(\\.?|\\+?|\\-?|.?)*?"
+#Unreserved: "(\(#Alpha)|\(#Digit)|\\-|\\.|_|~)"
+#Pct_Encoded: "%\(#Hexdig){2}"
+#Sub_Delims: "(\\!|\\$|\\&|\\'|\\(|\\)|\\*|\\+|\\,|\\;|\\=)"
+#Pchar: "(\(#Unreserved)|\(#Pct_Encoded)|\(#Sub_Delims)|\\:|\\@)"
+#IPv6Address: "(?:[A-F0-9]{1,4}:){7}[A-F0-9]{1,4}"
+#IPvFuture: "v\(#Hexdig)+\\.(\(#Unreserved)|\(#Sub_Delims)|\\:)+"
+#IP_Literal: "(\(#IPv6Address)|\(#IPvFuture))"
+#IPv4address: "(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)"
+#Port: "\(#Digit)*"
+#Reg_Name: "(\(#Unreserved) | \(#Pct_Encoded) | \(#Sub_Delims))*"
+#Host: "(\(#IP_Literal)|\(#IPv4address)|\(#Reg_Name))"
+#Segment: "\(#Pchar)*"
+#Segment_NZ: "\(#Pchar)+"
+#Segment_NZ_NC: "(\(#Unreserved)|\(#Pct_Encoded)|\(#Sub_Delims)|\\@)+"
+#Path_Abempty: "(\\/\(#Segment))*"
+#Path_Absolute: "\\/\(#Segment_NZ)(\\/\(#Segment)).*"
+#Path_Rootless: "\(#Segment_NZ)(\\/\(#Segment).*)"
+#Path_Empty: ""
+#Userinfo: "(\(#Unreserved)|\(#Pct_Encoded)|\(#Sub_Delims)|\\:)*?"
+#Authority: "(\(#Userinfo)@)?\(#Host)(\\:\(#Port))?"
+#Hier_Part: "(\\/\\/)?(\(#Authority)|\(#Path_Abempty)|\(#Path_Absolute)|\(#Path_Rootless)|\(#Path_Empty))"
+#Query: "(\(#Pchar)|\\/|\\?)*"
+#Fragment: "(\(#Pchar)|\\/|\\?)*"
+
+#URI: =~ "\(#Scheme):\(#Hier_Part)\((#Query))?\((#Fragment))?"
+
+
+#TypeURI: #URI
+#ResourceURI: #URI
+
+#Provenance: {
+  // Standard attestation fields:
+  "_type": "https://in-toto.io/Statement/v0.1",
+  subject: [...#Subject],
+
+  // Predicate:
+  predicateType: "https://slsa.dev/provenance/v0.2",
+  predicate: {
+    builder: {
+      id: #TypeURI
+    },
+    buildType: #TypeURI,
+    invocation?: {
+      configSource?: {
+        uri?: #ResourceURI,
+        digest?: #DigestSet,
+        entryPoint?: string
+      },
+      parameters?: { ... },
+      environment?: { ... }
+    },
+    buildConfig?: { ... },
+    metadata?: {
+      buildInvocationId?: string,
+      buildStartedOn?: time.Time,
+      buildFinishedOn?: time.Time,
+      completeness?: {
+        parameters?: bool,
+        environment?: bool,
+        materials?: bool
+      },
+      reproducible?: bool
+    },
+    materials?: [
+      {
+        uri?: #ResourceURI,
+        digest?: #DigestSet
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This file can be used with cue cli tools to validate attestations
against provenance spec like:

`cue vet provenance-2.0.cue attestation.json`

It will return an error if it doesn't match the spec. This also
opens up the ability to use CUE for codegen for various tools down
the line allowing us to create a canonical validator and tools
written in other languages can just use the CUE spec for both
validation as well as generation of attestations that meet the spec.

---

This is a draft as I want to get folks input on doing it this way.

Using this validator, I did detect a few bugs in how Tekton Chains generates v0.2 provenance and was able to open up a PR to fix it.

The sorts of things I want to talk through, and some other thoughts are:
* Where should this code live? In this repo? In another repo?
* Certain things like URI validation are not readily available in CUE so I put it here for now. Also, I'm going to need someone to validate my regex as I'm sure I messed something up when reading through RFC3986. Also if there's a way to not do this in regex we probably shouldn't...
* This CUE spec can generate OpenAPI today, and eventually generate protobuf as well as other formats according to the CUE community. This could be helpful in SLSA community in creating some reference tooling.
* Am I missing something from the spec? Probably should include the definitions from the markdown as comments in the code.
* When building this out, I noticed a bit of ambiguity in some of the types. For example, it's not clear what the actual difference between TypeURI and ResourceURI is.
* I think in using CUE to be a canonical definition of the spec it makes it really easy to play around with changing the spec and having codegen and automated tooling handle generation and validation.