### PR TITLE
Add initial maintainers in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Maintainers
+* @MarkLodato @TomHennen @joshuagl


### PR DESCRIPTION
Our governance document lists Maintainers as one of the roles in the project,
but until now who holds that role has not been obvious.

List an initial set of maintainers based on number of contributions (Pull
Requests and Reviews) to the slsa-framework/slsa repository.

Fixes: slsa-framework/governance#9

@TomHennen and @MarkLodato this will make you a requested reviewer for all PRs against this repo. Please review and approve if you agree to be a maintainer of the project.

Note: I opted to list GitHub id's rather than creating a group as I believe that offers greater transparency. 