### PR TITLE
Simplify the specifications list template.

### DIFF
--- a/docs/_includes/specifications-list.html
+++ b/docs/_includes/specifications-list.html
@@ -1,12 +1,23 @@
+{%- comment -%}
+Displays the list of specification subpages.
+
+USAGE: {% include specifications-list subpages=page.subpages %}
+
+In the YAML frontmatter, include a snippet like this:
+    ---
+    subpages:
+      - title: Some page
+        description: Text to display below the link
+        relative_url: foo
+      - title: Another page
+        description: More text
+        relative_url: ../bar
+    ---
+{%- endcomment -%}
 <ul class="custom-list">
-{%- for collection in site.collections -%}
-{% if collection.label == 'spec' %}
-{% for item in site[collection.label] %}
+{%- for item in include.subpages %}
 <li>
-{% if item.path contains site.current_spec_version %}
-{%- assign v = page.url | replace: '/','' | replace: 'spec','' | replace: 'index','' -%}
-{% if item.title != 'Introduction' %}
-<a class="border-b border-black-900 inline-block w-full mb-6" href="{{ site.baseurl }}/{{item.path | replace: site.current_spec_version,v | replace: "_", "" | replace: ".md", "" }}">
+<a class="border-b border-black-900 inline-block w-full mb-6" href="{{ item.relative_url }}">
 <p class="h3 font-semibold mb-2 flex items-center text-green-dark">
     <span class="mr-4">
     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -17,23 +28,6 @@
 </p>
 <p class="mb-4 font-normal text-black pl-9">{{ item.description }}</p>
 </a>
-{% endif %}
-{% endif %}
 </li>
-{% endfor %}
-{% endif %}
-{%- endfor -%}
-<li>
-<a class="border-b border-black-900 inline-block w-full mb-6" href="{{ site.baseurl }}/spec/faq">
-    <p class="h3 font-semibold mb-2 flex items-center text-green-dark">
-        <span class="mr-4">
-        <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path d="M0.896251 18C-0.298751 12.0505 -0.298752 5.94951 0.896249 -7.47629e-07C7.1285 2.02552 12.9429 5.081 18 9C12.9429 12.919 7.1285 15.9745 0.896251 18Z" fill="#40DB88"/>
-        </svg>
-        </span>
-        FAQs
-    </p>
-    <p class="mb-4 font-normal text-black pl-9">Questions and more information</p>
-</a>
-</li>
+{% endfor -%}
 </ul>

--- a/docs/_spec/faq.md
+++ b/docs/_spec/faq.md
@@ -1,7 +1,6 @@
 ---
 title: Frequently Asked Questions
 layout: specifications
-description: Questions and more information
 ---
 
 ## Q: Why is SLSA not transitive?

--- a/docs/_spec/v0.1/index.md
+++ b/docs/_spec/v0.1/index.md
@@ -30,6 +30,23 @@ levels:
         title: Across the chain
         text: Level 4 means the build environment is fully accounted for, dependencies are tracked in provenance and insider threats are ruled out.
         badge: /images/SLSA-Badge-full-level4.svg
+
+subpages:
+  - title: Security levels
+    description: Start here for the level breakdowns
+    relative_url: levels
+
+  - title: Requirements
+    description: The checks and measures for each level
+    relative_url: requirements
+
+  - title: Threats
+    description: Specific supply chain attacks and how SLSA helps
+    relative_url: threats
+
+  - title: FAQs
+    description: Questions and more information
+    relative_url: ../faqs
 ---
 <section class="section bg-white">
 <!-- no indentation here to get markdown working with jekyll commonmark for styling the headings better -->
@@ -173,8 +190,9 @@ levels:
 <!-- Alpine js state for version buttons here -->
 {% include specifications-versions.html %}
 </div>
+            <!-- TODO: Allow other versions to be selected and displayed. -->
             <div class="w-full md:w-2/4 text-green mt-16 md:mt-0">
-                {% include specifications-list.html  %}
+                {%- include specifications-list.html subpages=page.subpages  -%}
             </div>
         </div>
     </div>

--- a/docs/_spec/v0.1/levels.md
+++ b/docs/_spec/v0.1/levels.md
@@ -2,7 +2,6 @@
 title: Security levels
 version: 0.1
 layout: specifications
-description: Start here for the level breakdowns
 ---
 <span class="subtitle">
 

--- a/docs/_spec/v0.1/requirements.md
+++ b/docs/_spec/v0.1/requirements.md
@@ -2,7 +2,6 @@
 title: Requirements
 version: 0.1
 layout: specifications
-description: The checks and measures for each level
 ---
 <span class="subtitle">
 

--- a/docs/_spec/v0.1/threats.md
+++ b/docs/_spec/v0.1/threats.md
@@ -2,7 +2,6 @@
 title: Threats
 version: 0.1
 layout: specifications
-description: Specific supply chain attacks and how SLSA helps
 ---
 <!-- markdownlint disable required to avoid list sub-items appearing in table of contents -->
 <!-- markdownlint-disable MD001 -->


### PR DESCRIPTION
Similar to e56c388 (#270), but for the list of subpages in /spec/v0.1/index. This change replace the "automatic" code with a manual list, which is much easier to understand and maintain.

No content change. The only HTML change is to switch from absolute to relative links and to eliminate empty `<li>` elements.

NOTE: Neither the original nor new code correctly handled displaying more than one specification version. This commit adds a TODO making it clear that it doesn't work.

### Testing

The old and new version result in identical HTML except as noted above, ignoring one whitespace change and build timestamps on posts.

```bash
$ git checkout main
$ bundle exec jekyll build
$ mv _site /tmp/old_site
$ git checkout spec-list
$ bundle exec jekyll build
$ diff -u {/tmp/old_site,_site}/spec/v0.1/index.html
```

Compare:

* https://deploy-preview-271--slsa.netlify.app/spec/v0.1/#specifications
* https://slsa.dev/spec/v0.1/#specifications