### PR TITLE
Provenance v1: Clarify when to ignore unrecognized fields

### DIFF
--- a/docs/github-actions-workflow/v1.md
+++ b/docs/github-actions-workflow/v1.md
@@ -39,9 +39,9 @@ may be error prone or require further analysis (such as `pull_request` or
 `repository_dispatch`). To add support for another event type, please open a
 [GitHub Issue][SLSA Issues].
 
-Note: Consumers are REQUIRED to reject unrecognized external parameters, so new
-event types can be added without a major version bump as long as they do not
-change the semantics of existing external parameters.
+Note: Consumers SHOULD reject unrecognized external parameters, so new event
+types can be added without a major version bump as long as they do not change
+the semantics of existing external parameters.
 
 Note: This build type is **not** meant to describe execution of a subset of a
 top-level workflow, such as an action, job, or reusable workflow. Only workflows

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -85,18 +85,13 @@ For concrete examples, see [index of build types](#index-of-build-types).
 
 This predicate follows the in-toto attestation [parsing rules]. Summary:
 
--   Consumers MUST ignore unrecognized fields.
+-   Consumers MUST ignore unrecognized fields unless otherwise noted.
 -   The `predicateType` URI includes the major version number and will always
     change whenever there is a backwards incompatible change.
 -   Minor version changes are always backwards compatible and "monotonic." Such
     changes do not update the `predicateType`.
 -   Producers MAY add extension fields using field names that are URIs.
 -   Unset, null, and empty field values MUST be interpreted equivalently.
-
-> **TODO:** The [GitHub Actions] spec says that consumers MUST **reject**
-> unrecognized external parameters, whereas here we say that they MUST
-> **ignore** unrecognized fields (including parameters). We need to figure out
-> which is correct and then resolve the conflict.
 
 ## Schema
 
@@ -177,6 +172,9 @@ The build system SHOULD be designed to minimize the size and complexity of
 `externalParameters`, in order to reduce fragility and ease [verification].
 Consumers SHOULD have an expectation of what "good" looks like; the more
 information that they need to check, the harder that task becomes.
+
+Verifiers SHOULD reject unrecognized or unexpected fields within
+`externalParameters`.
 
 <tr id="systemParameters"><td><code>systemParameters</code>
 <td>object<td>


### PR DESCRIPTION
Previously there was an inconsistency:

- The "Parsing Rules" said that consumers MUST **ignore** unrecognized fields. The intention is that implementations, or future minor versions of the spec, can add extra fields without invalidating what's already there.
- However, the design of `externalParameters` and the corresponding verification instructions assumed that consumers would **reject** unrecognized parameters. The idea here is that an unrecognized parameter cannot be expected, thus it's err on the side of safety an reject.

This PR attempts to fix this issue by stating that consumers MUST ignore unrecognized fields **unless otherwise noted** and noting that `externalParameters` is such an exception.

### Questions for reviewers

Is this sufficient to resolve the issue? Are there still any concerns about confusion or incorrect implementations?