### PR TITLE
Fix switching between provenance spec versions

### DIFF
--- a/docs/_includes/versions-dropdown.html
+++ b/docs/_includes/versions-dropdown.html
@@ -9,7 +9,9 @@
   {%- endif %}">
 {%- for item in versions reversed %}
 {%- unless item[1].hidden and spec_version != item[0] %}
-  <option value="{{ page.url | replace: spec_version, item[0] | relative_url }}" {% if spec_version == item[0] %}selected{% endif %} class="inline-block">{{item[1].name}}</option>
+  {% assign page_url_parts = page.url | split: '/' %}
+  {% assign page_url = page_url_parts | join: '/' %}
+  <option value="{{ page_url | replace: spec_version, item[0] | relative_url }}" {% if spec_version == item[0] %}selected{% endif %} class="inline-block">{{item[1].name}}</option>
 {%- endunless %}
 {%- endfor %}
 </select>


### PR DESCRIPTION
The v1 spec is in a child directory, whereas earlier (0.1 and 0.2) versions are direct children of the provenance folder. This means that when the versions-dropdown replaces the v1 version part with 0.1 or 0.2 in the replacement url includes a trailing '/'. Stripping the trailing url for all items in the version selector fixes navigating between provenance specification versions.