### PR TITLE
Document the `buildType` string on github-actions-workflow.

### DIFF
--- a/docs/github-actions-workflow/v0.1/index.md
+++ b/docs/github-actions-workflow/v0.1/index.md
@@ -8,6 +8,10 @@ hero_text: |
 
 ## Description
 
+```jsonc
+"buildType": "https://slsa.dev/github-actions-workflow/v0.1?draft"
+```
+
 This `buildType` describes the execution of a top-level [GitHub Actions]
 workflow that builds a software artifact.
 


### PR DESCRIPTION
This makes it unambiguous what the `buildType` string should be set to.
