### PR TITLE
Document a SLSA verification summary attestation.

### DIFF
--- a/docs/verification_summary/index.html
+++ b/docs/verification_summary/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <title>Redirecting&hellip;</title>
+  <meta http-equiv="refresh" content="0; url=v0.1">
+  <link rel="canonical" href="v0.1">
+  <meta name="robots" content="noindex">
+</html>

--- a/docs/verification_summary/index.md
+++ b/docs/verification_summary/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_to_url: v0.1
+sitemap: false
+---

--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -28,6 +28,18 @@ Describe what SLSA level an artifact or set of artifacts was verified at
 and other details about the verification process including what SLSA level
 the dependencies were verified at.
 
+This allows software consumers to make a decision about the validity of an
+artifact without needing to have access to all of the attestations about the
+artifact or all of its transitive dependencies.  They can use it to delegate
+complex policy decisions to some trusted party and then simply trust that
+party's decision regarding the artifact.
+
+It also allows software publishers to keep the details of their build pipeline
+confidential while still communicating that some verification has taken place.
+This might be necessary for legal reasons (keeping a software supplier
+confidential) or for security reasons (not revealing that an embargoed patch has
+been included).
+
 <div class="mt-16 mb-4">
 
 ## Prerequisite

--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -180,9 +180,9 @@ of the other top-level fields, such as `subject`, see [Statement]._
 
 > A count of the dependencies at each SLSA level.
 >
-> Map from [SlsaResult] the number of the artifact's _transitive_ dependencies that
-> were verified at the indicated level. Absence of a given level of [SlsaResult]
-> MUST be interpreted as reporting _0_ dependencies at that level.
+> Map from [SlsaResult] to the number of the artifact's _transitive_ dependencies
+> that were verified at the indicated level. Absence of a given level of
+> [SlsaResult] MUST be interpreted as reporting _0_ dependencies at that level.
 
 <div class="mt-16 mb-4">
 

--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -102,8 +102,8 @@ indicate these exceptions using `vsa.minimum_downgrade_dependency_level`.
   // Required
   "verifier": {
     "id": "<URI>"
-    }
-  "time_verified": <TIMESTAMP>
+  },
+  "time_verified": <TIMESTAMP>,
   "policy": "<URI>",
   "verification_result": "<PASSED|FAILED>",
   "policy_level": "<SlsaResult>",
@@ -212,8 +212,8 @@ WARNING: This is just for demonstration purposes.
 "predicate": {
   "verifier": {
     "id": "https://example.com/publication_verifier"
-    }
-  "time_verified": "1985-04-12T23:20:50.52Z"
+  },
+  "time_verified": "1985-04-12T23:20:50.52Z",
   "policy": "https://example.com/example_tarball.policy",
   "verification_result": "PASSED",
   "policy_level": "SLSA_LEVEL_3",

--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -219,7 +219,10 @@ WARNING: This is just for demonstration purposes.
     "id": "https://example.com/publication_verifier"
   },
   "time_verified": "1985-04-12T23:20:50.52Z",
