### PR TITLE
Layer "draft" banner under the nav menu

### DIFF
--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -499,7 +499,6 @@ details {
   right: 0;
   pointer-events: none;
   margin: 80px 10px 10px;
-  z-index: 800;
 
   > input[type=checkbox]:checked + div {
     display: none;

--- a/docs/_sass/minima/_layout.scss
+++ b/docs/_sass/minima/_layout.scss
@@ -237,6 +237,7 @@
 
 .site-nav {
     padding: $spacer-l 0 $spacer-l 0;
+    z-index: 1;
 
     .nav-trigger {
         display: none;


### PR DESCRIPTION
Previously the "draft" banner was on top of the nav menu, which made it impossible to navigate unless you dismissed the banner. We don't actually need a z-index on the banner since it's defined earlier in the document than the rest of the page, but the nav menu needs a z-index to make it appear above the banner.

**Preview:** https://deploy-preview-506--slsa.netlify.app/spec/v1.0/levels

#### Desktop - Before

![before - desktop](https://user-images.githubusercontent.com/58860/195842230-b6ec0b2d-1fda-4680-9a4f-ec76c3507f4c.png)

#### Desktop - After

![after - desktop](https://user-images.githubusercontent.com/58860/195842272-bba036af-696c-46d7-8685-d735d8599dec.png)

#### Mobile - Before

![before - mobile](https://user-images.githubusercontent.com/58860/195842443-92d18314-b635-4777-af42-51408070c762.png)

#### Mobile - After

![after - mobile](https://user-images.githubusercontent.com/58860/195842506-043f7b27-1c9a-42ae-aa35-f29c58ea07fd.png)
