### PR TITLE
Main menu updates and fixes

### DIFF
--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -23,18 +23,17 @@
     - title: FAQ
       url: /spec/v0.1/faq
 
-    - spacer: true
-
     - title: Attestations
+      children:
 
-    - title: General Model
-      url: /attestation-model
+      - title: General Model
+        url: /attestation-model
 
-    - title: Provenance
-      url: /provenance
+      - title: Provenance
+        url: /provenance
 
-    - title: VSA
-      url: /verification_summary
+      - title: VSA
+        url: /verification_summary
 
 - title: Use cases
   url: /use-cases

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,7 +1,7 @@
 
 
 <header
-  x-data="{ open: false, navOpen: false, sticky: false, lastPos: window.scrollY }"
+  x-data="{ open: false, open1: false, open1sub1: false, open2: false, navOpen: false, sticky: false, lastPos: window.scrollY }"
   x-ref="navbar"
   x-on:scroll.window="
     sticky = window.scrollY >= $refs.navbar.offsetHeight && lastPos >= window.scrollY;
@@ -10,30 +10,27 @@
   x-bind:class="{
   'sticky': sticky,
   'fixed': !sticky && lastPos > 0,
-  'static': lastPos === 0 && !sticky
+  'static': lastPos === 0 && !sticky,
+  'menu-open': navOpen
   }"
   class="site-header {% if page.url != '/spec/{{ site.current_spec_version }}/' and page.url != {{ site.baseurl }} and page.url != '/' or page.url == '/spec/{{ site.current_spec_version }}/' %} is-specification-markdown{% endif %}">
   <div class="wrapper">
-  <div class="py-4 md:py-0 flex items-center justify-between">
+  <div class="site-header-inner">
       <a rel="author" href="{{ "/" | relative_url }}" class="relative logo">
-        {% if page.url == '/' %}
-          <img src="{{ site.baseurl }}/images/logo.svg" alt="{{site.title}} logo" />
-        {% else %}
-        <img x-cloak x-show="!sticky" src="{{ site.baseurl }}/images/logo-green.svg" alt="{{site.title}} logo" />
-          <img x-cloak x-show="sticky" src="{{ site.baseurl }}/images/logo.svg" alt="{{site.title}} logo" />
-        {% endif%}
+        <img x-cloak class="logo-green" :class="{ 'show-logo': sticky === false }" src="{{ site.baseurl }}/images/logo-green.svg" alt="{{site.title}} logo" />
+        <img x-cloak class="logo-white" :class="{ 'show-logo': sticky === true }" src="{{ site.baseurl }}/images/logo.svg" alt="{{site.title}} logo" />
       </a>
-      {% include nav.html mobile=true %}
       {% include nav.html %}
       <div class="ml-4 flex justify-end">
-        <button  x-on:click="navOpen = ! navOpen" :class="{ 'active': navOpen === true }" class="mobile-menu-button inline-block md:hidden">
+        <button x-on:click="navOpen = ! navOpen" :class="{ 'active': navOpen === true }" class="mobile-menu-button inline-block">
           <span></span>
           <span></span>
           <span></span>
         </button>
