### PR TITLE
Add GitLab Provenance Example

### DIFF
--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -466,6 +466,73 @@ in `builder`.
 
 <div class="mt-8 mb-4">
 
+#### GitLab CI
+
+</div>
+
+The GitLab CI team has implemented an [artifact attestation](https://docs.gitlab.com/ee/ci/runners/configure_runners.html#artifact-attestation) capability in their GitLab Runner 15.1 release.
+
+If GitLab is the one to generate provenance, and the runner is GitLab-hosted or self-hosted,
+then the builder would be as follows:
+
+```jsonc
+"builder": {
+  "id": "https://gitlab.com/foo/bar/-/runners/12345678"
+}
+```
+
+<div class="mt-8 mb-4">
+
+#### GitLab CI Job
+
+</div>
+
+```jsonc
+"buildType": "https://gitlab.com/gitlab-org/gitlab-runner/-/blob/v15.1.0/PROVENANCE.md",
+"invocation": {
+  "configSource": {
+    // the git repo that contains the GitLab CI job referenced in the entrypoint
+    "uri": "https://gitlab.com//foo/bar",
+    // The resolved git commit hash reflecting the version of the repo used
+    // for this build.
+    "digest": {
+        "sha256": "abc..."
+    },
+    // the name of the CI job that triggered the build
+    "entryPoint": "build"
+  },
+  // Other variables that are required to reproduce the build and that cannot be
+  // recomputed using existing information. (Documentation would explain how to
+  // recompute the rest of the fields.)
+  "environment": {
+      // Name of the GitLab runner
+      "name": "hosted-gitlab-runner",
+      // The runner executor
+      "executor": "kubernetes",
+      // The architecture on which the CI job is run
+      "architecture": "amd64"
+  },
+  // Collection of all external inputs (CI variables) related to the job
+  "parameters": {
+      "CI_PIPELINE_ID": "",
+      "CI_PIPELINE_URL": "",
+      // All other CI variable names are listed here. Values are always represented as empty strings to avoid leaking secrets.
+  }
+},
+  "metadata": {
+      "buildStartedOn": "2022-06-17T00:47:27+03:00",
+      "buildFinishedOn": "2022-06-17T00:47:28+03:00",
+      "completeness": {
+          "parameters": true,
+          "environment": true,
+          "materials": false
+      },
+      "reproducible": false
+  }
+```
+
+<div class="mt-8 mb-4">
+
 ### Google Cloud Build
 
 </div>

--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -466,7 +466,7 @@ in `builder`.
 
 <div class="mt-8 mb-4">
 
-#### GitLab CI
+### GitLab CI
 
 </div>
 
@@ -519,16 +519,16 @@ then the builder would be as follows:
       // All other CI variable names are listed here. Values are always represented as empty strings to avoid leaking secrets.
   }
 },
-  "metadata": {
-      "buildStartedOn": "2022-06-17T00:47:27+03:00",
-      "buildFinishedOn": "2022-06-17T00:47:28+03:00",
-      "completeness": {
-          "parameters": true,
-          "environment": true,
-          "materials": false
-      },
-      "reproducible": false
-  }
+"metadata": {
+  "buildStartedOn": "2022-06-17T00:47:27+03:00",
+  "buildFinishedOn": "2022-06-17T00:47:28+03:00",
+  "completeness": {
+      "parameters": true,
+      "environment": true,
+      "materials": false
+  },
+  "reproducible": false
+}
 ```
 
 <div class="mt-8 mb-4">


### PR DESCRIPTION
GitLab recently released version 15.1 of their runner which introduced the ability to generate SLSA provenance for GitLab jobs that produce artifacts. https://docs.gitlab.com/ee/ci/runners/configure_runners.html#artifact-attestation

I updated the provenance page to reflect this. I slotted it in the middle of the GitHub and Google Cloud examples.

- Kept GitHub's example above because it seems more prevalent 
- Put it above Google Cloud because it is a real life example and not for demonstration purposes

_This is my first open source submission ever - please let me know how I can improve this PR.  I tried to follow the contributing guidance as close as possible._