### PR TITLE
Fix consumer opt-in requirement

### DIFF
--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -443,8 +443,8 @@ showing what the options are:
 A package's <dfn>consumer</dfn> is the organization or individual that uses the
 package.
 
-The only requirement on the consumer is that they MAY have to opt-in to enable
-SLSA verification, depending on the package ecosystem.
+The consumer MUST enable SLSA verification when the package ecosystem requires
+to opt-in for the verification to be enabled.
 
 > **TODO:** Anything else? Do they need to make risk-based decisions? Respond to
 > errors/warnings?


### PR DESCRIPTION
The use of MAY in the consumer requirement is incorrect and fails to capture the intended requirement. MAY means that something is optional and can be done or not without any impact on conformance. This commit changes the requirement into a MUST using a different formulation.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>