### PR TITLE
Use vs Exfiltration: Provenance - Authenticated

### DIFF
--- a/docs/spec/v0.1/requirements.md
+++ b/docs/spec/v0.1/requirements.md
@@ -366,8 +366,15 @@ all the other requirements.
 <td>
 
 The provenance's authenticity and integrity can be verified by the consumer.
-This SHOULD be through a digital signature from a private key accessible only to
-the service generating the provenance.
+This SHOULD be through a digital signature from a private key that may only
+be accessed and used by the build service.  
+
+Regardless of mechanism, there MUST be controls in place to prevent exfiltration of
+private authentication-related material and illegitimate use of said material through
+intended channels.  It must not be possible to read or alter the private authentication materials
+(Other than for maintenance operations, such as key rotation)
+nor should it be possible to use the mechanism to authenticate artifacts outside of the build process.
+
 
 <td> <td>✓<td>✓<td>✓
 <tr id="service-generated">


### PR DESCRIPTION
First swing at adding some text that separates illegitimate use of authentication-related material from exfiltration of said material.  Sebastien and I have been bouncing this back and forth a bit and wanted to get something out to drive discussion.

I think one thing that makes this text difficult is accounting for different mechanisms use different means to protect the provenance.  Were we just talking about digital signatures, it would be straightforward to say something that boils down to "don't let people steal or misuse the signing materials."  Keeping things generic means inventing a term like "authentication-related materials."  

This is related to issue #187 