### PR TITLE
Add the SLSA spec as a single page

### DIFF
--- a/docs/_includes/onepage.liquid
+++ b/docs/_includes/onepage.liquid
@@ -1,0 +1,25 @@
+{% comment %}
+This code turns a set of pages contained in a directory into one single page.
+{% endcomment %}
+
+{% assign filenames = include.filenames %}
+{% assign dir = include.dir %}
+
+{% assign files = filenames | split: "," %}
+{% capture pattern %}page.url contains "{{dir}}"{% endcapture %}
+{% assign pages = site.pages | where_exp: "page", pattern %}
+
+<!-- index page begins -->
+{% capture pattern %}page.url == "{{dir}}"{% endcapture %}
+{% assign index = site.pages | where_exp: "page", pattern |first %}
+{% include section.liquid content=index.content files=files baseurl=dir noshift=true %}
+<!-- index page ends -->
+
+{% for file in files %}
+   {% capture pattern %}page.url contains "{{file}}"{% endcapture %}
+   {% assign p = pages | where_exp: "page", pattern | first %}
+   <!-- {{p.url}} begins -->
+   <h2 id="{{file}}">{{p.title}}</h2>
+   {% include section.liquid content=p.content files=files baseurl=dir noshift=false %}
+   <!-- {{p.url}} ends -->
+{% endfor %}

