### PR TITLE
Fix version selector

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -7,30 +7,17 @@
 #           status: <string> # one of: Working Draft, In Review, Stable, Retired
 #           draft: <bool, optional> # if true, display a "draft" warning banner
 #           hidden: <bool, optional> # if true, do not show in dropdown
-#           pages: <list, optional> # the pagenames need to match the filenames
 #       current: <version>
 #
 # Where:
 #   <spec> = specification name, i.e. first component of the URL
 #   <version> = version name, i.e. second component of the URL, e.g. v1.0
-#
-# pages allows defining which pages exist in each version. The selector will
-# show the corresponding option as disabled when a page doesn't exist in
-# that version. When pages isn't defined it is assumed that the same pages
-# exist across the different versions.
 
 spec:
   versions:
     v0.1:
       name: Version 0.1
       status: Stable
-      pages:
-        index,
-        terminology,
-        levels,
-        requirements,
-        threats,
-        faq
     v1.0:
       name: Version 1.0 (DRAFT)
       status: Working Draft
@@ -38,15 +25,6 @@ spec:
       # We will hide 1.0 until it is ready for review. Viewers can still type
       # the URL manually, but we will not link to it from the main page.
       hidden: true
-      pages:
-        index,
-        levels,
-        principles,
-        terminology,
-        requirements,
-        verifying-systems,
-        threats,
-        faq
   current: v0.1
 
 provenance:

--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -15,9 +15,9 @@
 #   <version> = version name, i.e. second component of the URL, e.g. v1.0
 #
 # pages allows defining which pages exist in each version. The selector will
-# only provide the option to select a different version if the page exists
-# in that version. When pages isn't defined it is assumed that the same
-# pages exist across the different versions.
+# show the corresponding option as disabled when a page doesn't exist in
+# that version. When pages isn't defined it is assumed that the same pages
+# exist across the different versions.
 
 spec:
   versions:

--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -1,3 +1,4 @@
+# This file controls the version selector
 # Schema:
 #     <spec>:
 #       versions:
@@ -6,17 +7,30 @@
 #           status: <string> # one of: Working Draft, In Review, Stable, Retired
 #           draft: <bool, optional> # if true, display a "draft" warning banner
 #           hidden: <bool, optional> # if true, do not show in dropdown
+#           pages: <list, optional> # the pagenames need to match the filenames
 #       current: <version>
 #
 # Where:
 #   <spec> = specification name, i.e. first component of the URL
-#   <version> = verison name, i.e. second component of the URL, e.g. v1.0
+#   <version> = version name, i.e. second component of the URL, e.g. v1.0
+#
+# pages allows defining which pages exist in each version. The selector will
+# only provide the option to select a different version if the page exists
+# in that version. When pages isn't defined it is assumed that the same
+# pages exist across the different versions.
 
 spec:
   versions:
     v0.1:
       name: Version 0.1
       status: Stable
+      pages:
+        index,
+        terminology,
+        levels,
+        requirements,
+        threats,
+        faq
     v1.0:
       name: Version 1.0 (DRAFT)
       status: Working Draft
@@ -24,6 +38,15 @@ spec:
       # We will hide 1.0 until it is ready for review. Viewers can still type
       # the URL manually, but we will not link to it from the main page.
       hidden: true
+      pages:
+        index,
+        levels,
+        principles,
+        terminology,
+        requirements,
+        verifying-systems,
+        threats,
+        faq
   current: v0.1
 
 provenance:

--- a/docs/_includes/versions-dropdown.html
+++ b/docs/_includes/versions-dropdown.html
@@ -9,16 +9,19 @@
   {%- endif %}">
 {%- for item in versions reversed %}
 {%- unless item[1].hidden and spec_version != item[0] %}
-  {% assign page_url_parts = page.url | split: '/' %}
-  {% assign page_url = page_url_parts | join: '/' %}
+  {%- assign page_url_parts = page.url | split: '/' %}
+  {%- assign page_url = page_url_parts | join: '/' %}
   {% comment %}
     The url of index pages don't end with index but with /.
     Beware, the contains test is string based so it could give a false positive
     in case of a page name collision, such as if you have "foo" and "foobar"
   {% endcomment %}
-  {% assign terminator = page.url | slice: -1 %}
+  {%- assign terminator = page.url | slice: -1 %}
   {%- if terminator == "/" or item[1].pages == nil or item[1].pages contains page_url_parts.last %}
     <option value="{{ page_url | replace: spec_version, item[0] | relative_url }}" {% if spec_version == item[0] %}selected{% endif %} class="inline-block">{{item[1].name}}</option>
