### PR TITLE
Adding FRSCA in getting started

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -40,6 +40,7 @@ hero_text: If you’re looking to jump straight in and try SLSA, here’s a quic
                         <li><a href="https://github.com/slsa-framework/azure-devops-demo">Azure DevOps provenance generator</a> (SLSA level 1)</li>
                         <li><a href="https://cloud.google.com/build/docs/securing-builds/use-provenance-and-binary-authorization">Google Cloud Build</a> (SLSA level 2)</li>
                         <li><a href="https://github.com/sigstore/cosign">Sigstore Cosign for storing signed provenance</a></li>
+                        <li><a href="https://github.com/buildsec/frsca">OpenSSF - Factory for Repeatable Secure Creation of Artifacts (FRSCA)</a> (Currently SLSA level 2)</li>
                     </ul>
                 </div>
             </div>


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Adding OpenSSF [FRSCA](https://github.com/buildsec/frsca) to the getting started page as another example implementation of how to obtain the various SLSA levels. FRSCA is an implementation of the CNCF's [Secure Software Factory Reference Architecture](https://docs.google.com/document/d/1FwyOIDramwCnivuvUxrMmHmCr02ARoA3jw76o1mGfGQ) which is based on the CNCF's [Software Supply Chain Best Practices White Paper](https://github.com/cncf/tag-security/blob/main/supply-chain-security/supply-chain-security-paper/CNCF_SSCP_v1.pdf). 

Currently FRSCA is SLSA level 2 but in the coming weeks will be at SLSA level 3/4 with the addition of Tekton + Spire. 