-        <a class="hidden md:inline-block" href="{{site.github.repository_url}}" target="_blank"><svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
-        <path fill-rule="evenodd" clip-rule="evenodd" d="M11.2344 0.150879C5.28641 0.150879 0.468811 4.96848 0.468811 10.9165C0.468811 15.6803 3.55046 19.7039 7.82978 21.1303C8.36806 21.2245 8.56991 20.9016 8.56991 20.619C8.56991 20.3633 8.55646 19.5155 8.55646 18.6139C5.8516 19.1118 5.15184 17.9545 4.93653 17.3489C4.81541 17.0394 4.29059 16.084 3.83306 15.8283C3.45626 15.6264 2.91798 15.1285 3.8196 15.1151C4.66739 15.1016 5.27295 15.8956 5.47481 16.2185C6.44371 17.8468 7.99126 17.3893 8.61028 17.1067C8.70448 16.4069 8.98708 15.9359 9.29659 15.6668C6.90125 15.3977 4.39825 14.4691 4.39825 10.3513C4.39825 9.18051 4.81541 8.21161 5.50172 7.45802C5.39407 7.18888 5.01727 6.08541 5.60938 4.60514C5.60938 4.60514 6.51099 4.32254 8.56991 5.70861C9.43116 5.46639 10.3462 5.34527 11.2613 5.34527C12.1764 5.34527 13.0914 5.46639 13.9527 5.70861C16.0116 4.30909 16.9132 4.60514 16.9132 4.60514C17.5053 6.08541 17.1285 7.18888 17.0209 7.45802C17.7072 8.21161 18.1244 9.16706 18.1244 10.3513C18.1244 14.4826 15.6079 15.3977 13.2126 15.6668C13.6028 16.0032 13.9392 16.6492 13.9392 17.6584C13.9392 19.0983 13.9258 20.2556 13.9258 20.619C13.9258 20.9016 14.1276 21.238 14.6659 21.1303C16.8031 20.4088 18.6602 19.0353 19.9758 17.2031C21.2915 15.3708 21.9994 13.1721 22 10.9165C22 4.96848 17.1824 0.150879 11.2344 0.150879Z" fill="white"/>
-        </svg>
+        <a class="desktop-github-icon" href="{{site.github.repository_url}}" target="_blank">
+          <svg width="22" height="22" viewBox="0 0 22 22" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+            <path fill-rule="evenodd" clip-rule="evenodd" d="M11.2344 0.150879C5.28641 0.150879 0.468811 4.96848 0.468811 10.9165C0.468811 15.6803 3.55046 19.7039 7.82978 21.1303C8.36806 21.2245 8.56991 20.9016 8.56991 20.619C8.56991 20.3633 8.55646 19.5155 8.55646 18.6139C5.8516 19.1118 5.15184 17.9545 4.93653 17.3489C4.81541 17.0394 4.29059 16.084 3.83306 15.8283C3.45626 15.6264 2.91798 15.1285 3.8196 15.1151C4.66739 15.1016 5.27295 15.8956 5.47481 16.2185C6.44371 17.8468 7.99126 17.3893 8.61028 17.1067C8.70448 16.4069 8.98708 15.9359 9.29659 15.6668C6.90125 15.3977 4.39825 14.4691 4.39825 10.3513C4.39825 9.18051 4.81541 8.21161 5.50172 7.45802C5.39407 7.18888 5.01727 6.08541 5.60938 4.60514C5.60938 4.60514 6.51099 4.32254 8.56991 5.70861C9.43116 5.46639 10.3462 5.34527 11.2613 5.34527C12.1764 5.34527 13.0914 5.46639 13.9527 5.70861C16.0116 4.30909 16.9132 4.60514 16.9132 4.60514C17.5053 6.08541 17.1285 7.18888 17.0209 7.45802C17.7072 8.21161 18.1244 9.16706 18.1244 10.3513C18.1244 14.4826 15.6079 15.3977 13.2126 15.6668C13.6028 16.0032 13.9392 16.6492 13.9392 17.6584C13.9392 19.0983 13.9258 20.2556 13.9258 20.619C13.9258 20.9016 14.1276 21.238 14.6659 21.1303C16.8031 20.4088 18.6602 19.0353 19.9758 17.2031C21.2915 15.3708 21.9994 13.1721 22 10.9165C22 4.96848 17.1824 0.150879 11.2344 0.150879Z" />
+          </svg>
         </a>
         </div>
     </div>