--- a/docs/_includes/section.liquid
+++ b/docs/_includes/section.liquid
@@ -1,0 +1,81 @@
+{% comment %}
+This code includes the content of a page after massaging it to fix the
+header levels to shift them down one level, make the links relative,
+and change "page" to "section" in the content.
+Note: This last step is fragile. It could have adverse effects since
+this is merely text based.
+{% endcomment %}
+
+{% unless include.noshift %}
+   {% assign fixedcontent = include.content | replace: "# ", "## " %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "<h4", "<h5"}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "</h4>", "</h5>"}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "<h3", "<h4"}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "</h3>", "</h4>"}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "<h2", "<h3"}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "</h2>", "</h3>"}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "<h1", "<h2"}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "</h1>", "</h2>"}}{% endcapture %}
+{% else %}
+   {% assign fixedcontent = include.content %}
+{% endunless %}
+
+{% for file in include.files %}
+   {%comment%}[Link](baseurl/file) -> [Link](#file){%endcomment%}
+   {% capture pattern %}]({{include.baseurl}}{{file}}{% endcapture %}
+   {% capture anchor %}](#{{file}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}[Link](file) -> [Link](#file){%endcomment%}
+   {% capture pattern %}]({{file}}{% endcapture %}
+   {% capture anchor %}](#{{file}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}[Link](#file#) -> [Link](#){%endcomment%}
+   {% capture pattern %}](#{{file}}#{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, "](#"}}{% endcapture %}
+
+   {%comment%}[Link]: baseurl/file -> [Link]: #file{%endcomment%}
+   {% capture pattern %}]: {{include.baseurl}}{{file}}{% endcapture %}
+   {% capture anchor %}]: #{{file}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}[Link]: file -> [Link]: #file{%endcomment%}
+   {% capture pattern %}]: {{file}}{% endcapture %}
+   {% capture anchor %}]: #{{file}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}[Link]: #file# -> [Link]: #{%endcomment%}
+   {% capture pattern %}]: #{{file}}#{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, "]: #"}}{% endcapture %}
+
+   {%comment%}href="baseurl/file -> href="#file{%endcomment%}
+   {% capture pattern %}href="{{include.baseurl}}{{file}}{% endcapture %}
+   {% capture anchor %}href="#{{file}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}href="file -> href="#file{%endcomment%}
+   {% capture pattern %}href="{{file}}{% endcapture %}
+   {% capture anchor %}href="#{{file}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}href="#file# -> href="#{%endcomment%}
+   {% capture pattern %}href="#{{file}}#{% endcapture %}
+   {% capture anchor %}href="#{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+
+   {%comment%}Links to index page / baseurl{%endcomment%}
+   {%comment%}[Link](baseurl){%endcomment%}
+   {% capture pattern %}]({{include.baseurl}}){% endcapture %}
+   {% capture anchor %}]({{page.url}}){% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}We do not know how to handle this form: [Link]: baseurl
+   Changing this will screw up all other links starting with baseurl
+   {% capture pattern %}]: {{include.baseurl}}{% endcapture %}
+   {% capture anchor %}]: {{page.url}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%endcomment%}
+   {%comment%}href="index -> href="thispage{%endcomment%}
+   {% capture pattern %}href="index{% endcapture %}
+   {% capture anchor %}href="{{page.url}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}href="baseurl" -> href="thispage"{%endcomment%}
+   {% capture pattern %}href="{{include.baseurl}}"{% endcapture %}
+   {% capture anchor %}href="{{page.url}}"{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+{% endfor %}
+{{fixedcontent | replace: " page", " section" | replace: "Page", "Section" }}

--- a/docs/spec/v0.1/onepage.md
+++ b/docs/spec/v0.1/onepage.md
@@ -1,0 +1,12 @@
+---
+title: SLSA Specification
+layout: standard
+---
+{%- comment -%}
+A single page containing all the following files as different sections
+{%- endcomment -%}
+
+{% assign dir = "/spec/v0.1/" %}
+{% assign filenames = "terminology,levels,requirements,threats,faq" %}
+
+{% include onepage.liquid dir=dir filenames=filenames %}

--- a/docs/spec/v1.0/faq.md
+++ b/docs/spec/v1.0/faq.md
@@ -30,6 +30,8 @@ bit-for-bit identical output. This property
 including easier debugging, more confident cherry-pick releases, better build
 caching and storage efficiency, and accurate dependency tracking.
 
+TODO: Fix this to account for the fact that we don't have SLSA 4 in v1.0
+
 For these reasons, SLSA 4 [requires](../levels.md#level-requirements) reproducible builds
 unless there is a justification why the build cannot be made reproducible.
 [Example](https://lists.reproducible-builds.org/pipermail/rb-general/2021-January/002177.html)

--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -12,11 +12,11 @@ This is **version 1.0** of the SLSA specification, which defines the SLSA
 levels. For other versions, use the chooser <span class="hidden md:inline">to
 the right</span><span class="md:hidden">at the bottom of this page</span>. For
 the recommended attestation formats, including provenance, see "Specifications"
-in the menu at the top of the page.
+in the menu at the top.
 
 ## About this release candidate
 
-This is release candidate is a preview of version 1.0. It contains all
+This release candidate is a preview of version 1.0. It contains all
 anticipated concepts and major changes for v1.0, but there are still outstanding
 TODOs and cleanups. We expect to cover all TODOs and address feedback before the
 1.0 final release.

--- a/docs/spec/v1.0/onepage.md
+++ b/docs/spec/v1.0/onepage.md
@@ -1,0 +1,11 @@
+---
+title: SLSA Specification
+---
+{%- comment -%}
+A single page containing all the following files as different sections
+{%- endcomment -%}
+
+{% assign dir = "/spec/v1.0/" %}
+{% assign filenames = "levels,principles,terminology,requirements,verifying-systems,threats,faq,future-directions" %}
+
+{% include onepage.liquid dir=dir filenames=filenames %}


### PR DESCRIPTION
More work can be done on this but with this change one can access the whole SLSA spec on a single page. All the internal links are fixed to be relative to that page, headers are shifted one level done to get the proper TOC.
I primarily focused on the v1.0 version but it also works on the v0.1 version although some headers appear on several pages so when put on the same page it seems a bit odd.
Let me know what you think.

The page is found at /spec/v1.0/onepage and /spec/v0.1/onepage. The version selector even works across! :-)