### PR TITLE
Add `input_attestations` to VSA and bump up to v0.2

### DIFF
--- a/docs/verification_summary/index.html
+++ b/docs/verification_summary/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-US">
   <title>Redirecting&hellip;</title>
-  <meta http-equiv="refresh" content="0; url=v0.1">
-  <link rel="canonical" href="v0.1">
+  <meta http-equiv="refresh" content="0; url=v0.2">
+  <link rel="canonical" href="v0.2">
   <meta name="robots" content="noindex">
 </html>

--- a/docs/verification_summary/index.md
+++ b/docs/verification_summary/index.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: v0.1
+redirect_to_url: v0.2
 sitemap: false
 ---

--- a/docs/verification_summary/v0.2.md
+++ b/docs/verification_summary/v0.2.md
@@ -4,10 +4,6 @@ layout: standard
 hero_text: Verification summary attestations communicate that an artifact has been verified at a specific SLSA level and details about that verification.
 ---
 
-**IMPORTANT:** This is a DRAFT version of the VSA spec that is **subject to
-change.** Once this version is finalized, the "-draft" suffix will be removed.
-For the latest stable version, see [v0.1](0.1).
-
 <details class="mt-12">
 <summary>Note about 0.x versions</summary>
 
@@ -94,7 +90,7 @@ to establish minimum requirements on dependencies SLSA levels may use
 }],
 
 // Predicate
-"predicateType": "https://slsa.dev/verification_summary/v0.2-draft",
+"predicateType": "https://slsa.dev/verification_summary/v0.2",
 "predicate": {
   // Required
   "verifier": {
@@ -106,6 +102,13 @@ to establish minimum requirements on dependencies SLSA levels may use
     "uri": "<URI>",
     "digest": { /* DigestSet */ }
   }
+  "input_attestations": [
+    {
+      "uri": "<URI>",
+      "digest": { <digest-of-attestation-data> }
+    },
+    ...
+  ],
   "verification_result": "<PASSED|FAILED>",
   "policy_level": "<SlsaResult>",
   "dependency_levels": {
@@ -187,6 +190,35 @@ of the other top-level fields, such as `subject`, see [Statement]._
 
 > Collection of cryptographic digests for the contents of the policy used to perform verification.
 
+<a id="input_attestations"></a>
+`input_attestations` _object, optional_
+
+> The collection of attestations that were used to perform verification.
+> Conceptually similar to the `materials` field in the [SLSA Provenance](/provenance).
+>
+> This field can be absent if the verifier does not support this feature;
+> If present, this field must contain information on _all_ the attestations
+> used to perform verification.
+> An empty collection indicates the decision was made without attestations.
+
+<a id="input_attestations.uri"></a>
+`input_attestations[*].uri` _string ([ResourceURI]), optional_
+
+> A URI that can be used (provided the requester has read permission) to fetch
+> the attestation.
+>
+> An absent field indicates the verifier does not know where to fetch the attestation
+> (e.g. it was supplied by the verification requester).
+>
+> The data fetched from the URI may contain more than one attestation (e.g. an
+> attestation bundle file). In that case, the attestation is identified by
+> `digest` field values.
+
+<a id="input_attestations.digest"></a>
+`input_attestations[*].digest` _object ([DigestSet]), required_
+
+> Collection of cryptographic digests for this attestation.
+
 <a id="verification_result"></a>
 `verification_result` _string, required_
 
@@ -222,7 +254,7 @@ WARNING: This is just for demonstration purposes.
 }],
 
 // Predicate
-"predicateType": "https://slsa.dev/verification_summary/v0.2-draft",
+"predicateType": "https://slsa.dev/verification_summary/v0.2",
 "predicate": {
   "verifier": {
     "id": "https://example.com/publication_verifier"
@@ -233,6 +265,12 @@ WARNING: This is just for demonstration purposes.
     "uri": "https://example.com/example_tarball.policy",
     "digest": {"sha256": "1234..."}
   },
+  "input_attestations": [
+    {
+      "uri": "https://example.com/provenances/example-1.2.3.tar.gz.intoto.jsonl",
+      "digest": {"sha256": "abcd..."}
+    }
+  ],
   "verification_result": "PASSED",
   "policy_level": "SLSA_LEVEL_3",
   "dependency_levels": {
@@ -267,7 +305,9 @@ Must be one of these values:
 
 </div>
 
--   0.2-draft: Added `resource_uri` field.
+-   0.2:
+    -   Added `resource_uri` field.
+    -   Added optional `input_attestations` field.
 -   0.1: Initial version.
 
 [SlsaResult]: #slsaresult


### PR DESCRIPTION
Adds `input_attestations` to fix #387.
Also takes VSA v0.2 out of draft status.