### PR TITLE
Clarify null vs. unset for optional fields

### DIFF
--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -127,6 +127,8 @@ This predicate follows the in-toto attestation [parsing rules]. Summary:
 -   Minor version changes are always backwards compatible and "monotonic." Such
     changes do not update the `predicateType`.
 -   Producers MAY add extension fields using field names that are URIs.
+-   Optional fields MAY be unset or null, and should be treated equivalently.
+    Both are equivalent to empty for _object_ or _array_ values.
 
 <div class="mt-8 mb-4">
 
@@ -186,18 +188,18 @@ of the other top-level fields, such as `subject`, see [Statement]._
 `invocation.configSource` _object, optional_
 
 > Describes where the config file that kicked off the build came from.
-> This is effectively a pointer to the source where `buildConfig` came from. Unset or null is equivalent to empty.
+> This is effectively a pointer to the source where `buildConfig` came from.
 
 <a id="invocation.configSource.uri"></a>
 `invocation.configSource.uri` _string ([ResourceURI]), optional_
 
-> URI indicating the identity of the source of the config. Unset or null is equivalent to empty.
+> URI indicating the identity of the source of the config.
 
 <a id="invocation.configSource.digest"></a>
 `invocation.configSource.digest` _object ([DigestSet]), optional_
 
 > Collection of cryptographic digests for the contents of the artifact
-> specified by `invocation.configSource.uri`. Unset or null is equivalent to empty.
+> specified by `invocation.configSource.uri`.
 
 <a id="invocation.configSource.entryPoint"></a>
 `invocation.configSource.entryPoint` _string, optional_
@@ -231,7 +233,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > This is an arbitrary JSON object with a schema defined by `buildType`.
 >
 > This is considered to be incomplete unless `metadata.completeness.parameters`
-> is true. Unset or null is equivalent to empty.
+> is true.
 
 <a id="invocation.environment"></a>
 `invocation.environment` _object, optional_
@@ -250,12 +252,12 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > This is an arbitrary JSON object with a schema defined by `buildType`.
 >
 > This is considered to be incomplete unless `metadata.completeness.environment`
-> is true. Unset or null is equivalent to empty.
+> is true.
 
 <a id="metadata"></a>
 `metadata` _object, optional_
 
-> Other properties of the build. Unset or null is equivalent to empty.
+> Other properties of the build.
 
 <a id="metadata.buildInvocationId"></a>
 `metadata.buildInvocationId` _string, optional_
@@ -279,7 +281,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 `metadata.completeness` _object, optional_
 
 > Indicates that the `builder` claims certain fields in this message to be
-> complete. Unset or null is equivalent to empty.
+> complete.
 
 <a id="metadata.completeness.parameters"></a>
 `metadata.completeness.parameters` _boolean, optional_
@@ -312,7 +314,6 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > to verify information about the build.
 >
 > This is an arbitrary JSON object with a schema defined by `buildType`.
-> Unset or null is equivalent to empty.
 
 <a id="materials"></a>
 `materials` _array of objects, optional_
@@ -321,7 +322,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > dependencies, build tools, base images, and so on.
 >
 > This is considered to be incomplete unless `metadata.completeness.materials`
-> is true. Unset or null is equivalent to empty.
+> is true.
 
 <a id="materials.uri"></a>
 `materials[*].uri` _string ([ResourceURI]), optional_
@@ -337,8 +338,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 <a id="materials.digest"></a>
 `materials[*].digest` _object ([DigestSet]), optional_
 
-> Collection of cryptographic digests for the contents of this artifact. Unset 
-> or null is equivalent to empty.
+> Collection of cryptographic digests for the contents of this artifact.
 
 <div class="mt-16 mb-4">
 

--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -186,18 +186,18 @@ of the other top-level fields, such as `subject`, see [Statement]._
 `invocation.configSource` _object, optional_
 
 > Describes where the config file that kicked off the build came from.
-> This is effectively a pointer to the source where `buildConfig` came from.
+> This is effectively a pointer to the source where `buildConfig` came from. Unset or null is equivalent to empty.
 
 <a id="invocation.configSource.uri"></a>
 `invocation.configSource.uri` _string ([ResourceURI]), optional_
 
-> URI indicating the identity of the source of the config.
+> URI indicating the identity of the source of the config. Unset or null is equivalent to empty.
 
 <a id="invocation.configSource.digest"></a>
 `invocation.configSource.digest` _object ([DigestSet]), optional_
 
 > Collection of cryptographic digests for the contents of the artifact
-> specified by `invocation.configSource.uri`.
+> specified by `invocation.configSource.uri`. Unset or null is equivalent to empty.
 
 <a id="invocation.configSource.entryPoint"></a>
 `invocation.configSource.entryPoint` _string, optional_
@@ -255,7 +255,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 <a id="metadata"></a>
 `metadata` _object, optional_
 
-> Other properties of the build.
+> Other properties of the build. Unset or null is equivalent to empty.
 
 <a id="metadata.buildInvocationId"></a>
 `metadata.buildInvocationId` _string, optional_
@@ -279,7 +279,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 `metadata.completeness` _object, optional_
 
 > Indicates that the `builder` claims certain fields in this message to be
-> complete.
+> complete. Unset or null is equivalent to empty.
 
 <a id="metadata.completeness.parameters"></a>
 `metadata.completeness.parameters` _boolean, optional_
@@ -312,6 +312,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > to verify information about the build.
 >
 > This is an arbitrary JSON object with a schema defined by `buildType`.
+> Unset or null is equivalent to empty.
 
 <a id="materials"></a>
 `materials` _array of objects, optional_
@@ -336,7 +337,8 @@ of the other top-level fields, such as `subject`, see [Statement]._
 <a id="materials.digest"></a>
 `materials[*].digest` _object ([DigestSet]), optional_
 
-> Collection of cryptographic digests for the contents of this artifact.
+> Collection of cryptographic digests for the contents of this artifact. Unset 
+> or null is equivalent to empty.
 
 <div class="mt-16 mb-4">
 


### PR DESCRIPTION
The provenance spec explicitly dictates handling of null or unset values for certain object and array fields, but not all. With this change null or unset values of these types will be uniformly treated as empty.