### PR TITLE
Fix "Change history" rendering of VSA page

### DIFF
--- a/docs/verification_summary/v0.1.md
+++ b/docs/verification_summary/v0.1.md
@@ -251,9 +251,12 @@ Must be one of these values:
 -   SLSA_LEVEL_4
 -   FAILED (Indicates policy evaluation failed)
 
+<div class="mt-16 mb-4">
+
 ## Change history
 
 </div>
+
 -   0.1: Initial version.
 
 [SlsaResult]: #slsaresult


### PR DESCRIPTION
Previously the bullet didn't render correctly and the spacing was messed
up.

Signed-off-by: Mark Lodato <lodato@google.com>