--- a/docs/_includes/nav-level.html
+++ b/docs/_includes/nav-level.html
@@ -1,0 +1,31 @@
+{% assign subLevel =  0 %}
+{%- if include.collection.size > 0 -%}
+  <ul class="sub-menu level-{{ include.level }}">
+    {%- for subitem in include.collection -%}
+    <li>
+      {%- if subitem.spacer %}
+        <hr>
+      {%- elsif subitem.url %}
+        <a class="dropdown-link" href="{{ subitem.url | relative_url }}">
+          {{ subitem.title | escape }}
+        </a>
+      {%- elsif subitem.children.size > 0 %}
+        {% assign subMenu = sublevel | plus: 1 %}
+        {% assign subName = include.name  | append: 'sub' | append: subMenu %}
+        <button x-on:click="{{subName}} = ! {{subName}}" class="dropdown-link cursor">{{ subitem.title | escape }}
+          <div class=" ml-2">
+            <svg width="9" height="9" viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+              <path d="M3.05881 5.064L0.972811 0.906H5.13081L3.05881 5.064Z" />
+            </svg>
+          </div>
+        </button>
+        <div @click.outside="{{subName}} = false" x-on:resize.window="{{ subName }} ? {{ subName }} = false : true;" x-show="{{subName}}" x-transition class="dropdown">
+          {% include nav-level.html collection=subitem.children mobile=include.mobile name=subName level=subMenu %}
+        </div>
+      {%- else %}
+        <em>{{ subitem.title | escape }}</em>
+      {%- endif %}
+    </li>
+    {%- endfor %}
+  </ul>
+  {%- endif -%}

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,51 +1,29 @@
-{%- if include.mobile -%}
-  {% assign ul_class = "list flex flex-col md:flex-row flex-wrap justify-center pt-16 pb-8 px-5" %}
-  {% assign li_class = "relative w-2/4" %}
-  {% assign button_fill = "#ffffff" %}
-  {% assign div_cloak = "" %}
-  {% assign div_class = "relative md:absolute m-0 md:py-4 md:bg-white rounded-lg md:shadow-md dropdown" %}
-{%- else -%}
-  {% assign ul_class = "list flex justify-center" %}
-  {% assign li_class = "relative" %}
-  {% assign button_fill = "none" %}
-  {% assign div_cloak = "x-cloak" %}
-  {% assign div_class = "absolute m-0 p-4 -ml-2 mt-4 bg-white rounded-lg shadow-md dropdown" %}
-{%- endif -%}
-<nav {% if include.mobile -%}
-    :class="{ 'active': navOpen === true }" class="site-nav-mobile"
-    {%- else -%}
+{% assign menu = 0 %}
+
+<nav
+    :class="{ 'active': navOpen === true }" 
     class="site-nav"
-    {%- endif -%}>
-  <ul class="{{ul_class}}">
+>
+  <ul class="root-menu list">
     {%- for item in site.data.nav -%}
-      <li class="{{li_class}}">
+      <li>
         {%- if item.url -%}
-          <a class="{% if item.url == page.url %}active{% endif %} page-link text-white flex items-center" href="{{ item.url | relative_url }}">
+          <a class="{% if item.url == page.url %}active{% endif %} root-link text-white flex items-center" href="{{ item.url | relative_url }}">
             {{ item.title | escape }}
           </a>
         {%- else -%}
           {% comment %}TODO: add "active" class if on a child page{% endcomment %}
-          <a class="page-link text-white flex items-center cursor">
-            <button x-on:click="open = ! open" class="flex items-center">{{ item.title | escape }} <div class=" ml-2"><svg width="9" height="9" viewBox="0 0 6 6" fill="{{button_fill}}" xmlns="http://www.w3.org/2000/svg">
-              <path d="M3.05881 5.064L0.972811 0.906H5.13081L3.05881 5.064Z" fill="white"/>
-              </svg></div></button>
-          </a>
-          <div @click.outside="open = false" {{div_cloak}} x-show="open" x-transition class="{{div_class}}">
-            <ul>
-              {%- for subitem in item.children -%}
-                <li>
-                  {%- if subitem.spacer %}
-                  <hr>
-                  {%- elsif subitem.url %}
-                  <a class="text-white md:text-black" href="{{ subitem.url | relative_url }}">
-                    {{ subitem.title | escape }}
-                  </a>
-                  {%- else %}
-                  <em>{{ subitem.title }}:</em>
-                  {%- endif %}
-                </li>
-              {%- endfor %}
-            </ul>
+          {% assign menu = menu | plus: 1 %}
+          {% assign rootName = 'open' | append: menu %}
+          <button class="root-link cursor" x-on:click="{{rootName}} = ! {{rootName}}">{{ item.title | escape }} 
+            <div class="ml-2">
+              <svg width="9" height="9" viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+                <path d="M3.05881 5.064L0.972811 0.906H5.13081L3.05881 5.064Z" />
+              </svg>
+            </div>
+          </button>
+          <div @click.outside="{{rootName}} = false" x-on:resize.window="{{ rootName }} ? {{ rootName }} = false : true" x-show="{{rootName}}" x-transition class="dropdown">
+            {% include nav-level.html collection=item.children name=rootName mobile=include.mobile level=menu %}
           </div>
         {%- endif -%}
       </li>

