### PR TITLE
dependabot: fix bundler, decrease freq to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,16 +2,16 @@ version: 2
 updates:
 
 - package-ecosystem: bundler
-  directory: "/"
+  directory: "/docs"
   schedule:
     interval: weekly
 
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
 
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly


### PR DESCRIPTION
Our Gemfile is in the docs directory, not the root directory.

Decrease all the frequencies to weekly (not daily) to slightly reduce
the amount of PR spam we get.

Signed-off-by: Mark Lodato <lodato@google.com>