-  "policy": "https://example.com/example_tarball.policy",
+  "policy": {
+    "uri": "https://example.com/example_tarball.policy",
+    "digest": {"sha256": "1234..."}
+  },
   "verification_result": "PASSED",
   "policy_level": "SLSA_LEVEL_3",
   "dependency_levels": {

--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -1,0 +1,242 @@
+---
+title: SLSA Verification Summary Attestation (VSA)
+layout: standard
+hero_text: Verification summary attestations communicate that an artifact has been verified at a specific SLSA level and details about that verification.
+---
+<details class="mt-12">
+<summary>Note about 0.x versions</summary>
+
+We expect regular iteration on 0.x versions until 1.0. During 0.x, we lean
+towards smaller, faster releases in order to get earlier feedback on the design.
+After 1.0, we will limit the frequency of breaking changes.
+
+To make this manageable, we recommend that:
+
+-   Generators choose the latest 0.x version at the time of implementation and
+    then stick with that until 1.0 unless there is reason to upgrade before then.
+-   Consumers accept all known versions and convert internally between them.
+
+</details>
+
+<div class="mt-16 mb-4">
+
+## Purpose
+
+</div>
+
+Describe what SLSA level an artifact or set of artifacts was verified at
+and other details about the verification process including what SLSA level
+the dependencies were verified at.
+
+<div class="mt-16 mb-4">
+
+## Prerequisite
+
+</div>
+
+Understanding of SLSA [Software
+Attestations](https://github.com/slsa-framework/slsa/blob/main/controls/attestations.md),
+[SLSA Provenance](https://slsa.dev/provenance), and the larger
+[in-toto attestation] framework.
+
+<div class="mt-16 mb-4">
+
+## Model
+
+</div>
+
+A Verification Summary Attestation (VSA) is an attestation that some entity
+(`verifier`) verified one or more software artifacts (the `subject` of an
+in-toto attestation [Statement]) by evaluating the artifact and a `bundle`
+of attestations against some `policy`.  Users who trust the `verifier` may
+assume that the artifacts met the indicated SLSA level without themselves
+needing to evaluate the artifact or to have access to the attestations the
+`verifier` used to make its determination.
+
+The VSA also allows consumers to determine the minimum verified level of
+all of an artifact’s _transitive_ dependencies.  The verifier does this by
+either a) verifying the provenance of each non-source dependency listed in
+the [materials](https://slsa.dev/provenance/v0.2#materials) of the artifact
+being verified (recursively) or b) matching the non-source dependency
+listed in `materials` (by subject.digest == materials.digest and, ideally,
+subject.name == materials.uri) to a VSA _for that dependency_ and taking
+the `min(vsa.policy_level, vsa.minimum_dependency_level`).  Policy
+verifiers wishing to establish minimum requirements on dependencies SLSA
+levels may use vsa.minimum_dependency_level to do so.
+
+Since dependency graphs can be quite complex a policy verifier may wish to
+require a default SLSA level X for all dependencies but allow for explicit
+exceptions that have level < X.  This allows progress to be made without
+being held back by a handful of ‘stubborn’ dependencies.  Verifiers
+indicate these exceptions using `vsa.minimum_downgrade_dependency_level`.
+
+<div class="mt-16 mb-4">
+
+## Schema
+
+</div>
+
+```jsonc
+// Standard attestation fields:
+"_type": "https://in-toto.io/Statement/v0.1",
+"subject": [{
+  "name": <artifact-URI-in-request>,
+  "digest": { <digest-in-request> }
+}],
+
+// Predicate
+"predicateType": "https://slsa.dev/verification_summary/v0.1",
+"predicate": {
+  // Required
+  "verifier": {
+    "id": "<URI>"
+    }
+  "time_verified": <TIMESTAMP>
+  "policy": "<URI>",
+  "verification_result": "<PASSED|FAILED>",
+  "policy_level": "<SlsaResult>",
+  "minimum_dependency_level": "<SlsaResult>",
+  "minimum_downgrade_dependency_level": "<SlsaResult>"
+}
+```
+
+<div class="mt-8 mb-4">
+
+### Parsing rules
+
+</div>
+
+This predicate follows the in-toto attestation [parsing rules]. Summary:
+
+-   Consumers MUST ignore unrecognized fields.
+-   The predicateType URI includes the major version number and will always
+    change whenever there is a backwards incompatible change.
+-   Minor version changes are always backwards compatible and "monotonic." Such
+    changes do not update the predicateType.
+-   Producers MAY add extension fields using field names that are URIs.
+
+<div class="mt-8 mb-4">
+
+### Fields
+
+</div>
+
+_NOTE: This section describes the fields within predicate. For a description
+of the other top-level fields, such as subject, see [Statement]._
+
+<a id="verifier"></a>
+verifier _object, required_
+
+> Identifies the entity that performed the verification.
+>
+> The identity MUST reflect the trust base that consumers care about. How
+> detailed to be is a judgment call.
+>
+> Consumers MUST accept only specific (signer, verifier) pairs. For example,
+> "GitHub" can sign provenance for the "GitHub Actions" verifier, and "Google"
+> can sign provenance for the "Google Cloud Deploy" verifier, but "GitHub" cannot
+> sign for the "Google Cloud Deploy" verifier.
+>
+> The field is required, even if it is implicit from the signer, to aid readability and
+> debugging. It is an object to allow additional fields in the future, in case one
+> URI is not sufficient.
+
+<a id="verifier.id"></a>
+verifier.id _string ([TypeURI]), required_
+
+> URI indicating the verifier’s identity.
+
+<a id="time_verified"></a>
+time_verified _string ([Timestamp]), required_
+
+> Timestamp indicating what time the verification occurred.
+
+<a id="policy"></a>
+policy _string ([TypeURI]), required_
+
+> The URI of the policy that was used to verify this artifact.
+
+<a id="verification_result"></a>
+verification_result _string, required_
+
+> Either “PASSED” or “FAILED” to indicate if the artifact passed or failed the policy verification.
+
+<a id="policy_level"></a>
+policy_level _string ([SlsaResult]), required_
+
+> Indicates what SLSA level the artifact itself (and not its dependencies) was verified at or "FAILED" if policy verification failed.
+
+<a id="minimum_dependency_level"></a>
+minimum_dependency_level _string ([SlsaResult]), optional_
+
+> The minimum verified SLSA level of all the artifacts _transitive_ dependencies excluding any
+> dependencies that have been explicitly downgraded to a lower acceptable level in the policy.
+> Absence indicates no evaluation of dependencies has taken place.
+
+<a id="minimum_downgrade_dependency_level"></a>
+minimum_downgrade_dependency_level _string ([SlsaResult]), optional_
+
+> The minimum verified SLSA level of all the artifacts _transitive_ dependencies that have
+> been explicitly downgraded by a policy.
+> Absence indicates no evaluation of dependencies has taken place.
+
+<div class="mt-16 mb-4">
+
+## Example
+
+</div>
+
+WARNING: This is just for demonstration purposes.
+
+```jsonc
+"_type": "https://in-toto.io/Statement/v0.1",
+"subject": [{
+  "name": "https://example.com/example-1.2.3.tar.gz",
+  "digest": {"sha256": "5678..."}
+}],
+
+// Predicate
+"predicateType": "https://slsa.dev/verification_summary/v0.1",
+"predicate": {
+  "verifier": {
+    "id": "https://example.com/publication_verifier"
+    }
+  "time_verified": "1985-04-12T23:20:50.52Z"
+  "policy": "https://example.com/example_tarball.policy",
+  "verification_result": "PASSED",
+  "policy_level": "SLSA_LEVEL_3",
+  "minimum_dependency_level": "SLSA_LEVEL_2",
+  "minimum_downgrade_dependency_level": "SLSA_LEVEL_1"
+}
+```
+
+<div class="mt-16 mb-4">
+<a id="slsaresult"></a>
+
+## _SlsaResult (String)_
+
+</div>
+
+The result of evaluating an artifact (or set of artifacts) against SLSA.
+Must be one of these values:
+
+-   SLSA_LEVEL_0
+-   SLSA_LEVEL_1
+-   SLSA_LEVEL_2
+-   SLSA_LEVEL_3
+-   SLSA_LEVEL_4
+-   FAILED (Indicates policy evaluation failed)
+
+## Change history
+
+</div>
+-   0.1: Initial version.
+
+[SlsaResult]: #slsaresult
+[DigestSet]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#DigestSet
+[ResourceURI]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#ResourceURI
+[Statement]: https://github.com/in-toto/attestation/blob/main/spec/README.md#statement
+[Timestamp]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#Timestamp
+[TypeURI]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#TypeURI
+[in-toto attestation]: https://github.com/in-toto/attestation
+[parsing rules]: https://github.com/in-toto/attestation/blob/main/spec/README.md#parsing-rules

--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -65,22 +65,16 @@ assume that the artifacts met the indicated SLSA level without themselves
 needing to evaluate the artifact or to have access to the attestations the
 `verifier` used to make its determination.
 
-The VSA also allows consumers to determine the minimum verified level of
+The VSA also allows consumers to determine the verified levels of
 all of an artifact’s _transitive_ dependencies.  The verifier does this by
 either a) verifying the provenance of each non-source dependency listed in
 the [materials](https://slsa.dev/provenance/v0.2#materials) of the artifact
 being verified (recursively) or b) matching the non-source dependency
 listed in `materials` (by subject.digest == materials.digest and, ideally,
-subject.name == materials.uri) to a VSA _for that dependency_ and taking
-the `min(vsa.policy_level, vsa.minimum_dependency_level`).  Policy
-verifiers wishing to establish minimum requirements on dependencies SLSA
-levels may use `vsa.minimum_dependency_level` to do so.
-
-Since dependency graphs can be quite complex a policy verifier may wish to
-require a default SLSA level X for all dependencies but allow for explicit
-exceptions that have level < X.  This allows progress to be made without
-being held back by a handful of ‘stubborn’ dependencies.  Verifiers
-indicate these exceptions using `vsa.minimum_downgrade_dependency_level`.
+subject.name == materials.uri) to a VSA _for that dependency_ and using
+`vsa.policy_level` and `vsa.dependency_levels`.  Policy verifiers wishing
+to establish minimum requirements on dependencies SLSA levels may use
+`vsa.dependency_levels` to do so.
 
 <div class="mt-16 mb-4">
 