--- a/docs/_sass/minima.scss
+++ b/docs/_sass/minima.scss
@@ -84,11 +84,12 @@ $content-width: 1180px !default;
 $on-mobile-old: 320px !default;
 $on-mobile: 440px !default;
 $on-palm: 600px !default;
-$on-tablet: 775px !default;
+$on-tablet: 768px !default;
 $on-laptop: 1180px !default;
+$media-menu: 870px !default;
 
 @mixin media-query($device) {
-    @media screen and (max-width: $device) {
+    @media screen and (max-width: ($device - .1)) {
         @content;
     }
 }

--- a/docs/_sass/minima/_layout.scss
+++ b/docs/_sass/minima/_layout.scss
@@ -2,12 +2,6 @@
  * Site header
  */
 .site-header {
-    @include media-query($on-tablet) {
-        min-height: $spacer-xl * 2;
-    }
-    @include media-query($on-palm) {
-        min-height: $spacer-xl;
-    }
     transition: all .25s ease-in-out;
     will-change: transform;
 
@@ -20,39 +14,22 @@
     width: 100%;
     z-index: 20;
 
-    &.is-specification-markdown {
-        & .site-nav ul li a{
-            color: $text-color;
-        }
-
-        & svg path {
-            fill: $text-color;
-
-            @include media-query($on-tablet) {
-                 fill: white;
-            }
-        }
+    @include media-query($on-tablet) {
+        min-height: $spacer-xl * 2;
     }
 
-    & .logo-white {
-        visibility: hidden;
-        opacity:0;
-        transition: all .25s ease-in-out;
-        height: 0;
-        width: 0;
-    }
-
-    & .logo-green {
-        visibility: visible;
-        opacity:1;
-        transition: all .25s ease-in-out;
-        width: 100px;
+    @include media-query($on-palm) {
+        min-height: $spacer-xl;
     }
 
     &.fixed {
         transform: translateY(-100%);
         background-color: #155757;
         position: fixed;
+
+        .logo-white {
+            opacity: 1;
+        }
     }
 
     &.sticky {
@@ -60,18 +37,8 @@
         background-color: #155757;
         position: fixed;
 
-        & .logo-white {
-            visibility: visible;
-            opacity:1;
-            transition: all .25s ease-in-out;
-        }
-
-        & .logo-green {
-            visibility: hidden;
-            opacity:0;
-            transition: all .25s ease-in-out;
-            height: 0;
-            width: 0;
+        .logo-white {
+            opacity: 1;
         }
 
         .mobile-menu-button {
@@ -79,94 +46,60 @@
                 background-color: white;
             }
         }
-
-        &.is-specification-markdown {
-            & .site-nav ul li a{
-                color: white;
-            }
-
-            & .site-nav ul li ul li a{
-                color: $text-color;
-
-                &:hover {
-
-                    &:after {
-                        background-color: $text-color;
-                    }
-                }
-
-                &.active {
-                    &:after {
-                        background-color: $text-color;
-                    }
-                }
-            }
-
-            & svg path {
-                fill: white;
-            }
-        }
-
     }
 
     &.static {
         transform: translateY(0%);
         background-color: transparent;
-        transition: all .25s ease-in-out;
 
-        & .logo-white {
-            visibility: hidden;
-            opacity:0;
-            transition: all .25s ease-in-out;
-        }
-
-        & .logo-green {
-            visibility: visible;
+        .logo-white {
             opacity:1;
-            transition: all .25s ease-in-out;
         }
+    }
 
-        &.is-specification-markdown {
-            & .site-nav ul li a {
-                color: $text-color;
+    &.static.is-specification-markdown {
+        .logo-white {
+            opacity: 0;
+        }
+    }
 
-                @include media-query($on-tablet) {
-                    color: white;
-                }
+    &.static.menu-open {
+        .logo-white { 
+            opacity:1;
+        }
+    }
+}
 
+.site-header-inner {
+    padding: 16px 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+
+    @include media-query-min($media-menu) {
+        padding: 0;
+    }
+
+    .desktop-github-icon {
+        display: none;
+    
+        @include media-query-min($media-menu) {
+            display: inline-block;
+            color: white;
+    
+            .is-specification-markdown & {
+                &,
+                &.active, 
                 &:hover {
-
-                    &:after {
-                        background-color: $text-color;
-                    }
-                }
-
-                &.active {
-                    &:after {
-                        background-color: $text-color;
-                    }
-                    @include media-query($on-tablet) {
-                        &:after {
-                            display: none;
-                        }
-                    }
+                    color: $text-color;
                 }
             }
-
-            & .site-nav ul li > ul li a {
-                color: $text-color;
-
+    
+            .sticky.is-specification-markdown & {
+                &,
+                &.active, 
                 &:hover {
-
-                    &:after {
-                        background-color: $text-color;
-                    }
-                }
-
-                &.active {
-                    &:after {
-                        background-color: $text-color;
-                    }
+                    color: white;
                 }
             }
         }
@@ -175,7 +108,31 @@
 
 .logo {
     width: 100px;
+    min-width: 100px;
     z-index: 10;
+    position: relative;
+
+    img {
+        transition: opacity .25s ease-in-out;
+
+        &.show-logo {
+            opacity: 1;
+        }
+    }
+
+    .logo-green {
+        opacity: 1;
+    }
+
+    .logo-white {
+        position: absolute;
+        top: 0;
+        left: 0;
+
+        .static.menu-open & {
+            opacity: 1;
+        }
+    }
 }
 
 .mobile-menu-button {
@@ -188,14 +145,19 @@
     padding: 0px;
     outline: none;
     user-select: none;
+
     & span {
         display: block;
-        background-color: #102B2D;
+        background-color: white;
         width: 100%;
         height: 2px;
         margin-bottom: 5px;
         transform-origin: 4px 0px;
-        transition: transform 0.5s cubic-bezier(0.77, 0.2, 0.05, 1) 0s, background-color 0s cubic-bezier(0.77, 0.2, 0.05, 1) 0s, opacity 0.55s ease 0s;
+        transition: transform 0.5s cubic-bezier(0.77, 0.2, 0.05, 1) 0s, background-color .25s cubic-bezier(0.77, 0.2, 0.05, 1) 0s, opacity 0.55s ease 0s;
+
+        .is-specification-markdown & {
+            background-color: #102B2D;
+        }
     }
 
     &.active span {
@@ -209,8 +171,13 @@
         transform: rotate(0deg) scale(0.2, 0.2);
         background-color: white;
     }
+
     &.active span:last-child {
         transform: rotate(-45deg) translate(1px, -4px);
+    }
+
+    @include media-query-min($media-menu) {
+        display: none;
     }
 }
 
@@ -236,112 +203,28 @@
 }
 
 .site-nav {
-    padding: $spacer-l 0 $spacer-l 0;
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+    position: absolute;
+    padding: 64px 20px 32px 20px;
+    margin: 0;
+    z-index: 1;
+    width: 100%;
+    top: 0;
+    left: 0;
+    transition: all cubic-bezier(0.77, 0.2, 0.05, 1) 0.3s;
+    background-color: #102B2D;
     z-index: 1;
 
-    .nav-trigger {
-        display: none;
-    }
-
-    .menu-icon {
-        display: none;
-    }
-
-    ul li {
-        a{
-            color: $text-color-light;
-            font-weight: 400;
-            line-height: $base-line-height;
-            position: relative;
-            font-family: "Prodigy";
-            width: 100%;
-
-            &:hover {
-                text-decoration: none;
-
-                &:after {
-                    content: '';
-                    width: 100%;
-                    height: 1px;
-                    background-color: white;
-                    position: absolute;
-                    bottom:0px;
-                }
-            }
-
-            &.active {
-                &:after {
-                    content: '';
-                    width: 100%;
-                    height: 1px;
-                    background-color: white;
-                    position: absolute;
-                    bottom:0px;
-                }
-            }
-        }
-
-        // Gaps between nav items, but not on the last one
-        &:not(:last-child) {
-            margin-right: 20px;
-        }
-
-        ul li:not(:last-child) {
-            margin-right: 0px;
-        }
-
-        & ul {
-            li {
-                margin:0;
-                a{
-                    color: $text-color;
-                    font-weight: 400;
-                    line-height: $base-line-height;
-                    font-family: "Prodigy";
-                    display: block;
-
-                    &:hover {
-                        text-decoration: none;
-
-                        &:after {
-                            content: '';
-                            width: auto;
-                            height: 1px;
-                            background-color: white;
-                            position: absolute;
-                            bottom:0px;
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    .dropdown ul{
-        min-width: 115px;
-    }
-
-    @include media-query($on-tablet) {
-        display: none;
-    }
-}
-
-.site-nav-mobile {
-    display: none;
-    @include media-query($on-tablet) {
-        width: 100%;
-        position: absolute;
-        top: -100vh;
-        left: 0;
+    &.active {
+        top: 0;
+        transform: translateY(0);
         transition: all cubic-bezier(0.77, 0.2, 0.05, 1) 0.3s;
-        background-color: #102B2D;
-        z-index: 1;
-        display: block;
+    }
 
-        &.active {
-            top: 0;
-            transition: all cubic-bezier(0.77, 0.2, 0.05, 1) 0.3s;
-        }
+    @include media-query($media-menu) {
+        transform: translateY(-100%);
 
         label[for="nav-trigger"] {
             display: block;
@@ -371,29 +254,220 @@
             display: block;
             padding-bottom: 5px;
         }
+    }
 
-        .page-link {
-            display: block;
-            padding: 10px 0;
-            font-family: "Prodigy";
-            color: white;
-            font-weight: normal;
+    @include media-query-min($media-menu) {
+        display: flex;
+        justify-content: center;
+        flex-direction: row;
+        flex-wrap: no-wrap;
+        padding: $spacer-l 0 $spacer-l 0;
+        background-color: transparent;
+        transition: none;
+        position: static;
+
+        &.active {
+            transition: none;
         }
 
-        .dropdown ul {
-            padding-left: 15px;
+        .nav-trigger {
+            display: none;
         }
 
-        .dropdown ul li a {
-            display: block;
-            padding: 9px 0;
-            font-family: "Prodigy";
-            color: white;
-            font-weight: normal;
+        .menu-icon {
+            display: none;
+        }
+    }
+}
 
+.root-menu {
+    display: flex;
+    flex-direction: column;
+    flex-wrap: wrap;
+
+    @include media-query($media-menu) {
+        max-width: 360px;
+    }
+
+    li {
+        position: relative;
+    }
+
+    @include media-query-min($media-menu) {
+        width: auto;
+        flex-direction: row;
+        flex-wrap: no-wrap;
+
+        > li {
+            margin-right: 20px;
+        }
+
+        > li:last-child  {
+            margin-right: 0;
+        }
+
+        > li:last-child .dropdown {
+            right: -10px;
         }
     }
 
+    .root-link {
+        font-weight: 400;
+        line-height: $base-line-height;
+        position: relative;
+        display: inline-block;
+        padding: 10px 0;
+        font-family: "Prodigy";
+        color: white;
+        font-weight: normal;
+
+        &::after {
+            content: '';
+            height: 1px;
+            background-color: currentColor;
+            position: absolute;
+            bottom:0px;
+            left: 0;
+            right: 0;
+            display: none;
+        }
+
+        &:hover {
+            text-decoration: underline;
+        }
+
+        @include media-query-min($media-menu) {
+            color: $text-color-light;
+            padding: 0;
+
+            &.active, 
+            &:hover {
+                text-decoration: none;
+    
+                &:after {
+                    display: block;
+                }
+            }
+            
+            .is-specification-markdown & {
+                &,
+                &.active, 
+                &:hover {
+                    color: $text-color;
+                }
+            }
+
+            .sticky.is-specification-markdown & {
+                &,
+                &.active, 
+                &:hover {
+                    color: white;
+                }
+            }
+        }
+    }
+
+    button.root-link {
+        display: flex;
+        align-items: center;
+    }
+}
+
+.dropdown {
+    position: relative;
+
+    ul {
+        padding-left: 15px;
+    }
+
+    hr {
+        margin-top: 9px;
+    }
+        
+    em {
+        display: block;
+        padding: 9px 0;
+        color: transparentize(white, .5);
+    }
+
+    @include media-query-min($media-menu) {
+        --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.2),0 2px 4px -1px rgba(0, 0, 0, 0.2);
+        background-color: #fff;
+        position: absolute;
+        margin: 16px 0 0 -8px;
+        padding: 16px;
+        border-radius: 8px;
+        box-shadow: var(--tw-ring-offset-shadow,0 0 #0000),var(--tw-ring-shadow,0 0 #0000),var(--tw-shadow);
+        z-index: 1;
+
+        ul {
+            width: 100%;
+            min-width: 200px;
+            padding-left: 0;
+        }
+
+        li {
+            margin:0;
+        }
+
+        em {
+            color: transparentize($text-color, .5);
+        }
+        .dropdown {
+            margin-top: 0;
+            margin-left: 50%;
+        }
+    
+    }
+
+    .dropdown-link {  
+        color: white;
+        font-weight: 400;
+        line-height: $base-line-height;
+        position: relative;
+        display: inline-block;
+        padding: 9px 0;
+        position: relative;
+        font-family: "Prodigy";
+        text-decoration: none; 
+        
+        &:hover {
+            text-decoration: underline;
+        }
+
+        @include media-query-min($media-menu) {
+            color: $text-color;
+            padding: 0;
+        
+            &:hover {
+                text-decoration: none;
+            }
+        }
+
+        .is-specification-markdown & {
+            &.active, 
+            &:hover {
+
+            }
+        }
+
+        .sticky.is-specification-markdown & {
+            &.active, 
+            &:hover {
+
+            }
+        }
+    }
+
+    button.dropdown-link {
+        display: flex;
+        align-items: center;
+    }
+}
+
+.sub-menu { 
+    @include media-query-min($media-menu) {
+    }
 }
 
 /**


### PR DESCRIPTION
### Structural changes
- Combine HTML for desktop and mobile menus
- Fix the fact that only one top level item can have a sub menu
- Move "Specifications" -> "Attestations" to a second level sub menu

Please note: While the menu heirarchy is generated dymanically based on the `_nav.yml` contents, the sub menu UI show/hide logic requires the `header.html` `x-data` boolean flags to be in place ahead of time. Hense the hard-coding of these. Adding additional sub-menus in the future will require both `_nav.yml` and `header.html` `x-data` to be updated in a similar manner.

### Additional layout fixes
- Increase sub menu width to minimise text wrapping
- Prevent last sub menu item appearing off the screen edge
- Fix main menu width at interim screen sizes (the labels get smushed just before switching to the mobile layout)
- Close sub menus on screen resize (a resize could cross the desktop to mobile switchover point)
- Ensure all menu text is visible on mobile
- Fix logo/menu toggle colours on all main menu variations

Closes https://github.com/slsa-framework/slsa/issues/340