### PR TITLE
RFC: Support markdown in hero_text for specification and standard?

### DIFF
--- a/docs/_layouts/specifications.html
+++ b/docs/_layouts/specifications.html
@@ -14,7 +14,7 @@
                         <h1 class="pr-32 pb-16 pt-32">{{ page.title }}</h1>
                         <div class="md:flex justify-between items-start text-black">
                             <div class="w-full md:w-3/5">
-                                <p>{{ page.hero_text }}</p>
+                                <p>{{ page.hero_text | markdownify }}</p>
                             </div>
                         </div>
                     </div>

--- a/docs/_layouts/standard.html
+++ b/docs/_layouts/standard.html
@@ -14,7 +14,7 @@
                         <h1 class="pr-32 mb-16 mt-32">{{ page.title }}</h1>
                         <div class="md:flex justify-between items-start">
                             <div class="w-full md:w-3/5">
-                                <p>{{ page.hero_text }}</p>
+                                <p>{{ page.hero_text | markdownify }}</p>
                             </div>
                             <div class="table-of-contents w-full md:w-1/3">
                                 {% if page.title == 'Provenance' %}


### PR DESCRIPTION
While playing around with layout for the Software attestations page in #438 I discovered that the `hero_text` did not support Markdown formatting. This PR enables support for Markdown in the `hero_text`. As I ultimately did not need it for #438 I pulled it out into a separate PR to see whether it's considered useful?