### PR TITLE
SLSA v1.0: Fix broken links; move TODO to new "about this release candidate" section

### DIFF
--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -492,7 +492,7 @@ complete example predicate.
 
 -   [GitHub Actions Workflow]
 
-[GitHub Actions Workflow]: /github-actions-workflow/v0.1/
+[GitHub Actions Workflow]: /github-actions-workflow/v0.1
 
 **TODO:** Before marking the spec stable, add at least 1-2 other build types to
 validate that the design is general enough to apply to other builders.

--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -14,6 +14,19 @@ the right</span><span class="md:hidden">at the bottom of this page</span>. For
 the recommended attestation formats, including provenance, see "Specifications"
 in the menu at the top of the page.
 
+## About this release candidate
+
+This is release candidate is a preview of version 1.0. It contains all
+anticipated concepts and major changes for v1.0, but there are still outstanding
+TODOs and cleanups. We expect to cover all TODOs and address feedback before the
+1.0 final release.
+
+Known issues:
+
+-   TODO: Use consistent terminology throughout the site: "publish" vs
+    "release", "publisher" vs "maintainer" vs "developer", "consumer" vs
+    "ecosystem" vs "downstream system", "build" vs "produce.
+
 ## Table of contents
 
 | Page | Description |

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -17,14 +17,6 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
 interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
 
-## TODO
-
-**TODO:** Use consistent terminology throughout the site: "publish" vs
-"release", "publisher" vs "maintainer" vs "developer", "consumer" vs
-"ecosystem" vs "downstream system", "build" vs "produce.
-
-**TODO:** Generate permalinks to sections.
-
 ## Overview
 
 ### Build levels

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -210,7 +210,7 @@ bi-directionally translatable to SLSA Provenance.
 -   *Authenticity:* No requirements.
 -   *Accuracy:* No requirements.
 
-[SLSA Provenance]: ../../provenance/v1/index
+[SLSA Provenance]: ../../provenance/v1
 [associated suite]: ../../attestation-model#recommended-suite
 
 <td>✓<td>✓<td>✓
@@ -435,8 +435,8 @@ prescribed by the package ecosystem.
 ### Setting Expectations
 
 <dfn>Expectations</dfn> define the allowed values for
-[`buildType`](/provenance/v1/#buildType) and
-[`externalParameters`](/provenance/v1/#externalParameters)
+[`buildType`](/provenance/v1#buildType) and
+[`externalParameters`](/provenance/v1#externalParameters)
 for a given package (assuming the SLSA provenance format) in order to address
 the [build integrity threats](threats#build-integrity-threats).
 > **TODO:** link to more concrete guidance once it's available.
@@ -520,7 +520,7 @@ Verification MUST include the following steps:
 
 -   Ensuring that the builder identity is one of those in the map of trusted
     builder id's to SLSA level.
--   [Verification of the provenance](/provenance/v1/#verification) metadata.
+-   [Verification of the provenance](/provenance/v1#verification) metadata.
 -   Ensuring that the values for `BuildType` and `ExternalParameters` in the
     provenance match the known expectations. The package ecosystem MAY allow
     an approved list of `ExternalParameters` to be ignored during verification.


### PR DESCRIPTION
- Fix broken links from #615, now that the URLs ending in slash no longer resolve.
- Move TODO section from requirements.md to index.md, creating a new "About this release candidate" section.
