### PR TITLE
Add label to guest blog posts

### DIFF
--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -3,7 +3,7 @@ layout: post-list
 is_post: true
 ---
 
-<p class="h3 post-author">{% if page.is_guest_post -%}A Guest Post{%- endif %} by {{ page.author }}</p>
+<p class="h3 post-author">{% if page.is_guest_post -%}Guest post{%- endif %} by {{ page.author }}</p>
 
 <p class="post-date"><time datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date_to_string }}</time></p>
 

--- a/docs/_layouts/post.html
+++ b/docs/_layouts/post.html
@@ -2,7 +2,9 @@
 layout: post-list
 is_post: true
 ---
-<p class="h3 post-author">by {{ page.author }}</p>
+
+<p class="h3 post-author">{% if page.is_guest_post -%}A Guest Post{%- endif %} by {{ page.author }}</p>
+
 <p class="post-date"><time datetime="{{ page.date | date: "%Y-%m-%d" }}">{{ page.date | date_to_string }}</time></p>
 
 {{ content }}

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -6,7 +6,7 @@ layout: post-list
   {% for post in site.posts %}
     <li class="mb-8">
       <h2 class="h2 mb-6"><a href="{{ post.url }}">{{ post.title }}</a></h2>
-      <p><b>posted by {{ post.author }} on {{ post.date | date_to_string }}</b></p>
+      <p><b>{% if post.is_guest_post -%}A Guest Post{%- endif %} by {{ post.author }} on {{ post.date | date_to_string }}</b></p>
       {% if post.subtitle %}
         {{ post.subtitle }}
       {% endif %}

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -6,7 +6,7 @@ layout: post-list
   {% for post in site.posts %}
     <li class="mb-8">
       <h2 class="h2 mb-6"><a href="{{ post.url }}">{{ post.title }}</a></h2>
-      <p><b>{% if post.is_guest_post -%}A Guest Post{%- endif %} by {{ post.author }} on {{ post.date | date_to_string }}</b></p>
+      <p><b>{% if post.is_guest_post -%}Guest post{%- endif %} by {{ post.author }} on {{ post.date | date_to_string }}</b></p>
       {% if post.subtitle %}
         {{ post.subtitle }}
       {% endif %}


### PR DESCRIPTION
This change adds the label "Guest Post" to the author line of guest blog posts, both to the post itself and the blog page.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>