### PR TITLE
Fix social preview

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,6 @@
 title: SLSA
-description: Supply-chain Levels for Software Artifacts
+description: Security framework to ensure software supply chain integrity
+logo: /images/icons/android-chrome-512x512.png
 copyright_html: Copyright 2021 The Linux Foundation<br>under the terms of the <a href="https://github.com/slsa-framework/slsa/blob/main/LICENSE">Apache License 2.0</a>
 repository: slsa-framework/slsa
 collections:
@@ -54,3 +55,8 @@ defaults:
       path: "_spec"
     values:
       folder: true
+  - scope:
+      path: ""
+    values:
+      # Set the Social image icon
+      image: /images/icons/android-chrome-512x512.png

--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -12,10 +12,9 @@
     <link rel="icon" type="image/x-icon" href="{{ "images/icons/favicon.ico" | relative_url }}">
     <link rel="mask-icon" href="{{ "images/icons/safari-pinned-tab.svg" | relative_url }}" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#da532c" />
-    <meta name="msapplication-square150x150logo" content="images/icons/mstile-150x150.png" />
+    <meta name="msapplication-square150x150logo" content="{{ "images/icons/mstile-150x150.png" | relative_url }}" />
     <meta name="theme-color" content="#ffffff" />
-    <title>SLSA • {% if page.title %}{{page.title}}{% endif %}</title>
-    <meta name="twitter:title" content="A common language for different levels of software security. SLSA (salsa) is Supply-chain Levels for Software Artifacts." />
+    <title>{{ site.title }} • {{page.title}}</title>
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-title: Overview
+title: Supply-chain Levels for Software Artifacts
 subheading: Safeguarding artifact integrity across any software supply chain
 levels:
     - 1:


### PR DESCRIPTION
This continues using the jekyll-seo-tag plugin, which I think might be generating incorrect tags. The preview does not work on the various debug tools (e.g. twitters), but at least the description is better than before, and an image tag is generated. Let's submit this and see if it's any better on the real thing.

Partial fix for #274.