### PR TITLE
Run Google Analytics in "denied consent" mode.

### DIFF
--- a/docs/_includes/google-analytics.html
+++ b/docs/_includes/google-analytics.html
@@ -3,7 +3,10 @@
   window['ga-disable-{{ site.google_analytics }}'] = window.doNotTrack === "1" || navigator.doNotTrack === "1" || navigator.doNotTrack === "yes" || navigator.msDoNotTrack === "1";
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
+  gtag('consent', 'default', {
+    'ad_storage': 'denied',
+    'analytics_storage': 'denied'
+  });
   gtag('js', new Date());
-
   gtag('config', '{{ site.google_analytics }}');
 </script>


### PR DESCRIPTION
This stops cookies from loading so that we don't need a GDPR cookie banner.

This is an alternative to #237. I don't know how much this hampers our analytics, but I agree with @david-a-wheeler that should not do anything that requires consent.
