### PR TITLE
Add draft "gcb-triggered-build" buildType.

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -51,6 +51,14 @@ verification_summary:
       status: Stable
   current: v0.2
 
+gcb-triggered-build:
+  versions:
+    v1:
+      name: Version 1 (DRAFT)
+      draft: true
+      status: Working Draft
+  current: v1
+
 github-actions-workflow:
   versions:
     v0.1:

--- a/docs/gcb-triggered-build/examples/v1/example.json
+++ b/docs/gcb-triggered-build/examples/v1/example.json
@@ -27,7 +27,7 @@
         },
         "runDetails": {
             "metadata": {
-                "invocationId": "TODO",
+                "invocationId": "https://cloudbuild.googleapis.com/v1/projects/cloud-build-samples-project/locations/us-west1/builds/03eb98be-0390-4b05-b861-ef52ed4d2a34",
                 "startedOn": "2023-01-01T12:34:56Z"
             }
         }

--- a/docs/gcb-triggered-build/examples/v1/example.json
+++ b/docs/gcb-triggered-build/examples/v1/example.json
@@ -1,0 +1,41 @@
+{
+    "predicateType": "https://slsa.dev/provenance/v1?draft",
+    "predicate": {
+        "buildDefinition": {
+            "buildType": "https://slsa.dev/gcb-triggered-build/v1?draft",
+            "externalParameters": {
+                "configSource": {
+                    "ref": "refs/heads/main",
+                    "repository": "https://github.com/GoogleCloudPlatform/cloud-build-samples",
+                    "path": "basic-config/cloudbuild.yaml"
+                },
+                "sourceToBuild": {
+                    "dir": "basic-config"
+                },
+                "substitutions": {
+                    "count": "3",
+                    "mass": "1.3kg",
+                    "name": "wrench"
+                }
+            },
+            "resolvedDependencies": [
+                {
+                    "uri": "git+https://github.com/GoogleCloudPlatform/cloud-build-samples@refs/heads/main",
+                    "digest": { "sha1": "bb0fe8075f92bb82b679afe400a47b106f0cec4b" }
+                }
+            ]
+        },
+        "runDetails": {
+            "metadata": {
+                "invocationId": "TODO",
+                "startedOn": "2023-01-01T12:34:56Z"
+            }
+        }
+    },
+    "subject": [
+        {
+            "name": "_",
+            "digest": { "sha256": "fe4fe40ac7250263c5dbe1cf3138912f3f416140aa248637a60d65fe22c47da4" }
+        }
+    ]
+}

--- a/docs/gcb-triggered-build/index.md
+++ b/docs/gcb-triggered-build/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_to_url: v1
+sitemap: false
+---

--- a/docs/gcb-triggered-build/v1.0.md
+++ b/docs/gcb-triggered-build/v1.0.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_to_url: v1
+sitemap: false
+---

--- a/docs/gcb-triggered-build/v1.md
+++ b/docs/gcb-triggered-build/v1.md
@@ -86,11 +86,11 @@ Mutually exclusive with `path`. Exactly one of these fields MUST be set.
 Source code that was checked out and built. Normally this is the same as
 `configSource`; it only differs if the BuildTrigger had `gitFileSource` set.
 
-This field SHOULD be omitted if all subfields are empty, i.e. if the commit is
-the same as `configSource` and `dir` is empty.
+This field SHOULD be omitted if the `repository` and `ref` are the same as
+`configSource` and the `dir` is empty.
 
-In BuildTrigger, this corresponds to `sourceToBuild` (which falls back to the
-commit that triggered the build, for repo-based triggers).
+In BuildTrigger, this corresponds to either `sourceToBuild` or the commit that
+triggered the build, depending on the trigger type.
 
 <tr id="sourceToBuild.ref"><td><code>sourceToBuild.ref</code><td>string<td>
 
@@ -140,9 +140,6 @@ All system parameters are OPTIONAL.
 
 Immutable IDs can be used to provide stable identifiers across account and
 repository renames and to detect when an old name is reused for a new entity.
-
-> **TODO:** Any system parameters? Perhaps the trigger resource URI? Customer
-> org and project?
 
 [RepoType]: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.triggers#BuildTrigger.RepoType
 [RepositoryInfo]: #RepositoryInfo

--- a/docs/gcb-triggered-build/v1.md
+++ b/docs/gcb-triggered-build/v1.md
@@ -44,17 +44,6 @@ Issues].
 
 All external parameters are REQUIRED unless otherwise noted.
 
