### PR TITLE
Improve CSS on blog post pages.

### DIFF
--- a/docs/_layouts/post-list.html
+++ b/docs/_layouts/post-list.html
@@ -21,7 +21,7 @@
                     </div>
                 </section>
             </div>
-            <section class="wrapper inner main-content">
+            <section class="wrapper markdown inner main-content">
                 <div class="pb-16">{{ content }}</div>
             </section>
       </main>


### PR DESCRIPTION
This adds back spaces between paragraphs (#355), but it isn't a perfect solution because block quotes are all screwed up (use flex model, wrong color, etc.)

I didn't use this on the specification pages because there we use blockquotes. For the blog, so far it's a pure improvement.

## Before

![before](https://user-images.githubusercontent.com/58860/163004115-2fed293f-9836-4126-97e1-fc1d6ef156c9.png)

## After

![after](https://user-images.githubusercontent.com/58860/163004145-945a35b9-68ee-4e96-b9cf-c573dd37e54f.png)
