### PR TITLE
Update meeting calendar link and readme info

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ We rely on feedback from other organizations to evolve SLSA and be more useful t
 
 ### Joining the working group
 
--   We meet bi-weekly on Wednesdays at 9am PT. Anyone is welcome to join, whether to listen or to contribute. [Here's the invite](https://calendar.google.com/calendar/u/0/r/week/2021/8/11?eid=NjIycXNoOHBtbDhuNTJiNjlmaWk5ZjU5ZWVfMjAyMTA4MTFUMTYwMDAwWiBzNjN2b2VmaHA1aTlwZmx0YjVxNjduZ3Blc0Bn&sf=true).
--   We're part of the OpenSSF [Digital Identity Attestation Working Group](https://github.com/ossf/wg-digital-identity-attestation). The OpenSSF community calendar is [here](https://calendar.google.com/calendar/u/0?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
+-   We meet bi-weekly on Wednesdays at 9am PT. Anyone is welcome to join, whether to listen or to contribute. The OpenSSF community calender is [here](https://calendar.google.com/calendar/u/0?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).
+-   We're part of the OpenSSF [Supply Chain Integrity Working Group](https://github.com/ossf/wg-supply-chain-integrity).
 -   Our mailing list is [slsa-discussion@googlegroups.com](https://groups.google.com/g/slsa-discussion).
 -   You can join our chat on the OpenSSF Slack [here](https://openssf.slack.com/archives/C029E4N3DPF)
 


### PR DESCRIPTION
- Old invite points to hangouts instead of zoom. Updating this to point to updated calendar instead. 
- Update parent WG name

Signed-off-by: Brandon Lum <lumjjb@gmail.com>