### PR TITLE
SLSA v1.0: update requirements.md for new tracks

### DIFF
--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -13,6 +13,10 @@ For an informative description of the levels intended for all audiences, see
 better understand the reasoning behind the requirements, see [Threats and
 mitigations](threats.md).
 
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
 ## TODO
 
 **TODO:** Update the requirements to provide guidelines for how to implement,

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -304,7 +304,7 @@ allow finding detailed debug logs.
 
 The [prior version](../v0.1/requirements.md) of SLSA defined a "SLSA 4" that
 included the following requirements. A future Build L4 may incorporate some or
-all of the following, in whole or in part.
+all of the following, in whole or in part. This list is not exhaustive.
 
 > NOTE: The draft requirements here are unversioned and subject to change.
 
@@ -388,6 +388,118 @@ the build worker.
 
 ## Source track
 
-The Source track is not yet defined. For an idea of what the levels might look
-like in a future version, see
-[v0.1 Source requirements](../v0.1/requirements.md#source-requirements).
+The Source track is not yet defined. The
+[prior version](../v0.1/requirements.md#source-requirements) of SLSA included
+the following source requirements, which may form the basis for a future Source
+track. Each entry may or may not be included in the future, in whole or in part.
+The list is not exhaustive.
+
+> NOTE: The draft requirements here are unversioned and subject to change.
+
+<details id="version-controlled">
+<summary>Version controlled (draft)</summary>
+
+Every change to the source is tracked in a version control system that meets the
+following requirements:
+
+-   **[Change history]** There exists a record of the history of changes
+    that went into the revision. Each change must contain: the identities of
+    the uploader and reviewers (if any), timestamps of the reviews (if any)
+    and submission, the change description/justification, the content of
+    the change, and the parent revisions.
+
+-   **\[Immutable reference]** There exists a way to indefinitely reference
+    this particular, immutable revision. In git, this is the {repo URL +
+    branch/tag/ref + commit ID}.
+
+Most popular version control system meet this requirement, such as git,
+Mercurial, Subversion, or Perforce.
+
+NOTE: This does NOT require that the code, uploader/reviewer identities, or
+change history be made public. Rather, some organization must attest to the fact
+that these requirements are met, and it is up to the consumer whether this
+attestation is sufficient.
+
+"○" = RECOMMENDED.
+
+</details>
+<details id="verified-history">
+<summary>Verified history (draft)</summary>
+
+Every change in the revision's history has at least one strongly authenticated
+actor identity (author, uploader, reviewer, etc.) and timestamp. It must be
+clear which identities were verified, and those identities must use [two-step
+verification](https://www.google.com/landing/2step/) or similar. (Exceptions
+noted below.)
+
+-   **[First-parent history]** In the case of a non-linear version control
+    system, where a revision can have more than one parent, only the "first
+    parent history" is in scope. In other words, when a feature branch is merged
+    back into the main branch, only the merge itself is in scope.
+-   **[Historical cutoff]** There is some TBD exception to allow existing
+    projects to meet SLSA 3/4 even if historical revisions were present in the
+    history. Current thinking is that this could be either last N months or a
+    platform attestation guaranteeing that future changes in the next N months
+    will meet the requirements.
+
+"Strongly authenticated" means that the actor was mapped to a specific person
+using an authentication mechanism which is resistant to account and credential
+compromise. For example, 2-factor authentication (2FA) where one factor is a
+hardware security key (i.e. YubiKey).
+
+</details>
+<details id="retained-indefinitely">
+<summary>Retained indefinitely (draft)</summary>
+
+The revision and its change history are preserved indefinitely and cannot be
+deleted, except when subject to an established and transparent policy for
+obliteration, such as a legal or policy requirement.
+
+-   **[Immutable history]** It must not be possible for persons to delete or
+    modify the history, even with multi-party approval, except by trusted
+    platform admins with two-party approval following the obliterate policy.
+-   **[Limited retention for SLSA 3]** At SLSA 3 (but not 4), it is acceptable
+    for the retention to be limited to 18 months, as attested by the source
+    control platform.
+    -   Example: If a commit is made on 2020-04-05 and then a retention
+        attestation is generated on 2021-01-01, the commit must be retained
+        until at least 2022-07-01.
+
+</details>
+<details id="two-person-reviewed">
+<summary>Two-person reviewed (draft)</summary>
+
+Every change in the revision's history was agreed to by two trusted persons
+prior to submission, and both of these trusted persons were strongly
+authenticated. (Exceptions from [Verified History](#verified-history) apply here
+as well.)
+
+-   The following combinations are acceptable:
+    -   Uploader and reviewer are two different trusted persons.
+    -   Two different reviewers are trusted persons.
+-   **[Different persons]** The platform ensures that no person can use
+  alternate identities to bypass the two-person review requirement.
+    -   Example: if a person uploads with identity X then reviews with alias Y,
+        the platform understands that this is the same person and does not
+        consider the review requirement satisfied.
+-   **[Informed review]** The reviewer is able and encouraged to make an
+    informed decision about what they're approving. The reviewer should be
+    presented with a full, meaningful content diff between the proposed revision
+    and the previously reviewed revision. For example, it is not sufficient to
+    just indicate that file changed without showing the contents.
+-   **[Context-specific approvals]** Approvals are for a specific context, such
+    as a repo + branch in git. Moving fully reviewed content from one context to
+    another still requires review. (Exact definition of "context" depends on the
+    project, and this does not preclude well-understood automatic or reviewless
+    merges, such as cutting a release branch.)
+    -   Git example: If a fully reviewed commit in one repo is merged into a
+        different repo, or a commit in one branch is merged into a different
+        branch, then the merge still requires review.
+
+"Trusted persons" are the set of persons who are granted the authority to
+maintain a software project. For example, https://github.com/MarkLodato/dotfiles
+has just one trusted person (MarkLodato), while
+https://hg.mozilla.org/mozilla-central has a set of trusted persons with write
+access to the mozilla-central repository.
+
+</details>

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -306,7 +306,7 @@ The [prior version](../v0.1/requirements.md) of SLSA defined a "SLSA 4" that
 included the following requirements. A future Build L4 may incorporate some or
 all of the following, in whole or in part. This list is not exhaustive.
 
-> NOTE: The draft requirements here are unversioned and subject to change.
+> WARNING: The draft requirements here are unversioned and subject to change.
 
 <details id="parameterless">
 <summary>Parameterless (draft)</summary>
@@ -394,7 +394,7 @@ the following source requirements, which may form the basis for a future Source
 track. Each entry may or may not be included in the future, in whole or in part.
 The list is not exhaustive.
 
-> NOTE: The draft requirements here are unversioned and subject to change.
+> WARNING: The draft requirements here are unversioned and subject to change.
 
 <details id="version-controlled">
 <summary>Version controlled (draft)</summary>

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -29,202 +29,36 @@ showing what the options are:
 
 ## Summary table
 
-| Requirement                          | SLSA 1 | SLSA 2 | SLSA 3 | SLSA 4 |
-| ------------------------------------ | ------ | ------ | ------ | ------ |
-| Source - [Version controlled]        |        | ✓      | ✓      | ✓      |
-| Source - [Verified history]          |        |        | ✓      | ✓      |
-| Source - [Retained indefinitely]     |        |        | 18 mo. | ✓      |
-| Source - [Two-person reviewed]       |        |        |        | ✓      |
-| Build - [Scripted build]             | ✓      | ✓      | ✓      | ✓      |
-| Build - [Build service]              |        | ✓      | ✓      | ✓      |
-| Build - [Build as code]              |        |        | ✓      | ✓      |
-| Build - [Ephemeral environment]      |        |        | ✓      | ✓      |
-| Build - [Isolated]                   |        |        | ✓      | ✓      |
-| Build - [Parameterless]              |        |        |        | ✓      |
-| Build - [Hermetic]                   |        |        |        | ✓      |
-| Build - [Reproducible]               |        |        |        | ○      |
-| Provenance - [Available]             | ✓      | ✓      | ✓      | ✓      |
-| Provenance - [Authenticated]         |        | ✓      | ✓      | ✓      |
-| Provenance - [Service generated]     |        | ✓      | ✓      | ✓      |
-| Provenance - [Non-falsifiable]       |        |        | ✓      | ✓      |
-| Provenance - [Dependencies complete] |        |        |        | ✓      |
-| Common - [Security]                  |        |        |        | ✓      |
-| Common - [Access]                    |        |        |        | ✓      |
-| Common - [Superusers]                |        |        |        | ✓      |
+| Requirement ([Build track])      | Build L1 | Build L2 | Build L3 |
+| -------------------------------- | -------- | -------- | -------- |
+| Build - [Scripted build]         | ✓        | ✓        | ✓        |
+| Build - [Build service]          |          | ✓        | ✓        |
+| Build - [Build as code]          |          |          | ✓        |
+| Build - [Ephemeral environment]  |          |          | ✓        |
+| Build - [Isolated]               |          |          | ✓        |
+| Provenance - [Available]         | ✓        | ✓        | ✓        |
+| Provenance - [Authenticated]     |          | ✓        | ✓        |
+| Provenance - [Service generated] |          | ✓        | ✓        |
+| Provenance - [Non-falsifiable]   |          |          | ✓        |
 
-<!-- markdownlint-disable MD036 -->
-_○ = required unless there is a justification_
-
-[access]: #access
 [authenticated]: #authenticated
 [available]: #available
 [build as code]: #build-as-code
 [build service]: #build-service
-[dependencies complete]: #dependencies-complete
 [ephemeral environment]: #ephemeral-environment
-[hermetic]: #hermetic
 [isolated]: #isolated
 [non-falsifiable]: #non-falsifiable
-[parameterless]: #parameterless
-[reproducible]: #reproducible
-[retained indefinitely]: #retained-indefinitely
 [scripted build]: #scripted-build
-[security]: #security
 [service generated]: #service-generated
-[superusers]: #superusers
-[two-person reviewed]: #two-person-reviewed
-[verified history]: #verified-history
-[version controlled]: #version-controlled
 
-## Definitions
+## Build track
 
-> See also [Terminology](terminology.md) for general SLSA concepts. The
-> defintions below are only used in this document.
+[build track]: #build-track
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
-"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
-interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
-
-<a id="immutable-reference"></a>**Immutable reference:** An identifier that is
-guaranteed to always point to the same, immutable artifact. This MUST allow the
-consumer to locate the artifact and SHOULD include a cryptographic hash of the
-artifact's contents to ensure integrity. Examples: git URL + branch/tag/ref \+
-commit ID; cloud storage bucket ID + SHA-256 hash; Subversion URL (no hash).
-
-[immutable reference]: #immutable-reference
-[immutable references]: #immutable-reference
-
-**Provenance**: Metadata about how an artifact was produced.
-
-**Revision:** An immutable, coherent state of a source. In Git, for example, a
-revision is a commit in the history reachable from a specific branch in a
-specific repository. Different revisions within one repo MAY have different
-levels. Example: the most recent revision on a branch meets SLSA 4 but very old
-historical revisions before the cutoff do not.
-
-**Strong authentication:** Authentication that maps back to a specific person
-using an authentication mechanism which is resistant to account and credential
-compromise. For example, 2-factor authentication (2FA) where one factor is a
-hardware security key (i.e. YubiKey).
-
-**Trusted persons:** Set of persons who are granted the authority to maintain a
-software project. For example, https://github.com/MarkLodato/dotfiles has just
-one trusted person (MarkLodato), while https://hg.mozilla.org/mozilla-central
-has a set of trusted persons with write access to the mozilla-central
-repository.
-
-## Source requirements
+### Build process requirements
 
 <table>
-<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
-<tr id="version-controlled">
-<td>Version controlled
-<td>
-
-Every change to the source is tracked in a version control system that meets the
-following requirements:
-
--   **[Change history]** There exists a record of the history of changes
-    that went into the revision. Each change must contain: the identities of
-    the uploader and reviewers (if any), timestamps of the reviews (if any)
-    and submission, the change description/justification, the content of
-    the change, and the parent revisions.
-
--   **\[Immutable reference]** There exists a way to indefinitely reference
-    this particular, immutable revision. In git, this is the {repo URL +
-    branch/tag/ref + commit ID}.
-
-Most popular version control system meet this requirement, such as git,
-Mercurial, Subversion, or Perforce.
-
-NOTE: This does NOT require that the code, uploader/reviewer identities, or
-change history be made public. Rather, some organization must attest to the fact
-that these requirements are met, and it is up to the consumer whether this
-attestation is sufficient.
-
-"○" = RECOMMENDED.
-
-<td>○<td>✓<td>✓<td>✓
-<tr id="verified-history">
-<td>Verified history
-<td>
-
-Every change in the revision's history has at least one strongly authenticated
-actor identity (author, uploader, reviewer, etc.) and timestamp. It must be
-clear which identities were verified, and those identities must use [two-step
-verification](https://www.google.com/landing/2step/) or similar. (Exceptions
-noted below.)
-
--   **[First-parent history]** In the case of a non-linear version control
-    system, where a revision can have more than one parent, only the "first
-    parent history" is in scope. In other words, when a feature branch is merged
-    back into the main branch, only the merge itself is in scope.
--   **[Historical cutoff]** There is some TBD exception to allow existing
-    projects to meet SLSA 3/4 even if historical revisions were present in the
-    history. Current thinking is that this could be either last N months or a
-    platform attestation guaranteeing that future changes in the next N months
-    will meet the requirements.
-
-<td> <td> <td>✓<td>✓
-<tr id="retained-indefinitely">
-<td>Retained indefinitely
-<td>
-
-The revision and its change history are preserved indefinitely and cannot be
-deleted, except when subject to an established and transparent policy for
-obliteration, such as a legal or policy requirement.
-
--   **[Immutable history]** It must not be possible for persons to delete or
-    modify the history, even with multi-party approval, except by trusted
-    platform admins with two-party approval following the obliterate policy.
--   **[Limited retention for SLSA 3]** At SLSA 3 (but not 4), it is acceptable
-    for the retention to be limited to 18 months, as attested by the source
-    control platform.
-    -   Example: If a commit is made on 2020-04-05 and then a retention
-        attestation is generated on 2021-01-01, the commit must be retained
-        until at least 2022-07-01.
-
-<td> <td> <td>18 mo.<td>✓
-<tr id="two-person-reviewed">
-<td>Two-person reviewed
-<td>
-
-Every change in the revision's history was agreed to by two trusted persons
-prior to submission, and both of these trusted persons were strongly
-authenticated. (Exceptions from [Verified History](#verified-history) apply here
-as well.)
-
--   The following combinations are acceptable:
-    -   Uploader and reviewer are two different trusted persons.
-    -   Two different reviewers are trusted persons.
--   **[Different persons]** The platform ensures that no person can use
-  alternate identities to bypass the two-person review requirement.
-    -   Example: if a person uploads with identity X then reviews with alias Y,
-        the platform understands that this is the same person and does not
-        consider the review requirement satisfied.
--   **[Informed review]** The reviewer is able and encouraged to make an
-    informed decision about what they're approving. The reviewer should be
-    presented with a full, meaningful content diff between the proposed revision
-    and the previously reviewed revision. For example, it is not sufficient to
-    just indicate that file changed without showing the contents.
--   **[Context-specific approvals]** Approvals are for a specific context, such
-    as a repo + branch in git. Moving fully reviewed content from one context to
-    another still requires review. (Exact definition of "context" depends on the
-    project, and this does not preclude well-understood automatic or reviewless
-    merges, such as cutting a release branch.)
-    -   Git example: If a fully reviewed commit in one repo is merged into a
-        different repo, or a commit in one branch is merged into a different
-        branch, then the merge still requires review.
-
-<td> <td> <td> <td>✓
-</table>
-
-## Build requirements
-
-Requirements on build process:
-
-<table>
-<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
+<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3
 <tr id="scripted-build">
 <td>Scripted build
 <td>
@@ -237,7 +71,7 @@ Examples:
 -   Build script is Makefile, invoked via `make all`.
 -   Build script is .github/workflows/build.yaml, invoked by GitHub Actions.
 
-<td>✓<td>✓<td>✓<td>✓
+<td>✓<td>✓<td>✓
 <tr id="build-service">
 <td>Build service
 <td>
@@ -247,7 +81,7 @@ workstation.
 
 Examples: GitHub Actions, Google Cloud Build, Travis CI.
 
-<td> <td>✓<td>✓<td>✓
+<td> <td>✓<td>✓
 <tr id="build-as-code">
 <td>Build as code
 <td>
@@ -266,7 +100,7 @@ Examples:
 -   Tekton bundles generated from text files by a SLSA compliant build process
     and stored in an OCI registry with SLSA provenance metadata available.
 
-<td> <td> <td>✓<td>✓
+<td> <td> <td>✓
 <tr id="ephemeral-environment">
 <td>Ephemeral environment
 <td>
@@ -275,7 +109,7 @@ The build service ensured that the build steps ran in an ephemeral environment,
 such as a container or VM, provisioned solely for this build, and not reused
 from a prior build.
 
-<td> <td> <td>✓<td>✓
+<td> <td> <td>✓
 <tr id="isolated">
 <td>Isolated
 <td>
@@ -288,78 +122,13 @@ free of influence from other build instances, whether prior or concurrent.
 -   It MUST NOT be possible for one build to persist or influence the build environment of a subsequent build.
 -   Build caches, if used, MUST be purely content-addressable to prevent tampering.
 
-<td> <td> <td>✓<td>✓
-<tr id="parameterless">
-<td>Parameterless
-<td>
-
-The build output cannot be affected by user parameters other than the build
-entry point and the top-level source location. In other words, the build is
-fully defined through the build script and nothing else.
-
-Examples:
-
--   GitHub Actions
-    [workflow_dispatch](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch)
-    `inputs` MUST be empty.
--   Google Cloud Build
-    [user-defined substitutions](https://cloud.google.com/build/docs/configuring-builds/substitute-variable-values)
-    MUST be empty. (Default substitutions, whose values are defined by the
-    server, are acceptable.)
-
-<td> <td> <td> <td>✓
-<tr id="hermetic">
-<td>Hermetic
-<td>
-
-All transitive build steps, sources, and dependencies were fully declared up
-front with [immutable references], and the build steps ran with no network
-access.
-
-The user-defined build script:
-
--   MUST declare all dependencies, including sources and other build steps,
-    using [immutable references] in a format that the build service understands.
-
-The build service:
-
--   MUST fetch all artifacts in a trusted control plane.
--   MUST NOT allow mutable references.
--   MUST verify the integrity of each artifact.
-    -   If the [immutable reference] includes a cryptographic hash, the service
-        MUST verify the hash and reject the fetch if the verification fails.
-    -   Otherwise, the service MUST fetch the artifact over a channel that
-        ensures transport integrity, such as TLS or code signing.
--   MUST prevent network access while running the build steps.
-    -   This requirement is "best effort." It SHOULD deter a reasonable team
-        from having a non-hermetic build, but it need not stop a determined
-        adversary. For example, using a container to prevent network access is
-        sufficient.
-
-<td> <td> <td> <td>✓
-<tr id="reproducible">
-<td>Reproducible
-<td>
-
-Re-running the build steps with identical input artifacts results in bit-for-bit
-identical output. Builds that cannot meet this MUST provide a justification why
-the build cannot be made reproducible.
-
-"○" means that this requirement is "best effort". The user-provided build script
-SHOULD declare whether the build is intended to be reproducible or a
-justification why not. The build service MAY blindly propagate this intent
-without verifying reproducibility. A consumer MAY reject the build if it does
-not reproduce.
-
-<td> <td> <td> <td>○
+<td> <td> <td>✓
 </table>
 
-## Provenance requirements
-
-Requirements on the process by which provenance is generated and consumed:
+### Provenance generation requirements
 
 <table>
-<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
+<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3
 <tr id="available">
 <td>Available
 <td>
@@ -371,7 +140,7 @@ all the other requirements.
 
 [SLSA Provenance]: ../../provenance
 
-<td>✓<td>✓<td>✓<td>✓
+<td>✓<td>✓<td>✓
 <tr id="authenticated">
 <td>Authenticated
 <td>
@@ -380,7 +149,7 @@ The provenance's authenticity and integrity can be verified by the consumer.
 This SHOULD be through a digital signature from a private key accessible only to
 the service generating the provenance.
 
-<td> <td>✓<td>✓<td>✓
+<td> <td>✓<td>✓
 <tr id="service-generated">
 <td>Service generated
 <td>
@@ -399,10 +168,8 @@ steps:
     -   Reasoning: This only allows a "bad" build to falsely claim that it
         produced a "good" artifact. This is not a security problem because the
         consumer MUST accept only "good" builds and reject "bad" builds.
--   The "reproducible" boolean and justification from
-    [Reproducible](#reproducible).
 
-<td> <td>✓<td>✓<td>✓
+<td> <td>✓<td>✓
 <tr id="non-falsifiable">
 <td>Non-falsifiable
 <td>
@@ -428,28 +195,14 @@ steps without the build service verifying their correctness:
     -   Reasoning: This only allows a "bad" build to falsely claim that it
         produced a "good" artifact. This is not a security problem because the
         consumer MUST accept only "good" builds and reject "bad" builds.
--   The "reproducible" boolean and justification from
-    [Reproducible](#reproducible).
 
-<td> <td> <td>✓<td>✓
-<tr id="dependencies-complete">
-<td>Dependencies complete
-<td>
-
-Provenance records all build dependencies that were available while running the
-build steps. This includes the initial state of the machine, VM, or container of
-the build worker.
-
--   MUST include all user-specified build steps, sources, dependencies.
--   SHOULD include all service-provided artifacts.
-
-<td> <td> <td> <td>✓
+<td> <td> <td>✓
 </table>
 
-Requirements on the contents of the provenance:
+### Provenance contents requirements
 
 <table>
-<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
+<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3
 <tr id="identifies-artifact">
 <td>Identifies artifact
 <td>
@@ -461,7 +214,7 @@ provided, the RECOMMENDED algorithm is SHA-256 for cross-system
 compatibility. If another algorithm is used, it SHOULD be resistant to
 collisions and second preimages.
 
-<td>✓<td>✓<td>✓<td>✓
+<td>✓<td>✓<td>✓
 <tr id="identifies-builder">
 <td>Identifies builder
 <td>
@@ -470,7 +223,7 @@ The provenance identifies the entity that performed the build and generated the
 provenance. This represents the entity that the consumer must trust. Examples:
 "GitHub Actions with a GitHub-hosted worker", "jdoe@example.com's machine".
 
-<td>✓<td>✓<td>✓<td>✓
+<td>✓<td>✓<td>✓
 <tr id="identifies-build-instructions">
 <td>Identifies build instructions
 <td>
@@ -491,7 +244,7 @@ asked to do (as in
 or
 [the Explicitly Run Commands example](/provenance/v0.2#explicitly-run-commands)).
 
-<td>✓<td>✓<td>✓<td>✓
+<td>✓<td>✓<td>✓
 <tr id="identifies-source-code">
 <td>Identifies source code
 <td>
@@ -508,10 +261,7 @@ authenticated by the builder.
 At level 3+ this information MUST be authenticated by the builder (i.e. the
 builder either needs to have fetched the source itself or _observed_ the fetch).
 
-At level 4 this information MUST be complete (i.e. all source repositories used
-in the build are listed).
-
-<td><td>✓<td>✓ (Authenticated)<td>✓ (Complete)
+<td><td>✓<td>✓✓
 <tr id="identifies-entry-point">
 <td>Identifies entry point
 <td>
@@ -525,33 +275,14 @@ Example:
 -   source repo: git URL + branch/tag/ref + commit ID
 -   entrypoint: path to config file(s) (e.g. ./.zuul.yaml) + job name within config (e.g. envoy-build-arm64)
 
-<td><td><td>✓<td>✓
+<td><td><td>✓
 <tr id="includes-all-params">
 <td>Includes all build parameters
 <td>
 
-The provenance includes all build parameters under a user's control. See
-[Parameterless](#parameterless) for details. (At L3, the parameters must be
-listed; at L4, they must be empty.)
+The provenance includes all build parameters under a user's control.
 
-<td> <td> <td>✓<td>✓
-<tr id="includes-all-deps">
-<td>Includes all transitive dependencies
-<td>
-
-The provenance includes all transitive dependencies listed in
-[Dependencies Complete](#dependencies-complete).
-
-<td> <td> <td> <td>✓
-<tr id="includes-reproducible-info">
-<td>Includes reproducible info
-<td>
-
-The provenance includes a boolean indicating whether build is intended to be
-reproducible and, if so, all information necessary to reproduce the build. See
-[Reproducible](#reproducible) for more details.
-
-<td> <td> <td> <td>✓
+<td> <td> <td>✓
 <tr id="includes-metadata">
 <td>Includes metadata
 <td>
@@ -562,41 +293,22 @@ allow finding detailed debug logs.
 
 "○" = RECOMMENDED.
 
-<td>○<td>○<td>○<td>○
+<td>○<td>○<td>○
 </table>
 
-## Common requirements
+### Possible future requirements
 
-Common requirements for every trusted system involved in the supply chain
-(source, build, distribution, etc.)
+The [prior version](../v0.1/requirements.md) of SLSA defined a "SLSA 4" that
+included the following requirements. A future Build L4 may incorporate some or
+all of the following, in whole or in part:
 
-<table>
-<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
-<tr id="security">
-<td>Security
-<td>
+-   [Parameterless](../v0.1/requirements.md#parameterless)
+-   [Hermetic](../v0.1/requirements.md#hermetic)
+-   [Dependencies complete](../v0.1/requirements.md#dependencies-complete)
+-   [Reproducible](../v0.1/requirements.md#reproducible)
 
-The system meets some TBD baseline security standard to prevent compromise.
-(Patching, vulnerability scanning, user isolation, transport security, secure
-boot, machine identity, etc. Perhaps
-[NIST 800-53](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-53r5.pdf)
-or a subset thereof.)
+## Source track
 
-<td> <td> <td> <td>✓
-<tr id="access">
-<td>Access
-<td>
-
-All physical and remote access must be rare, logged, and gated behind
-multi-party approval.
-
-<td> <td> <td> <td>✓
-<tr id="superusers">
-<td>Superusers
-<td>
-
-Only a small number of platform admins may override the guarantees listed here.
-Doing so MUST require approval of a second platform admin.
-
-<td> <td> <td> <td>✓
-</table>
+The Source track is not yet defined. For an idea of what the levels might look
+like in a future version, see
+[v0.1 Source requirements](../v0.1/requirements.md#source-requirements).

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -302,9 +302,10 @@ allow finding detailed debug logs.
 
 ### Possible future requirements
 
-The [prior version](../v0.1/requirements.md) of SLSA defined a "SLSA 4" that
-included the following requirements. A future Build L4 may incorporate some or
-all of the following, in whole or in part. This list is not exhaustive.
+The initial [draft version (v0.1)](../v0.1/requirements.md) of SLSA defined a
+"SLSA 4" that included the following requirements. A future Build L4 may
+incorporate some or all of the following, in whole or in part. This list is not
+exhaustive.
 
 > WARNING: The draft requirements here are unversioned and subject to change.
 
@@ -388,11 +389,11 @@ the build worker.
 
 ## Source track
 
-The Source track is not yet defined. The
-[prior version](../v0.1/requirements.md#source-requirements) of SLSA included
-the following source requirements, which may form the basis for a future Source
-track. Each entry may or may not be included in the future, in whole or in part.
-The list is not exhaustive.
+The Source track is not yet defined. The initial
+[draft version (v0.1)](../v0.1/requirements.md#source-requirements) of SLSA
+included the following source requirements, which may form the basis for a
+future Source track. Each entry may or may not be included in the future, in
+whole or in part. The list is not exhaustive.
 
 > WARNING: The draft requirements here are unversioned and subject to change.
 


### PR DESCRIPTION
**Preview:** https://deploy-preview-512--slsa.netlify.app/spec/v1.0/requirements

- Rename "L1/2/3" to "Build L1/2/3" and delete "L4".
- Hide the old Source and L4 requirements under a click and identified as "draft" for a future version. This gives an insight into our thinking for the next version, is a hint for readers accustomed to v0.1, and allows us to iterate on the wording over time.
- Move definitions down to where they are used to make the doc easier to read.

Note: no requirements were changed in this PR. Just removing the levels.

This removes one of the "optional" requirements, partially addressing #423.

Part of #510.