### PR TITLE
css: distinguish multi-line entries in ToC

### DIFF
--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -88,8 +88,10 @@
 
 .table-of-contents {
     min-height: 300px;
-    ul{
-        margin-top: 5px;
+    font-family: 'Prodigy';
+
+    ul {
+        margin-top: 10px;
         // Opacity on hover effect
         &:hover > li {
             transition: 150ms all ease;
@@ -97,19 +99,18 @@
         }
     }
 
-    ul li {
-        margin-bottom: 5px;
-        font-family: 'Prodigy';
-    }
     // Focus on hover effect
     ul li:hover {
         opacity: 1;
     }
 
     a {
+        display: block;
         color: inherit;
         text-decoration: none;
         font-weight: 400;
+        margin-bottom: 10px;
+        line-height: 1.4;
     }
 
     ul {


### PR DESCRIPTION
Previously the table-of-contents did not have any visual distinction between two different entries vs one entry with multiple lines - they all ran together.

Now there is slightly more whitespace between entries and slightly less whitespace between lines within an entry.

before | after
--- | ---
![before](https://user-images.githubusercontent.com/58860/200059373-b19cff84-2d56-4133-a842-aa316c18ef63.png) | ![after](https://user-images.githubusercontent.com/58860/200059241-9d9af643-9f14-4294-8d1e-234adaa2e245.png)
![before](https://user-images.githubusercontent.com/58860/200059480-be7b8e0e-cd9a-4bdb-95cf-e396705ed4a2.png) | ![after](https://user-images.githubusercontent.com/58860/200059504-60af8b96-9bc9-4121-8a1d-5747a79ee620.png)
![before](https://user-images.githubusercontent.com/58860/200059564-039f27a7-747d-431e-8a9f-a52c7a94fa81.png) | ![after](https://user-images.githubusercontent.com/58860/200059604-60487fc7-e09e-4587-88ea-996f2dff0666.png)


