### PR TITLE
Blog: clean up styling, add banner for guest posts

### DIFF
--- a/docs/_layouts/post-list.html
+++ b/docs/_layouts/post-list.html
@@ -1,3 +1,6 @@
+---
+is_post: false
+---
 <!DOCTYPE html>
 <html lang="{{ page.lang | default: site.lang | default: "en" }}">
 
@@ -9,9 +12,13 @@
       <main aria-label="Content">
             <div class="wrapper">
                 <!-- Hero -->
-                <section class="hero specifications flex justify-center items-center">
+                <section class="hero {% if layout.is_post %}post{% else %}post-list{% endif %} flex justify-center items-center">
                     <div class="wrapper inner text-green-darkest text-left flex flex-col justify-start">
-                        <h1 class="pr-32 mb-16 mt-32">{{page.title}}</h1>
+                      {%- if layout.is_post %}
+                        <h1 class="pr-32 mb-4 mt-8">{{ page.title }}</h1>
+                      {%- else %}
+                        <h1 class="pr-32 mb-16 mt-32">{{ page.title }}</h1>
+                      {%- endif %}
                         <h2>{{ page.subtitle }}</h2>
                         <div class="md:flex justify-between items-start">
                             <div class="w-full md:w-3/5">

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -1,7 +1,17 @@
 ---
 layout: post-list
+is_post: true
 ---
-<h3 class="mt-8 mb-8"> by {{ page.author }}</h3>
-<p><b>{{ page.date | date_to_string }}</b></p>
+<p class="h3 post-author">by {{ page.author }}</p>
+<p class="post-date"><time datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date_to_string }}</time></p>
 
 {{ content }}
+
+{% if page.is_guest_post -%}
+<div class="guest-post-banner">
+  This is a guest post. The views expressed are not official positions of the
+  SLSA community or any parent organization. The author has requested and
+  incorporated reviewer feedback whenever possible, but the opinions presented
+  are the author’s alone.
+</div>
+{%- endif %}

--- a/docs/_posts/2022-04-08-blog-launch.md
+++ b/docs/_posts/2022-04-08-blog-launch.md
@@ -1,6 +1,6 @@
 ---
 title: Introducing the SLSA Blog
 author: "SLSA Community"
-layout: post
+is_guest_post: false
 ---
 We're excited to launch our very own blog, from which we will be posting project news, documentation, and other information about SLSA. Stay tuned for more posts coming your way soon.

--- a/docs/_posts/2022-04-11-slsa-is-no-free-lunch.md
+++ b/docs/_posts/2022-04-11-slsa-is-no-free-lunch.md
@@ -1,7 +1,7 @@
 ---
 title: SLSA Is No Free Lunch
 author: "Mike Lieberman"
-layout: post
+is_guest_post: true
 ---
 “What is SLSA?” followed closely by “What does SLSA do for me?” are the two most common questions I get when people learn about SLSA. This has led to a lot of confusion as to how folks apply SLSA, and the benefits they get. You can’t just apply SLSA practices to a pipeline that runs a build, generate a SLSA attestation and magically be protected from supply chain compromise. Contrary to a lot of the hype being thrown around, SLSA is no free lunch, and we must help protect our lunch!
 

--- a/docs/_posts/2022-05-02-slsa-sbom.md
+++ b/docs/_posts/2022-05-02-slsa-sbom.md
@@ -1,7 +1,7 @@
 ---
 title: "SBOM + SLSA: Accelerating SBOM success with the help of SLSA"
 author: "Brandon Lum, Isaac Hepworth, Meder Kydyraliev"
-layout: post
+is_guest_post: true
 ---
 
 <!-- markdownlint-disable-next-line MD033 -->

--- a/docs/_sass/minima/_layout.scss
+++ b/docs/_sass/minima/_layout.scss
@@ -474,6 +474,23 @@
     margin-bottom: $spacer-xl;
 }
 
+.markdown .post-author {
+    margin-top: $spacer-xl;
+    margin-bottom: $spacer-m;
+}
+
+.markdown .post-date {
+    color: $grey-color;
+}
+
+.markdown .guest-post-banner {
+    margin-left: $spacer-xxl;
+    margin-right: $spacer-xxl;
+    font-style: italic;
+    font-size: $small-font-size;
+    color: $grey-color;
+}
+
 
 // hero styling
 
@@ -492,12 +509,12 @@
         background-size: cover;
     }
 
-    &.specifications{
+    &.specifications, &.post-list {
         background-color: $light-green;
         height: auto;
     }
 
-    &.markdown-page{
+    &.markdown-page, &.post {
         background-color: white;
         height: auto;
         padding-bottom: 0;


### PR DESCRIPTION
Context: https://github.com/slsa-framework/slsa/issues/309#issuecomment-1113559601

Add a "views expressed disclaimer" on guest posts. 

Clean up the styling of blog posts:
- Smaller header with white background.
- Format the date to look a bit nicer.

Preview: https://deploy-preview-379--slsa.netlify.app/blog/2022/04/slsa-is-no-free-lunch

![top](https://user-images.githubusercontent.com/58860/166480624-7e97ae65-3582-44e2-a14a-23d8874fdeab.png)

[...]

![bottom](https://user-images.githubusercontent.com/58860/166481177-b791e29d-3d60-4581-9d84-f42207296614.png)


# What it looked like before

![old](https://user-images.githubusercontent.com/58860/166041870-9bfc93ba-09a2-451d-8b3b-26eb26c70083.png)