+  {%- elsif terminator != "/" and item[1].pages != nil %}
+    {% comment %}when the page doesn't exist disable the option{% endcomment %}
+    <option disabled class="inline-block">{{item[1].name}}</option>
   {% endif %}
 {%- endunless %}
 {%- endfor %}

--- a/docs/_includes/versions-dropdown.html
+++ b/docs/_includes/versions-dropdown.html
@@ -12,16 +12,18 @@
   {%- assign page_url_parts = page.url | split: '/' %}
   {%- assign page_url = page_url_parts | join: '/' %}
   {%- assign other_version = page_url | replace: spec_version, item[0] | relative_url %}
-  {% comment %}
+  {%- comment %}
     If the other version of the page doesn't exist disable the option
-  {% endcomment %}
+  {%- endcomment %}
   {%- assign p = site.pages | where_exp: "page", "page.url contains other_version" | first %}
-  {%- if p %}
-    {%- assign disabled = "" %}
+  {%- if p and spec_version == item[0] %}
+    {%- assign state = "selected" %}
+  {%- elsif p %}
+    {%- assign state = "" %}  
   {%- else %}
-    {%- assign disabled = "disabled " %}
+    {%- assign state = "disabled" %}
   {%- endif %}
-<option {{ disabled }} value="{{ other_version }}" {% if spec_version == item[0] %}selected{% endif %} class="inline-block">{{item[1].name}}</option>
+<option {{ state }} value="{{ other_version }}" class="inline-block">{{item[1].name}}</option>
 
 {%- endunless %}
 {%- endfor %}

--- a/docs/_includes/versions-dropdown.html
+++ b/docs/_includes/versions-dropdown.html
@@ -11,18 +11,18 @@
 {%- unless item[1].hidden and spec_version != item[0] %}
   {%- assign page_url_parts = page.url | split: '/' %}
   {%- assign page_url = page_url_parts | join: '/' %}
+  {%- assign other_version = page_url | replace: spec_version, item[0] | relative_url %}
   {% comment %}
-    The url of index pages don't end with index but with /.
-    Beware, the contains test is string based so it could give a false positive
-    in case of a page name collision, such as if you have "foo" and "foobar"
+    If the other version of the page doesn't exist disable the option
   {% endcomment %}
-  {%- assign terminator = page.url | slice: -1 %}
-  {%- if terminator == "/" or item[1].pages == nil or item[1].pages contains page_url_parts.last %}
-    <option value="{{ page_url | replace: spec_version, item[0] | relative_url }}" {% if spec_version == item[0] %}selected{% endif %} class="inline-block">{{item[1].name}}</option>
-  {%- elsif terminator != "/" and item[1].pages != nil %}
-    {% comment %}when the page doesn't exist disable the option{% endcomment %}
-    <option disabled class="inline-block">{{item[1].name}}</option>
-  {% endif %}
+  {%- assign p = site.pages | where_exp: "page", "page.url contains other_version" | first %}
+  {%- if p %}
+    {%- assign disabled = "" %}
+  {%- else %}
+    {%- assign disabled = "disabled " %}
+  {%- endif %}
+<option {{ disabled }} value="{{ other_version }}" {% if spec_version == item[0] %}selected{% endif %} class="inline-block">{{item[1].name}}</option>
+
 {%- endunless %}
 {%- endfor %}
 </select>

--- a/docs/_includes/versions-dropdown.html
+++ b/docs/_includes/versions-dropdown.html
@@ -11,7 +11,15 @@
 {%- unless item[1].hidden and spec_version != item[0] %}
   {% assign page_url_parts = page.url | split: '/' %}
   {% assign page_url = page_url_parts | join: '/' %}
-  <option value="{{ page_url | replace: spec_version, item[0] | relative_url }}" {% if spec_version == item[0] %}selected{% endif %} class="inline-block">{{item[1].name}}</option>
+  {% comment %}
+    The url of index pages don't end with index but with /.
+    Beware, the contains test is string based so it could give a false positive
+    in case of a page name collision, such as if you have "foo" and "foobar"
+  {% endcomment %}
+  {% assign terminator = page.url | slice: -1 %}
+  {%- if terminator == "/" or item[1].pages == nil or item[1].pages contains page_url_parts.last %}
+    <option value="{{ page_url | replace: spec_version, item[0] | relative_url }}" {% if spec_version == item[0] %}selected{% endif %} class="inline-block">{{item[1].name}}</option>
+  {% endif %}
 {%- endunless %}
 {%- endfor %}
 </select>


### PR DESCRIPTION
The selector currently offers to switch between versions even when the page does not exist in the other versions, which leads to a 404. This change fixes that by disabling the option if the other version of the page doesn't exist.

To replicate the problem simply go to: https://slsa.dev/spec/v1.0/principles then select "Version 0.1" -> 404

With this fix, the version 0.1 is disabled in the selector.

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>