### PR TITLE
Rename github-actions-workflow/v0.1 to v1

### DIFF
--- a/docs/github-actions-workflow/examples/v1/example.json
+++ b/docs/github-actions-workflow/examples/v1/example.json
@@ -2,7 +2,7 @@
     "predicateType": "https://slsa.dev/provenance/v1?draft",
     "predicate": {
         "buildDefinition": {
-            "buildType": "https://slsa.dev/github-actions-workflow/v0.1?draft",
+            "buildType": "https://slsa.dev/github-actions-workflow/v1?draft",
             "externalParameters": {
                 "inputs": {
                     "build_id": 123456768,

--- a/docs/github-actions-workflow/v1.md
+++ b/docs/github-actions-workflow/v1.md
@@ -9,7 +9,7 @@ hero_text: |
 ## Description
 
 ```jsonc
-"buildType": "https://slsa.dev/github-actions-workflow/v0.1?draft"
+"buildType": "https://slsa.dev/github-actions-workflow/v1?draft"
 ```
 
 This `buildType` describes the execution of a top-level [GitHub Actions]
@@ -190,7 +190,7 @@ github.run_id + "/attempts/" + github.run_attempt`.
 [Example]: #example
 
 ```json
-{% include_relative examples/v0.1/example.json %}
+{% include_relative examples/v1/example.json %}
 ```
 
 Note: The `builder.id` in the example assumes that the build runs under
@@ -199,6 +199,6 @@ If GitHub itself generated the provenance, the `id` would be different.
 
 ## Version history
 
-### v0.1
+### v1
 
 Initial version

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -163,7 +163,7 @@ The URI SHOULD resolve to a human-readable specification that includes: overall
 description of the build type; schema for `externalParameters` and
 `systemParameters`; unambiguous instructions for how to initiate the build given
 this BuildDefinition, and a complete example. Example:
-https://slsa.dev/github-actions-workflow/v0.1
+https://slsa.dev/github-actions-workflow/v1
 
 <tr id="externalParameters"><td><code>externalParameters</code>
 <td>object<td>
@@ -677,7 +677,7 @@ complete example predicate.
 
 -   [GitHub Actions Workflow]
 
-[GitHub Actions Workflow]: /github-actions-workflow/v0.1
+[GitHub Actions Workflow]: /github-actions-workflow/v1
 
 **TODO:** Before marking the spec stable, add at least 1-2 other build types to
 validate that the design is general enough to apply to other builders.


### PR DESCRIPTION
No one is relying on this string yet, and everything else is v1, so it makes sense to just call it v1. We can rename to v2 if we have a breaking change.
