### PR TITLE
Fixes for github-actions-workflow.

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -53,8 +53,8 @@ verification_summary:
 
 github-actions-workflow:
   versions:
-    v0.1:
-      name: Version 0.1 (DRAFT)
+    v1:
+      name: Version 1.0 (DRAFT)
       draft: true
       status: Working Draft
-  current: v0.1
+  current: v1

--- a/docs/github-actions-workflow/index.md
+++ b/docs/github-actions-workflow/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_to_url: v1
+sitemap: false
+---

--- a/docs/github-actions-workflow/v1.md
+++ b/docs/github-actions-workflow/v1.md
@@ -159,8 +159,8 @@ The `github` object SHOULD contains the following elements:
 | ---------------------------- | ------ | ----------- |
 | `github.actor_id`            | string | The numeric ID of the user that triggered the initial workflow run. |
 | `github.event_name`          | string | The name of the event that triggered the workflow run. |
-| `github.repository_id`       | string | The numeric ID corresponding to `systemParameters.workflow.repository`. |
-| `github.repository_owner_id` | string | The numeric ID of the user or organization that owns `systemParameters.workflow.repository`. |
+| `github.repository_id`       | string | The numeric ID corresponding to `externalParameters.workflow.repository`. |
+| `github.repository_owner_id` | string | The numeric ID of the user or organization that owns `externalParameters.workflow.repository`. |
 | `github.triggering_actor_id` | string | The numeric ID of the user that triggered the rerun, if different than `actor_id`. |
 
 Numeric IDs are used here to provide stable identifiers across account and


### PR DESCRIPTION
- Add redirect to v1 if version is unspecified.
- Fix version.yml to include this version. This has the effect of re-adding the "draft" banner.
- Fix typo in reference to `externalParameters`.
