### PR TITLE
docs(get-started): add link to provenance generators on SLSA 1 section

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -37,6 +37,7 @@ hero_text: If you’re looking to jump straight in and try SLSA, here’s a quic
                     </ul>
                     <p class="h4 font-bold mb-6" id="tools">Tools</p>
                     <ul class="list-disc mt-6 pl-6">
+                        <li><a href="https://github.com/slsa-framework/slsa-github-generator#provenance-only-generators">GitHub actions provenance generators</a> (SLSA level 3)</li>
                         <li><a href="https://github.com/slsa-framework/azure-devops-demo">Azure DevOps provenance generator</a> (SLSA level 1)</li>
                         <li><a href="https://cloud.google.com/build/docs/securing-builds/use-provenance-and-binary-authorization">Google Cloud Build</a> (SLSA level 2)</li>
                         <li><a href="https://github.com/sigstore/cosign">Sigstore Cosign for storing signed provenance</a></li>


### PR DESCRIPTION
Since there is no SLSA 1 GitHub actions provenance generators, on SLSA 1 section we refer to the SLSA 3 generator. This would prevent new users to give up on SLSA 1 if they have builders on Github.

Complements Pull Request #522

Signed-off-by: Diogo Teles Sant'Anna <diogoteles@google.com>