### PR TITLE
Fix Netlify build by removing JEKYLL_ENV

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,8 +2,3 @@
 base = "docs/"
 publish = "_site/"  # relative to `base` directory
 command = "bundle exec jekyll build"
-
-[context.environment]
-JEKYLL_ENV = "development"
-[context.production.environment]
-JEKYLL_ENV = "production"


### PR DESCRIPTION
The old setting broke the production deploy (but not previews).

Context: #266 

Tested: https://62e962f428e78400082b7a85--marklodato-slsa.netlify.app/
