### PR TITLE
Hack to fix paragraph spacing

### DIFF
--- a/docs/_layouts/standard.html
+++ b/docs/_layouts/standard.html
@@ -29,7 +29,7 @@
                     </div>
                 </section>
             </div>
-            <section class="wrapper inner main-content">
+            <section class="wrapper inner main-content fix-paragraph-spacing">
                 <div class="pb-16">{{ content }}</div>
             </section>
       </main>

--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -471,3 +471,11 @@ details {
   font-family: "Prodigy";
   line-height: 1;
 }
+
+// This is a hack to fix paragraph spacing. Really the theme should be fixed.
+// See https://github.com/slsa-framework/slsa/issues/335.
+.fix-paragraph-spacing {
+  p, ul, ol {
+    margin-bottom: 12px;
+  }
+}


### PR DESCRIPTION
The proper fix would be to fix the CSS, but for now the lack of inter-paragraph spacing (#335) is highly distracting so this is a cheap fix.

Preview: TODO

![image](https://user-images.githubusercontent.com/58860/178324460-e95486b9-9d53-43d7-8592-7bb561c2d55d.png)