@@ -107,8 +101,11 @@ indicate these exceptions using `vsa.minimum_downgrade_dependency_level`.
   "policy": "<URI>",
   "verification_result": "<PASSED|FAILED>",
   "policy_level": "<SlsaResult>",
-  "minimum_dependency_level": "<SlsaResult>",
-  "minimum_downgrade_dependency_level": "<SlsaResult>"
+  "dependency_levels": {
+    "<SlsaResult>": <Int>,
+    "<SlsaResult>": <Int>,
+    ...
+  }
 }
 ```
 
@@ -178,19 +175,14 @@ of the other top-level fields, such as `subject`, see [Statement]._
 
 > Indicates what SLSA level the artifact itself (and not its dependencies) was verified at or "FAILED" if policy verification failed.
 
-<a id="minimum_dependency_level"></a>
-`minimum_dependency_level` _string ([SlsaResult]), optional_
+<a id="dependency_levels"></a>
+`dependency_levels` _object, required_
 
-> The minimum verified SLSA level of all the artifacts _transitive_ dependencies excluding any
-> dependencies that have been explicitly downgraded to a lower acceptable level in the `policy`.
-> Absence indicates no evaluation of dependencies has taken place.
-
-<a id="minimum_downgrade_dependency_level"></a>
-`minimum_downgrade_dependency_level` _string ([SlsaResult]), optional_
-
-> The minimum verified SLSA level of all the artifacts _transitive_ dependencies that have
-> been explicitly downgraded by the `policy`.
-> Absence indicates no evaluation of dependencies has taken place.
+> A count of the dependencies at each SLSA level.
+>
+> Map from [SlsaResult] the number of the artifact's _transitive_ dependencies that
+> were verified at the indicated level. Absence of a given level of [SlsaResult]
+> MUST be interpreted as reporting _0_ dependencies at that level.
 
 <div class="mt-16 mb-4">
 
@@ -217,8 +209,12 @@ WARNING: This is just for demonstration purposes.
   "policy": "https://example.com/example_tarball.policy",
   "verification_result": "PASSED",
   "policy_level": "SLSA_LEVEL_3",
-  "minimum_dependency_level": "SLSA_LEVEL_2",
-  "minimum_downgrade_dependency_level": "SLSA_LEVEL_1"
+  "dependency_levels": {
+    "SLSA_LEVEL_4": 1,
+    "SLSA_LEVEL_3": 5,
+    "SLSA_LEVEL_2": 7,
+    "SLSA_LEVEL_1": 1,
+  }
 }
 ```
 

