### PR TITLE
SLSA v1.0 levels - depict differences in authentication L2 vs L3

### DIFF
--- a/docs/spec/v1.0/levels.md
+++ b/docs/spec/v1.0/levels.md
@@ -64,7 +64,7 @@ SLSA is intended to serve multiple populations:
 
 ## Levels and tracks
 
-SLSA levels are split into *tracks*. Each track has it's own set of levels that
+SLSA levels are split into *tracks*. Each track has its own set of levels that
 measure a particular aspect of supply chain security. The purpose of tracks is
 to recognize progress made in one aspect of security without blocking on an
 unrelated aspect. Tracks also allow the SLSA spec to evolve: we can add more
@@ -230,10 +230,9 @@ existing build services.
 
 All of [Build L2], plus:
 
--   Build service implements strong controls to prevent runs from influencing
-    one another, even within the same project.
-
--   Secret material used to sign the provenance must not be accessable to the user-defined build steps.    
+-   Build service implements strong controls to:
+    -  prevent runs from influencing one another, even within the same project.
+    -  prevent secret material used to sign the provenance from being accessible to the user-defined build steps.
 
 > **TODO:** Add requirement about survey and audit as per the v1.0 proposal.
 

--- a/docs/spec/v1.0/levels.md
+++ b/docs/spec/v1.0/levels.md
@@ -64,7 +64,7 @@ SLSA is intended to serve multiple populations:
 
 ## Levels and tracks
 
-SLSA levels are split into *tracks*. Each track has own set of levels that
+SLSA levels are split into *tracks*. Each track has it's own set of levels that
 measure a particular aspect of supply chain security. The purpose of tracks is
 to recognize progress made in one aspect of security without blocking on an
 unrelated aspect. Tracks also allow the SLSA spec to evolve: we can add more
@@ -190,7 +190,7 @@ service itself required by [Build L3].
 All of [Build L1], plus:
 
 -   Builds run on a hosted build service that generates and signs the
-    provenance itself, outside the control of the users of the build service.
+    provenance itself.
 
 <dt>Benefits<dd>
 
@@ -232,6 +232,8 @@ All of [Build L2], plus:
 
 -   Build service implements strong controls to prevent runs from influencing
     one another, even within the same project.
+
+-   Secret material used to sign the provenance must not be accessable to the user-defined build steps.    
 
 > **TODO:** Add requirement about survey and audit as per the v1.0 proposal.
 

--- a/docs/spec/v1.0/levels.md
+++ b/docs/spec/v1.0/levels.md
@@ -231,8 +231,8 @@ existing build services.
 All of [Build L2], plus:
 
 -   Build service implements strong controls to:
-    -  prevent runs from influencing one another, even within the same project.
-    -  prevent secret material used to sign the provenance from being accessible to the user-defined build steps.
+    -   prevent runs from influencing one another, even within the same project.
+    -   prevent secret material used to sign the provenance from being accessible to the user-defined build steps.
 
 > **TODO:** Add requirement about survey and audit as per the v1.0 proposal.
 


### PR DESCRIPTION
Signed-off-by: Aaron Bacchi <aaron.bacchi@gmail.com>

Based on this conversation- https://github.com/slsa-framework/slsa/pull/502#discussion_r995886785

My intention for this change is to outline the difference between the weak guarantee in L2 vs the strong guarantee in L3.

I am basing this off of my interpretation of the Authenticated and non-falsifiable requirements today.

Authenticated:
> The provenance’s authenticity and integrity can be verified by the consumer. This SHOULD be through a digital signature from a private key accessible only to the service generating the provenance.

Non-falsifiable: 
> Provenance cannot be falsified by the build service’s users.
> Any secret material used to demonstrate the non-falsifiable nature of the provenance, for example the signing key used to generate a digital signature, MUST be stored in a secure management system appropriate for such material and accessible only to the build service account.
> Such secret material MUST NOT be accessible to the environment running the user-defined build steps.

I like Mark's thoughts here:

> L1 - no authenticity requirement
> L2 - weak guarantee that the provenance came from a service and not a person, but exploitation may be easy
> L3 - strong guarantee that the provenance came from a service, and exploitation is difficult