### PR TITLE
terminology: define build [platform|service|step]

### DIFF
--- a/docs/_spec/v0.1/terminology.md
+++ b/docs/_spec/v0.1/terminology.md
@@ -27,6 +27,9 @@ supply chains plus its own sources and builds.
 | Artifact | An immutable blob of data; primarily refers to software, but SLSA can be used for any artifact. | A file, a git commit, a directory of files (serialized in some way), a container image, a firmware image. |
 | Source | Artifact that was directly authored or reviewed by persons, without modification. It is the beginning of the supply chain; we do not trace the provenance back any further. | Git commit (source) hosted on GitHub (platform). |
 | Build | Process that transforms a set of input artifacts into a set of output artifacts. The inputs may be sources, dependencies, or ephemeral build outputs. | .travis.yml (process) run by Travis CI (platform). |
+| Build platform | An automation and scheduling platform for running build processes. Better defined by what it is not: the most desirable attribute of a build platform is that builds do not happen on a developer's workstation. | GitHub Actions, Tekton, Jenkins, Buildbot. |
+| Build service | Often used interchangeably with build platform, though may additionally imply a managed/hosted build platform (rather than i.e., a developer operated server). | GitHub Actions, Google Cloud Build, Travis CI. |
+| Build step | A single task in the build process | a `step` in a GitHub Action Workflow. |
 | Package | Artifact that is "published" for use by others. In the model, it is always the output of a build process, though that build process can be a no-op. | Docker image (package) distributed on DockerHub (platform). A ZIP file containing source code is a package, not a source, because it is built from some other source, such as a git commit. |
 | Dependency | Artifact that is an input to a build process but that is not a source. In the model, it is always a package. | Alpine package (package) distributed on Alpine Linux (platform). |
 


### PR DESCRIPTION
Although Build platform is implicitly defined as part of the Build, there is still confusion around the term. 
Additionally what makes a build step is not explicitly defined. 

Expand the new terminology page to include:
* Build platform: runs builds/build processes
* Build service: typically a managed/hosted build platform
* Build step: a task in the build process