-> ⚠ **RFC:** Do we need the project and `serviceAccount`? Does it affect the
-> build? Should we trust a build under any project/account, or is that part of
-> the trust base? Should it go in `builder.id`?
-
-> ⚠ **RFC:** Do we need `repoType` from
-> [GitFileSource](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.triggers#BuildTrigger.GitFileSource)?
-> How can that be used to affect the build?
-
-> ⚠ **RFC:** Does this cover all of the ways to externally influence the build? Is
-> anything missing?
-
 <table>
 <tr><th>Parameter<th>Type<th>Description
 
@@ -62,20 +51,19 @@ All external parameters are REQUIRED unless otherwise noted.
 
 Location from which the build configuration was read.
 
-In BuildTrigger, this corresponds to `gitFileSource` if set, else
-`sourceToBuild` (which falls back to the commit that triggered the build, for
-repo-based triggers).
+In BuildTrigger, this corresponds to either `gitFileSource` or the source repo
+that triggered the build, depending on the trigger type.
 
 <tr id="configSource.ref"><td><code>configSource.ref</code><td>object<td>
 
-Git reference within `repository` from which the configuration was read, as
-either a fully qualified git ref (starting with `refs/`) or a commit SHA
-(lowercase hex). A commit SHA is only used if specified in the trigger.
+Git reference within `configSource.repository` from which the configuration was
+read, as either a fully qualified git ref (starting with `refs/`) or a commit
+SHA (lowercase hex). A commit SHA is only used if specified in the trigger.
 
 <tr id="configSource.repository"><td><code>configSource.repository</code><td>string<td>
 
-HTTPS URI of the git repository, with `https://` protocol and without `.git`
-suffix.
+HTTPS URI of the git repository containing the build configuration file, with
+`https://` protocol and without `.git` suffix.
 
 <tr id="configSource.path"><td><code>configSource.path</code><td>string<td>
 
@@ -99,21 +87,21 @@ Source code that was checked out and built. Normally this is the same as
 `configSource`; it only differs if the BuildTrigger had `gitFileSource` set.
 
 This field SHOULD be omitted if all subfields are empty, i.e. if the commit is
-the same as same as `configSource` and `dir` is empty.
+the same as `configSource` and `dir` is empty.
 
 In BuildTrigger, this corresponds to `sourceToBuild` (which falls back to the
 commit that triggered the build, for repo-based triggers).
 
 <tr id="sourceToBuild.ref"><td><code>sourceToBuild.ref</code><td>string<td>
 
-Git reference within `repository` that was checked out, as either a fully
-qualified git ref (starting with `refs/`) or a commit SHA (lowercase hex). A
-commit SHA is only used if specified in the trigger.
+Git reference within `sourceToBuild.repository` that was checked out, as either
+a fully qualified git ref (starting with `refs/`) or a commit SHA (lowercase
+hex). A commit SHA is only used if specified in the trigger.
 
 <tr id="sourceToBuild.repository"><td><code>sourceToBuild.repository</code><td>string<td>
 
-HTTPS URI of the git repository, with `https://` protocol and without `.git`
-suffix.
+HTTPS URI of the git repository that was checked out, with `https://` protocol
+and without `.git` suffix.
 
 <tr id="sourceToBuild.dir"><td><code>sourceToBuild.dir</code><td>string<td>
 
@@ -125,12 +113,39 @@ Can be empty / unset.
 Map of (string -> string) containing the substitutions to perform on the Build
 resource.
 
+In BuildTrigger, this corresponds to `substitutions`.
+
 </table>
 
 ### System parameters
 
+All system parameters are OPTIONAL.
+
+| Parameter | Type | Description |
+| --------- | ---- | ----------- |
+| `configSource` | [RepositoryInfo] | Metadata about `externalParameters.configSource`. |
+| `projectId` | string | Immutable project ID containing this build. Does not impact the provenance but affects what resources the build can access.|
+| `serviceAccount` | string | Service account that the build ran under. Does not impact the provenance but affects what resources the build can access.|
+| `sourceToBuild` | [RepositoryInfo] | Metadata about `externalParameters.sourceToBuild`. |
+| `triggerUri` | string | Resource URI of the trigger that invoked this build. |
+
+<a id="RepositoryInfo"></a>
+<dfn>RepositoryInfo</dfn> describes metadata about a repository.
+
+| RepositoryInfo | Type | Description |
+| -------------- | ---- | ----------- |
+| `repoType` | string ([RepoType]) | The hosting provider of `repository` in case it cannot be determined from the URI, such as for an enterprise account with a custom domain. |
+| `repositoryId` | string | The immutable (numeric) ID of `repository` provided by the source control host, if known. |
+| `repositoryOwnerId` | string | The immutable (numeric) ID of the user or organization that owns `repository`, if known. |
+
+Immutable IDs can be used to provide stable identifiers across account and
+repository renames and to detect when an old name is reused for a new entity.
+
 > **TODO:** Any system parameters? Perhaps the trigger resource URI? Customer
 > org and project?
+
+[RepoType]: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.triggers#BuildTrigger.RepoType
+[RepositoryInfo]: #RepositoryInfo
 
 ### Resolved dependencies
 

--- a/docs/gcb-triggered-build/v1.md
+++ b/docs/gcb-triggered-build/v1.md
@@ -166,7 +166,8 @@ to the workflow.
 
 ### Metadata
 
-> **TODO:** Is there a URI we can use for `invocationId`?
+The `invocationId` SHOULD be set to the URL of the build resource, i.e.
+`https://cloudbuild.googleapis.com/v1/projects/<project>/locations/<location>/builds/<build_id>`.
 
 ## Example
 

--- a/docs/gcb-triggered-build/v1.md
+++ b/docs/gcb-triggered-build/v1.md
@@ -1,0 +1,171 @@
+---
+title: "Build Type: GCB Triggered Build"
+layout: standard
+hero_text: |
+    A [SLSA Provenance](/provenance/v1) `buildType` that describes a build
+    executed by Google Cloud Build reading the build configuration from source.
+---
+
+## Description
+
+```jsonc
+"buildType": "https://slsa.dev/gcb-triggered-build/v1?draft"
+```
+
+This `buildType` describes the execution of a [Google Cloud Build (GCB)][GCB]
+build where GCB read the build configuration from a file in a source repository,
+usually called cloudbuild.yaml. This is only possible via a [Trigger], though
+theoretically a future API or CLI call could do the same.
+
+This `buildType` MUST NOT be used to describe:
+
+-   Cases where GCB did not verify that the build configuration came from a
+    source repository. This includes [local builds] that send the [Build] over
+    the wire, as well as [Triggers][Trigger] that set an explicit `build`. (If
+    desired, a separate `buildType` could be created for that purpose.)
+-   Pull request events. The semantics are confusing in the context of SLSA
+    since the build is not of the target but of the source, so to be safe these
+    are unsupported.
+
+If you have a use case for supporting these, please open a [GitHub Issue][SLSA
+Issues].
+
+[Build]: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds
+[GCB]: https://cloud.google.com/build/docs/api/reference/rest
+[SLSA Issues]: https://github.com/slsa-framework/slsa/issues
+[Trigger]: https://cloud.google.com/build/docs/api/reference/rest/v1/projects.triggers
+[local builds]: https://cloud.google.com/build/docs/running-builds/submit-build-via-cli-api
+
+## Build Definition
+
+### External parameters
+
+[External parameters]: #external-parameters
+
+All external parameters are REQUIRED unless otherwise noted.
+
+> ⚠ **RFC:** Do we need the project and `serviceAccount`? Does it affect the
+> build? Should we trust a build under any project/account, or is that part of
+> the trust base? Should it go in `builder.id`?
+
+> ⚠ **RFC:** Do we need `repoType` from
+> [GitFileSource](https://cloud.google.com/build/docs/api/reference/rest/v1/projects.locations.triggers#BuildTrigger.GitFileSource)?
+> How can that be used to affect the build?
+
+> ⚠ **RFC:** Does this cover all of the ways to externally influence the build? Is
+> anything missing?
+
+<table>
+<tr><th>Parameter<th>Type<th>Description
+
+<tr id="configSource"><td><code>configSource</code><td>object<td>
+
+Location from which the build configuration was read.
+
+In BuildTrigger, this corresponds to `gitFileSource` if set, else
+`sourceToBuild` (which falls back to the commit that triggered the build, for
+repo-based triggers).
+
+<tr id="configSource.ref"><td><code>configSource.ref</code><td>object<td>
+
+Git reference within `repository` from which the configuration was read, as
+either a fully qualified git ref (starting with `refs/`) or a commit SHA
+(lowercase hex). A commit SHA is only used if specified in the trigger.
+
+<tr id="configSource.repository"><td><code>configSource.repository</code><td>string<td>
+
+HTTPS URI of the git repository, with `https://` protocol and without `.git`
+suffix.
+
+<tr id="configSource.path"><td><code>configSource.path</code><td>string<td>
+
+Path to the build configuration file within the commit. Example:
+`cloudbuild.yaml`
+
+Mutually exclusive with `pathAutodetect`. Exactly one of these fields MUST be
+set.
+
+<tr id="configSource.pathAutodetect"><td><code>configSource.pathAutodetect</code><td>boolean<td>
+
+If true, `path` was autodetected, corresponding to the `autodetect` option in
+the BuildTrigger. This MUST NOT be set to false; use `path` instead if
+autodetection was not enabled.
+
+Mutually exclusive with `path`. Exactly one of these fields MUST be set.
+
+<tr id="sourceToBuild"><td><code>sourceToBuild</code><td>object<td>
+
+Source code that was checked out and built. Normally this is the same as
+`configSource`; it only differs if the BuildTrigger had `gitFileSource` set.
+
+This field SHOULD be omitted if all subfields are empty, i.e. if the commit is
+the same as same as `configSource` and `dir` is empty.
+
+In BuildTrigger, this corresponds to `sourceToBuild` (which falls back to the
+commit that triggered the build, for repo-based triggers).
+
+<tr id="sourceToBuild.ref"><td><code>sourceToBuild.ref</code><td>string<td>
+
+Git reference within `repository` that was checked out, as either a fully
+qualified git ref (starting with `refs/`) or a commit SHA (lowercase hex). A
+commit SHA is only used if specified in the trigger.
+
+<tr id="sourceToBuild.repository"><td><code>sourceToBuild.repository</code><td>string<td>
+
+HTTPS URI of the git repository, with `https://` protocol and without `.git`
+suffix.
+
+<tr id="sourceToBuild.dir"><td><code>sourceToBuild.dir</code><td>string<td>
+
+Directory within the commit in which to run the build, without a trailing slash.
+Can be empty / unset.
+
+<tr id="substitutions"><td><code>substitutions</code><td>object<td>
+
+Map of (string -> string) containing the substitutions to perform on the Build
+resource.
+
+</table>
+
+### System parameters
+
+> **TODO:** Any system parameters? Perhaps the trigger resource URI? Customer
+> org and project?
+
+### Resolved dependencies
+
+The `resolvedDependencies` SHOULD contain entries identifying the resolved git
+commit IDs corresponding to `externalParameters.configSource` and
+`externalParameters.sourceToBuild`. The dependencies' `uri` MUST be in [SPDX
+Download Location] format, i.e. `"git+" + repository + "@" + ref`. See
+[Example].
+
+The `resolvedDependencies` MAY contain additional artifacts known to be input
+to the workflow.
+
+[SPDX Download Location]: https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field
+
+## Run details
+
+### Builder
+
+> **TODO:** How should we populate `builder.id`? Should it include the tenant
+> project (and/or service account)?
+
+### Metadata
+
+> **TODO:** Is there a URI we can use for `invocationId`?
+
+## Example
+
+[Example]: #example
+
+```json
+{% include_relative examples/v1/example.json %}
+```
+
+## Version history
+
+### v1
+
+Initial version

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -675,12 +675,19 @@ basis.
 The following is an partial index of build type definitions. Each contains a
 complete example predicate.
 
+<!-- sort alphabetically -->
+
+-   [Google Cloud Build Trigger](/gcb-triggered-build/v1/)
 -   [GitHub Actions Workflow]
 
 [GitHub Actions Workflow]: /github-actions-workflow/v0.1
 
 **TODO:** Before marking the spec stable, add at least 1-2 other build types to
 validate that the design is general enough to apply to other builders.
+
+NOTE: There is no requirement for the build type to be listed here or for the
+definition to be hosted on slsa.dev, though we welcome contributions if they are
+of public interest.
 
 ## Migrating from 0.2
 


### PR DESCRIPTION
This buildType is for Google Cloud Build. It only supports "triggers" because those are the ones that are config-as-code, roughly corresponding to the existing "github-actions-workflow" buildType. (Config as code is not strictly required by SLSA v1.0, but without it setting expectations is not practical.)

I called this "v1" just to make everything v1. I sent out #624 separately to rename GHA v0.1 to v1.

/cc @prabenzom @bobcatfish @chitrangpatel @khalkie to review from GCB side.

Preview: https://deploy-preview-623--slsa.netlify.app/gcb-triggered-build/v1