### PR TITLE
Replace "permalink to debug logs" with "unique ID"

### DIFF
--- a/docs/_spec/v0.1/requirements.md
+++ b/docs/_spec/v0.1/requirements.md
@@ -537,7 +537,8 @@ reproducible and, if so, all information necessary to reproduce the build. See
 <td>
 
 The provenance includes metadata to aid debugging and investigations. This
-SHOULD at least include start and end timestamps and a permalink to debug logs.
+SHOULD at least include start and end timestamps and a unique identifier to
+allow finding detailed debug logs.
 
 "○" = RECOMMENDED.
 


### PR DESCRIPTION
Previously there was some confusion on whether an actual permalink is required (e.g. a URI) rather than a unique identifier. The intention was simply to allow joining of other data sources, not to require a URI, so hopefully the new wording makes this more clear.

The intent is *NOT* to now require a unique ID instead of a permalink, but rather to be more generic in what meets the requirement. In particular, if something already met the requirement before, it should still meet the requirement after this PR. Reviewers, please read carefully and offer suggestions if this doesn't read that way.

@bobcatfish does this help?