--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -74,7 +74,7 @@ listed in `materials` (by subject.digest == materials.digest and, ideally,
 subject.name == materials.uri) to a VSA _for that dependency_ and taking
 the `min(vsa.policy_level, vsa.minimum_dependency_level`).  Policy
 verifiers wishing to establish minimum requirements on dependencies SLSA
-levels may use vsa.minimum_dependency_level to do so.
+levels may use `vsa.minimum_dependency_level` to do so.
 
 Since dependency graphs can be quite complex a policy verifier may wish to
 require a default SLSA level X for all dependencies but allow for explicit
@@ -121,10 +121,10 @@ indicate these exceptions using `vsa.minimum_downgrade_dependency_level`.
 This predicate follows the in-toto attestation [parsing rules]. Summary:
 
 -   Consumers MUST ignore unrecognized fields.
--   The predicateType URI includes the major version number and will always
+-   The `predicateType` URI includes the major version number and will always
     change whenever there is a backwards incompatible change.
 -   Minor version changes are always backwards compatible and "monotonic." Such
-    changes do not update the predicateType.
+    changes do not update the `predicateType`.
 -   Producers MAY add extension fields using field names that are URIs.
 
 <div class="mt-8 mb-4">
@@ -133,11 +133,11 @@ This predicate follows the in-toto attestation [parsing rules]. Summary:
 
 </div>
 
