### PR TITLE
Clean up HTML syntax

### DIFF
--- a/docs/_includes/specifications-list.html
+++ b/docs/_includes/specifications-list.html
@@ -24,9 +24,9 @@ In the YAML frontmatter, include a snippet like this:
     <path d="M0.896251 18C-0.298751 12.0505 -0.298752 5.94951 0.896249 -7.47629e-07C7.1285 2.02552 12.9429 5.081 18 9C12.9429 12.919 7.1285 15.9745 0.896251 18Z" fill="#40DB88"/>
     </svg>
     </span>
-    {{ item.title }}
+    {{ item.title | escape }}
 </p>
-<p class="mb-4 font-normal text-black pl-9">{{ item.description }}</p>
+<p class="mb-4 font-normal text-black pl-9">{{ item.description | escape }}</p>
 </a>
 </li>
 {% endfor -%}

--- a/docs/_spec/v0.1/index.md
+++ b/docs/_spec/v0.1/index.md
@@ -101,7 +101,7 @@ subpages:
     </div>
 </section>
 <section class="section cta_banner bg-pastel-green">
-<a href="{{ site.baseurl }}/spec/{{ site.current_spec_version }}/threats" class="hover:no-underline h-full w-full">
+<a href="threats" class="hover:no-underline h-full w-full">
     <div class="wrapper inner w-full flex items-center justify-center">
         <p class="cta-link font-semibold h4">Read about threats in detail</p>
     </div>
@@ -174,7 +174,7 @@ subpages:
     </div>
 </section>
 <section class="section cta_banner bg-pastel-green">
-<a href="{{ site.baseurl }}/spec/{{ site.current_spec_version}}/levels" class="h-full w-full">
+<a href="levels" class="h-full w-full">
     <div class="wrapper inner w-full flex items-center justify-center">
         <p class="cta-link font-semibold h4">Read the level specifications</p>
     </div>

--- a/docs/_spec/v0.1/levels.md
+++ b/docs/_spec/v0.1/levels.md
@@ -3,14 +3,14 @@ title: Security levels
 version: 0.1
 layout: specifications
 ---
-<span class="subtitle">
+<div class="subtitle">
 
 SLSA is organized into a series of levels that provide increasing
 [integrity](terminology.md) guarantees. This gives you confidence that that
 software hasn’t been tampered with and can be securely traced back to its
 source.
 
-</span>
+</div>
 
 This page is an informative overview of the SLSA levels, describing their
 purpose and guarantees. For the normative requirements at each level, see

--- a/docs/_spec/v0.1/requirements.md
+++ b/docs/_spec/v0.1/requirements.md
@@ -3,12 +3,12 @@ title: Requirements
 version: 0.1
 layout: specifications
 ---
-<span class="subtitle">
+<div class="subtitle">
 
 This page covers all of the technical requirements for an artifact to meet the
 [SLSA Levels](levels.md).
 
-</span>
+</div>
 
 For background, see [Introduction](index.md) and [Terminology](terminology.md).
 To better understand the reasoning behind the requirements, see

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,11 +2,11 @@
 
 ## SLSA is currently in alpha
 
-<span class="subtitle">
+<div class="subtitle">
 
 Google has been using an internal version of SLSA since 2013 and requires it for all of Google's production workloads.
 
-</span>
+</div>
 
 We encourage the community to try adopting SLSA levels incrementally and to share your experiences back to us. We rely on feedback from other organizations to evolve SLSA and be more useful to more people. [Please get involved!](getinvolved.md)
 


### PR DESCRIPTION
* HTML-escape spec list output in Liquid template
* Use relative links to make HTML easier to maintain
* Use `div` for subtitles, not `span`