### PR TITLE
Added line to include link for SLSA Blog Criteria

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,8 @@ our [Code of Conduct](code-of-conduct.md) when engaging with the SLSA community.
 The SLSA project is authored on GitHub using [Issues] to describe proposed work
 and [Pull Requests] to submit changes.
 
+If you would like to contribute to the SLSA Blog, please see: https://github.com/slsa-framework/governance/blob/main/6._Contributing.md
+
 For other ways to engage with the SLSA community, see our [README](README.md).
 
 [Issues]: https://github.com/slsa-framework/slsa/issues


### PR DESCRIPTION
Dependent on approval for https://github.com/slsa-framework/governance/pull/13/ 


Signed-off-by: Melba <101211710+melba-lopez@users.noreply.github.com>