### PR TITLE
SLSA v1.0: overhaul requirements by party.

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -215,7 +215,7 @@ table {
     // color: lighten($text-color, 18%);
     border-collapse: collapse;
     border: 1px solid $grey-light;
-    tr {
+    &:not(.no-alternate) tr {
         &:nth-child(even) {
             background-color: $green-lightest;
         }

--- a/docs/spec/v1.0/levels.md
+++ b/docs/spec/v1.0/levels.md
@@ -183,10 +183,6 @@ SLSA---other than tamper protection---without changing their build workflows.
 
 </dl>
 
-> **TODO:** Add "Scripted Build" if decided in
-> [#498](https://github.com/slsa-framework/slsa/issues/498): "Build process is
-> fully scripted/automated, with no manual steps."
-
 </section>
 <section id="build-l2">
 


### PR DESCRIPTION
This is an overhaul of the requirements page to:

- #510
- #188
- Simplify the requirements

More specifically:

- Define the implementers: producer, build system, packaging ecosystem, consumer. This should get merged and de-duplicated with Terminology in a future PR.
- Simplify the build levels to minimize the number of independent checkboxes at each level. Now it is expressed in terms of degrees of provenance generation and isolation.
- Move documentation of the provenance to the provenance spec (separate PR). This avoids duplication of documentation and allows readers to see concrete formats. Otherwise we describe it a second time but more abstractly here, which is harder to understand and results in confusion.

This is currently a draft but ready for early review. There are still many TODOs and missing sections. We might want to merge it even with the TODOs so that different authors can tackle pieces independently.

TODO: Document further changes, such as removing the build-as-code requirement.

**Preview:** https://deploy-preview-536--slsa.netlify.app/spec/v1.0/requirements
