### PR TITLE
automatically pull date on build

### DIFF
--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="wrapper py-4 flex flex-wrap items-start justify-between w-full">
     <div class="w-full md:w-1/3 mb-8 md:mb-0">
       <p><strong>SLSA is a cross-industry collaboration.</strong><br>
-        © 2021 The Linux Foundation, under the terms of the Apache License 2.0</p>
+        © {{ site.time | date: '%Y' }} The Linux Foundation, under the terms of the Apache License 2.0</p>
     </div>
     <div class="w-full md:w-1/3 mb-8 md:mb-0">
       <p><strong>Privacy statement</strong><br>


### PR DESCRIPTION
Resolves #342

It will still require rebuilding when the year changes but I think that's more appropriate than some JS that pulls Date.now()
The copyright notice will only need to cover year+1 if there have been changes in year+1

![image](https://user-images.githubusercontent.com/9866621/161247931-4c21a7f8-d41f-49ae-846b-0ae0ed2ef823.png)
