### PR TITLE
README: Add steering committee list, fix GH alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ SLSA is currently led by an initial cross-organization, vendor-neutral steering 
 
 Shortcut to notify the steering committee on any issues/PRs:
 
-> @slsa-framework/teams/slsa-steering-committee
+> @slsa-framework/slsa-steering-committee
+
+To email the steering committee, use slsa-steering-committee@googlegroups.com.
 
 ## Contributors
 


### PR DESCRIPTION
Add the newly creating SLSA steering committee mailing list to the README file to allow people to easily contact the steering committee. This is not on the slsa.dev site since we'd prefer users to go through public channels.

Also fix the GitHub team name (no "teams/") in the README.

**Question:** Should it also go on slsa.dev?