### PR TITLE
Disable smooth scrolling

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -23,7 +23,6 @@ figure {
 
 html {
     min-width: $on-mobile-old;
-    scroll-behavior: smooth;
 }
 
 /**


### PR DESCRIPTION
I personally find this smooth scrolling very distracting, especially during development.

Things to test:
- Try clicking a link in the table of contents. Previously it would animate the scroll. Now it jumps straight there.
- Go to a particular section of the page then reload. Previously it would jump to the top then animate the scroll, which was distracting. Now it just reloads quickly.