### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ SLSA (pronounced ["salsa"](https://www.google.com/search?q=how+to+pronounce+sals
 
 The primary content of this repo is the [docs/](docs/) directory, which contains the core SLSA specification and sources to the [slsa.dev] website.
 
-You can read [SLSA's documentation here](docs/_spec/). The key documents are `levels` - which defines the framework - and `requirements`, which explains how to attain compliance.
+You can read [SLSA's documentation here](docs/spec/). The key documents are `levels` - which defines the framework - and `requirements`, which explains how to attain compliance.
 
 ## Project status
 


### PR DESCRIPTION
Fixed indirection -- `_spec` was renamed to `spec`.

Signed-off-by: David Bendory <bendory@users.noreply.github.com>