-_NOTE: This section describes the fields within predicate. For a description
-of the other top-level fields, such as subject, see [Statement]._
+_NOTE: This section describes the fields within `predicate`. For a description
+of the other top-level fields, such as `subject`, see [Statement]._
 
 <a id="verifier"></a>
-verifier _object, required_
+`verifier` _object, required_
 
 > Identifies the entity that performed the verification.
 >
@@ -154,42 +154,42 @@ verifier _object, required_
 > URI is not sufficient.
 
 <a id="verifier.id"></a>
-verifier.id _string ([TypeURI]), required_
+`verifier.id` _string ([TypeURI]), required_
 
 > URI indicating the verifier’s identity.
 
 <a id="time_verified"></a>
-time_verified _string ([Timestamp]), required_
+`time_verified` _string ([Timestamp]), required_
 
 > Timestamp indicating what time the verification occurred.
 
 <a id="policy"></a>
-policy _string ([TypeURI]), required_
+`policy` _string ([TypeURI]), required_
 
 > The URI of the policy that was used to verify this artifact.
 
 <a id="verification_result"></a>
-verification_result _string, required_
+`verification_result` _string, required_
 
 > Either “PASSED” or “FAILED” to indicate if the artifact passed or failed the policy verification.
 
 <a id="policy_level"></a>
-policy_level _string ([SlsaResult]), required_
+`policy_level` _string ([SlsaResult]), required_
 
 > Indicates what SLSA level the artifact itself (and not its dependencies) was verified at or "FAILED" if policy verification failed.
 
 <a id="minimum_dependency_level"></a>
-minimum_dependency_level _string ([SlsaResult]), optional_
+`minimum_dependency_level` _string ([SlsaResult]), optional_
 
 > The minimum verified SLSA level of all the artifacts _transitive_ dependencies excluding any
-> dependencies that have been explicitly downgraded to a lower acceptable level in the policy.
+> dependencies that have been explicitly downgraded to a lower acceptable level in the `policy`.
 > Absence indicates no evaluation of dependencies has taken place.
 
 <a id="minimum_downgrade_dependency_level"></a>
-minimum_downgrade_dependency_level _string ([SlsaResult]), optional_
+`minimum_downgrade_dependency_level` _string ([SlsaResult]), optional_
 
 > The minimum verified SLSA level of all the artifacts _transitive_ dependencies that have
-> been explicitly downgraded by a policy.
+> been explicitly downgraded by the `policy`.
 > Absence indicates no evaluation of dependencies has taken place.
 
 <div class="mt-16 mb-4">

--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -98,7 +98,10 @@ to establish minimum requirements on dependencies SLSA levels may use
     "id": "<URI>"
   },
   "time_verified": <TIMESTAMP>,
-  "policy": "<URI>",
+  "policy": {
+    "uri": "<URI>",
+    "digest": { /* DigestSet */ }
+  }
   "verification_result": "<PASSED|FAILED>",
   "policy_level": "<SlsaResult>",
   "dependency_levels": {
@@ -161,9 +164,19 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > Timestamp indicating what time the verification occurred.
 
 <a id="policy"></a>
-`policy` _string ([TypeURI]), required_
+`policy` _object, required_
 
-> The URI of the policy that was used to verify this artifact.
+> Describes the policy that was used to verify this artifact.
+
+<a id="policy.uri"></a>
+`policy.uri` _string ([ResourceURI]), required_
+
+> The URI of the policy used to perform verification.
+
+<a id="policy.digest"></a>
+`policy.digest` _object ([DigestSet]), optional_
+
+> Collection of cryptographic digests for the contents of the policy used to perform verification.
 
 <a id="verification_result"></a>
 `verification_result` _string, required_


### PR DESCRIPTION
Fixes #107 by creating an attestation that indicates a `verifier`
has determined that the specified `subject` artifact(s) meets the
indicated SLSA level.

In addition this attestation also indicates the minimum aggregate
SLSA level met by the dependencies used to build the artifact
which can help to address #61.

This leaves a number of things up to the user:
* What it means to evaluate an artifact against policy. (See #46)
* How to communicate the attestations required to create this
    attestation.
* How to debug failures

I borrowed heavily from slsa.dev/provenance in terms of
formatting/documentation.

If desired I can provide detailed algorithms for how the minimum_*
fields could be computed.

This attestation is based on work done by @AdamZWu.

Signed-off-by: Tom Hennen <tomhennen@google.com>