### PR TITLE
css: use different symbol for nested lists

### DIFF
--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -489,6 +489,12 @@ dl.as-table {
 
     ul:not(.custom-list) {
         list-style: disc;
+        ul {
+          list-style-type: circle;
+          ul {
+            list-style-type: square;
+          }
+        }
     }
 
     ol:not(.custom-list) {


### PR DESCRIPTION
This was already fixed for ordered lists in #548.

### Preview

Before: https://slsa.dev/spec/v0.1/requirements#hermetic

After: https://deploy-preview-579--slsa.netlify.app/spec/v0.1/requirements#hermetic

![preview of fix](https://user-images.githubusercontent.com/58860/214090703-85e33de0-b304-477f-aba9-734ecdd8a681.png)
