### PR TITLE
Nav bar should not include versions in spec links

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -31,10 +31,10 @@
       url: /attestation-model
 
     - title: Provenance
-      url: /provenance/v0.2
+      url: /provenance
 
     - title: VSA
-      url: /verification_summary/v0.1
+      url: /verification_summary
 
 - title: Use cases
   url: /use-cases
@@ -47,4 +47,3 @@
 
 - title: Blog
   url: /blog
-  


### PR DESCRIPTION
The nav bar was pointing at an older version of the VSA spec. We don't actually need the provenance or vsa links to include the version number since we have other redirectors in place to send folks to the latest version anyways.

Signed-off-by: Tom Hennen <tomhennen@google.com>