### PR TITLE
Set x-data automatically

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,7 +1,11 @@
 
 
 <header
-  x-data="{ open: false, open1: false, open1sub1: false, open1sub2: false, open2: false, navOpen: false, sticky: false, lastPos: window.scrollY }"
+  {% comment %}set x-data calling nav-init{% endcomment %}
+  x-data="{
+    {%- include nav-init.liquid %}
+    navOpen: false, sticky: false, lastPos: window.scrollY }"
+
   x-ref="navbar"
   x-on:scroll.window="
     sticky = window.scrollY >= $refs.navbar.offsetHeight && lastPos >= window.scrollY;

--- a/docs/_includes/nav-init.liquid
+++ b/docs/_includes/nav-init.liquid
@@ -1,0 +1,12 @@
+{% comment %}
+# This mimicks nav.html, walking down the navigation data, to set x-data
+{% endcomment %}
+{%- assign menu = 0 %}
+    {%- for item in site.data.nav -%}
+        {%- unless item.url -%}
+          {%- assign menu = menu | plus: 1 %}
+          {%- assign rootName = 'open' | append: menu %}
+    {{rootName}}: false,
+            {%- include nav-level-init.liquid collection=item.children name=rootName level=menu menuNum=0 %}
+        {%- endunless %}
+    {%- endfor -%}

--- a/docs/_includes/nav-level-init.liquid
+++ b/docs/_includes/nav-level-init.liquid
@@ -1,0 +1,13 @@
+{%- assign subLevel =  0 %}
+{%- if include.collection.size > 0 -%}
+    {%- assign menuNum = include.menuNum %}
+    {%- for subitem in include.collection -%}
+      {%- if subitem.children.size > 0 %}
+        {%- assign menuNum = menuNum | plus: 1 %}
+        {%- assign subMenu = sublevel | plus: 1 %}
+        {%- assign subName = include.name  | append: 'sub' | append: menuNum %}
+    {{ subName}}: false,
+          {%- include nav-level-init.liquid collection=subitem.children name=subName level=subMenu menuNum=menuNum %}
+      {%- endif %}
+    {%- endfor %}
+  {%- endif -%}

--- a/docs/_includes/nav-level.html
+++ b/docs/_includes/nav-level.html
@@ -11,9 +11,9 @@
           {{ subitem.title | escape }}
         </a>
       {%- elsif subitem.children.size > 0 %}
-        {% assign menuNum = menuNum | plus: 1 %}
-        {% assign subMenu = sublevel | plus: 1 %}
-        {% assign subName = include.name  | append: 'sub' | append: menuNum %}
+        {%- assign menuNum = menuNum | plus: 1 %}
+        {%- assign subMenu = sublevel | plus: 1 %}
+        {%- assign subName = include.name  | append: 'sub' | append: menuNum %}
         <button x-on:click="{{subName}} = ! {{subName}}" class="dropdown-link cursor">{{ subitem.title | escape }}
           <div class=" ml-2">
             <svg width="9" height="9" viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg" fill="currentColor">

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,11 +1,7 @@
 {% assign menu = 0 %}
-
-<nav
-    :class="{ 'active': navOpen === true }" 
-    class="site-nav"
->
+<nav :class="{ 'active': navOpen === true }" class="site-nav">
   <ul class="root-menu list">
-    {%- for item in site.data.nav -%}
+    {%- for item in site.data.nav %}
       <li>
         {%- if item.url -%}
           <a class="{% if item.url == page.url %}active{% endif %} root-link text-white flex items-center" href="{{ item.url | relative_url }}">
@@ -13,8 +9,8 @@
           </a>
         {%- else -%}
           {% comment %}TODO: add "active" class if on a child page{% endcomment %}
-          {% assign menu = menu | plus: 1 %}
-          {% assign rootName = 'open' | append: menu %}
+          {%- assign menu = menu | plus: 1 %}
+          {%- assign rootName = 'open' | append: menu %}
           <button class="root-link cursor" x-on:click="{{rootName}} = ! {{rootName}}">{{ item.title | escape }} 
             <div class="ml-2">
               <svg width="9" height="9" viewBox="0 0 6 6" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
@@ -27,6 +23,6 @@
           </div>
         {%- endif -%}
       </li>
-    {%- endfor -%}
+    {%- endfor %}
   </ul>
 </nav>


### PR DESCRIPTION
x-data must contain the right initializations for the cascading menus to function. This change adds code to generate these initializations automatically based on the menus defined in nav.yaml. This saves us from having to edit both places and to know the internals of how the menus are coded.
Also includes some minor changes to improve the html output.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>