### PR TITLE
Fix RFC2119 lint: Sentence Case, "Recommended Suite"

### DIFF
--- a/docs/provenance/v1/index.md
+++ b/docs/provenance/v1/index.md
@@ -91,8 +91,7 @@ This predicate follows the in-toto attestation [parsing rules]. Summary:
 -   Minor version changes are always backwards compatible and "monotonic." Such
     changes do not update the `predicateType`.
 -   Producers MAY add extension fields using field names that are URIs.
--   Optional fields MAY be unset or null, and SHOULD be treated equivalently.
-    Both are equivalent to empty for _object_ or _array_ values.
+-   Unset, null, and empty field values MUST be interpreted equivalently.
 
 ## Schema
 
@@ -427,10 +426,10 @@ in the GitHub Actions example above. The field is REQUIRED, even if it is
 implicit from the signer, to aid readability and debugging. It is an object to
 allow additional fields in the future, in case one URI is not sufficient.
 
-> ⚠ **RFC:** Should we just allow builders to set arbitrary properties, rather
-> than calling out `version` and `builderDependencies`? We don't expect
-> verifiers to use any of them, so maybe that's the simpler approach? Or have a
-> `properties` that is an arbitrary object? (#319)
+> ⚠ **RFC:** Would it be preferable to allow builders to set arbitrary
+> properties, rather than calling out `version` and `builderDependencies`? We
+> don't expect verifiers to use any of them, so maybe that's the simpler
+> approach? Or have a `properties` that is an arbitrary object? (#319)
 
 > ⚠ **RFC:** Do we want/need to identify the tenant of the build system,
 > separately from the build system itself? If so, a single `id`

--- a/lint.sh
+++ b/lint.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 
 # Require all RFC 2119 keywords to be uppercase to avoid ambiguity.
+#
+# For lack of a better solution, we allowlist "recommended suite" using a
+# negative lookahead assertion.
 check_rfc2119() {
   local CMD=(
-      git grep --break --heading --line-number --extended-regexp --all-match
+      git grep --break --heading --line-number --perl-regexp --all-match
       -e '(RFC ?|rfc ?)2119'
-      -e '\b(must( not)?|shall( not)?|should( not)?|may|required|recommended|optional)\b'
+      -e '\b([Mm]ust( not)?|[Ss]hall( not)?|[Ss]hould( not)?|[Mm]ay|[Rr]equired|[Rr]ecommended|[Oo]ptional)\b(?![ -][Ss]uite)'
   )
   # Exit silently if there are no matches.
   "${CMD[@]}" -q '*.md' || return 0


### PR DESCRIPTION
-   Catch Sentence Case, not just full lowercase, and fix existing uses of sentence case.
-   Allowlist "recommended suite" from attestation-model.md. This was previously causing the linter to fail. I can't think of a better way to phrase that avoids the term "recommended", and use of caps doesn't work because we use that title in a link.
