### PR TITLE
Create verification summary specification v0.2

### DIFF
--- a/docs/verification_summary/v0.2-draft.md
+++ b/docs/verification_summary/v0.2-draft.md
@@ -3,6 +3,11 @@ title: SLSA Verification Summary Attestation (VSA)
 layout: standard
 hero_text: Verification summary attestations communicate that an artifact has been verified at a specific SLSA level and details about that verification.
 ---
+
+**IMPORTANT:** This is a DRAFT version of the VSA spec that is **subject to
+change.** Once this version is finalized, the "-draft" suffix will be removed.
+For the latest stable version, see [v0.1](0.1).
+
 <details class="mt-12">
 <summary>Note about 0.x versions</summary>
 
@@ -68,8 +73,8 @@ all of an artifact’s _transitive_ dependencies.  The verifier does this by
 either a) verifying the provenance of each non-source dependency listed in
 the [materials](/provenance/v0.2#materials) of the artifact
 being verified (recursively) or b) matching the non-source dependency
-listed in `materials` (by subject.digest == materials.digest and, ideally,
-subject.name == materials.uri) to a VSA _for that dependency_ and using
+listed in `materials` (by `subject.digest` == `materials.digest` and, ideally,
+`vsa.resource_uri` == `materials.uri`) to a VSA _for that dependency_ and using
 `vsa.policy_level` and `vsa.dependency_levels`.  Policy verifiers wishing
 to establish minimum requirements on dependencies SLSA levels may use
 `vsa.dependency_levels` to do so.
@@ -84,18 +89,19 @@ to establish minimum requirements on dependencies SLSA levels may use
 // Standard attestation fields:
 "_type": "https://in-toto.io/Statement/v0.1",
 "subject": [{
-  "name": <artifact-URI-in-request>,
+  "name": <NAME>,
   "digest": { <digest-in-request> }
 }],
 
 // Predicate
-"predicateType": "https://slsa.dev/verification_summary/v0.1",
+"predicateType": "https://slsa.dev/verification_summary/v0.2-draft",
 "predicate": {
   // Required
   "verifier": {
     "id": "<URI>"
   },
   "time_verified": <TIMESTAMP>,
+  "resource_uri": <artifact-URI-in-request>,
   "policy": {
     "uri": "<URI>",
     "digest": { /* DigestSet */ }
@@ -161,6 +167,11 @@ of the other top-level fields, such as `subject`, see [Statement]._
 
 > Timestamp indicating what time the verification occurred.
 
+<a id="resource_uri"></a>
+`resource_uri` _string ([ResourceURI]), required_
+
+> URI that identifies the resource associated with the artifact being verified.
+
 <a id="policy"></a>
 `policy` _object, required_
 
@@ -206,17 +217,18 @@ WARNING: This is just for demonstration purposes.
 ```jsonc
 "_type": "https://in-toto.io/Statement/v0.1",
 "subject": [{
-  "name": "https://example.com/example-1.2.3.tar.gz",
+  "name": "out/example-1.2.3.tar.gz",
   "digest": {"sha256": "5678..."}
 }],
 
 // Predicate
-"predicateType": "https://slsa.dev/verification_summary/v0.1",
+"predicateType": "https://slsa.dev/verification_summary/v0.2-draft",
 "predicate": {
   "verifier": {
     "id": "https://example.com/publication_verifier"
   },
   "time_verified": "1985-04-12T23:20:50.52Z",
+  "resource_uri": "https://example.com/example-1.2.3.tar.gz",
   "policy": {
     "uri": "https://example.com/example_tarball.policy",
     "digest": {"sha256": "1234..."}
@@ -255,6 +267,7 @@ Must be one of these values:
 
 </div>
 
+-   0.2-draft: Added `resource_uri` field.
 -   0.1: Initial version.
 
 [SlsaResult]: #slsaresult


### PR DESCRIPTION
Introduces `resource_uri` field in predicate to hold the resource URI used for verification, instead of the statement field `subject.name`.