### PR TITLE
Move "Provenance" under specifications menu, and add link to "VSA"

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -23,8 +23,13 @@
     - title: FAQ
       url: /spec/faq
 
-- title: Provenance
-  url: /provenance/v0.2
+    - spacer: true
+
+    - title: Provenance
+      url: /provenance/v0.2
+
+    - title: VSA
+      url: /verification_summary/v0.1
 
 - title: Use cases
   url: /use-cases

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -34,9 +34,13 @@
             <ul>
               {%- for subitem in item.children -%}
                 <li>
+                  {%- if subitem.spacer %}
+                  <hr>
+                  {%- else %}
                   <a class="text-white md:text-black" href="{{ subitem.url | relative_url }}">
                     {{ subitem.title | escape }}
                   </a>
+                  {%- endif %}
                 </li>
               {%- endfor %}
             </ul>


### PR DESCRIPTION
It was a bit confusing why "Provenance" got its own top-level menu, especially since it too is a specification. Now all specs are under a single menu. This makes the top-level nav a bit cleaner.

Insert a horizontal rule to differentiate between the SLSA ladder and the attestations formats. Without that, the organization of the menu is a bit unclear.

Add a link to VSA. Fixes #334.

![desktop](https://user-images.githubusercontent.com/58860/161324422-c9857d3a-e12e-4913-9ec0-059870c2c611.png)

<img src="https://user-images.githubusercontent.com/58860/161324396-3a5d3da5-e4e6-48f9-be11-5be51a7c9ec6.png" height="500px">