### PR TITLE
Add definition of specification development stages

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -23,6 +23,11 @@
     - title: FAQ
       url: /spec/v0.1/faq
 
+    - title: Stages
+      url: /spec-stages
+
+    - spacer: true
+
     - title: Attestations
       children:
 

--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -8,9 +8,9 @@ should have different expectations. This document defines the different
 stages the SLSA project uses and their meaning for readers and
 contributors.
 
-Every specification should prominently display a *Status of this
-document* section stating which stage the specification you are
-looking at is in.
+Every specification page should prominently display a *Status* section
+stating which stage the specification is in with a link to its
+definition.
 
 ## Working Draft
 
@@ -25,7 +25,7 @@ work progresses. The status section of the document may provide
 additional information as to its development status and whether
 reviews and feedback are welcome.
 
-## Proposed Specification
+## In Review
 
 At this stage the document is considered to be feature complete and is
 published as a way to invite final reviews. Editorial changes may
@@ -33,12 +33,12 @@ still be made but no addition of new features is expected and short of
 problems being found no significant changes are expected to happen
 anymore.
 
-## Specification
+## Stable
 
-At this stage the document is considered final and stable. It is
-suitable for reference and implementation in production. Changes may
-only happen if deemed necessary and will be avoided as much as
-possible if they might adversely impact implementations.
+At this stage the document is considered stable. It is suitable for
+reference and implementation in production. Changes may only happen if
+deemed necessary and will be avoided as much as possible if they might
+adversely impact implementations.
 
 ## Retired
 

--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -1,0 +1,48 @@
+---
+title: Specification Stages
+layout: specifications
+---
+
+Specifications go through various stages of development from which you
+should have different expectations. This document defines these
+different stages and their meaning.
+
+Every specification should prominently display a *Status of this
+document* section stating which stage the specification you are
+looking at is in.
+
+## Working Draft
+
+This is the first stage of development a specification goes
+through. At this point, not much should be expected of it. The
+specification may be very incomplete and may change at any time and
+even be abandoned. It is therefore not suitable for reference or for
+implementation beyond experimentation.
+
+A specification may be published several times during this stage as
+work progresses. The status section of the document may provide
+additional information as to its development status and whether
+reviews and feedback are welcome.
+
+## Proposed Specification
+
+At this stage the document is considered to be feature complete and is
+published as a way to invite final reviews. Editorial changes may
+still be made but no addition of new features is expected and short of
+problems being found no significant changes are expected to happen
+anymore.
+
+## Specification
+
+At this stage the document is considered final and stable. It is
+suitable for reference and implementation in production. Changes may
+only happen if deemed necessary and will be avoided as much as
+possible if they might adversely impact implementations.
+
+## Retired
+
+This stage indicates that the specification should no longer be
+used. It has been either rendered obsolete by a newer version or
+abandoned for some reason. The status of the document may provide
+additional information and point to the new document to use intead if
+there is one.

--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -4,8 +4,9 @@ layout: specifications
 ---
 
 Specifications go through various stages of development from which you
-should have different expectations. This document defines these
-different stages and their meaning.
+should have different expectations. This document defines the different
+stages the SLSA project uses and their meaning for readers and
+contributors.
 
 Every specification should prominently display a *Status of this
 document* section stating which stage the specification you are

--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -42,8 +42,8 @@ adversely impact implementations.
 
 ## Retired
 
-This stage indicates that the specification should no longer be
-used. It has been either rendered obsolete by a newer version or
+This stage indicates that the specification is no longer maintained.
+It has been either rendered obsolete by a newer version or
 abandoned for some reason. The status of the document may provide
 additional information and point to the new document to use intead if
 there is one.


### PR DESCRIPTION
To address issue #541 this PR adds a page defining the different stages a specification can be in, setting the expectation that every specification being published will display a "Status of this document" section that communicates to the reader what stage of the development the spec is in and what they can expect from it.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>