### PR TITLE
SLSA v1.0: Rename "Key principles" to "Guiding principles"

### DIFF
--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -19,7 +19,7 @@ in the menu at the top of the page.
 | Page | Description |
 | ---- | --- |
 | [Security levels](levels.md) | Overview of SLSA, intended for all audiences. If you read one page, read this. |
-| [Key principles](principles.md) | Background on the guiding principles behind SLSA. |
+| [Guiding principles](principles.md) | Background on the guiding principles behind SLSA. |
 | [Terminology](terminology.md) | Terminology and model used by SLSA. |
 | [Requirements](requirements.md) | Detailed technical requirements, intended for system implementers. |
 | [Threats & mitigations](threats.md) | Specific supply chain attacks and how SLSA helps. |

--- a/docs/spec/v1.0/principles.md
+++ b/docs/spec/v1.0/principles.md
@@ -1,8 +1,9 @@
-# Key principles
+# Guiding principles
 
 <div class="subtitle">
 
-This page lays out the key guiding principles behind SLSA.
+This page provides a background on the guiding principles behind SLSA. It is
+intended to help the reader better understand SLSA's design decisions.
 
 </div>
 


### PR DESCRIPTION
The new name better reflects that it is background material rather than an important document that ever reader must read.

Also explain the intent of the page at the top so that readers can quickly determine whether or not to continue reading.
