### PR TITLE
Fix link.sh to properly set exit code.

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Require all RFC 2119 keywords to be uppercase to avoid ambiguity.
 check_rfc2119() {
   local CMD=(
       git grep --break --heading --line-number --extended-regexp --all-match
@@ -7,7 +8,7 @@ check_rfc2119() {
       -e '\b(must( not)?|shall( not)?|should( not)?|may|required|recommended|optional)\b'
   )
   # Exit silently if there are no matches.
-  "${CMD[@]}" -q '*.md' || return
+  "${CMD[@]}" -q '*.md' || return 0
   # If there are matches, print an error and then print the results afterward.
   # NOTE: We don't just capture the command above because that ends up being
   # more difficult to code and also messes with colors (tty detection). It's
@@ -24,6 +25,8 @@ EOF
   return 1
 }
 
+# Run all of the checks above and exit with non-zero status if any failed.
+# We use this structure to allow for multiple checks in the future.
 RC=0
-check_rfc2119 && RC=1
+check_rfc2119 || RC=1
 exit $RC


### PR DESCRIPTION
Previously it always exited with success (0), making it useless as a GitHub Actions presubmit.

Also add comments to explain why we use this structure.
