### PR TITLE
Provenance v1: make `builder.id` required again

### DIFF
--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -38,7 +38,7 @@ artifacts through execution of the `buildDefinition`.
 The model is as follows:
 
 -   Each build runs as an independent process on a multi-tenant platform. The
-    `builder` is the identity of this platform, representing the transitive
+    `builder.id` identifies this platform, representing the transitive
     closure of all entities that are [trusted] to faithfully run the build and
     record the provenance. (Note: The same model can be used for platform-less
     or single-tenant build systems.)
@@ -69,7 +69,7 @@ The model is as follows:
 
 -   During execution, the build process might communicate with the build
     platform's control plane and/or build caches. This communication is not
-    captured directly in the provenance, but is instead implied by the `builder`
+    captured directly in the provenance, but is instead implied by `builder.id`
     and subject to [SLSA Requirements](/spec/v1.0/requirements). Such
     communication SHOULD NOT influence the definition of the build; if it does,
     it SHOULD go in `resolvedDependencies` instead.
@@ -128,7 +128,8 @@ REQUIRED for SLSA Build L1: `buildDefinition`, `runDetails`
 <tr id="buildDefinition"><td><code>buildDefinition</code>
 <td><a href="#builddefinition">BuildDefinition</a><td>
 
-The input to the build. The accuracy and completeness are implied by `runDetails.builder.id`.
+The input to the build. The accuracy and completeness are implied by
+`runDetails.builder.id`.
 
 <tr id="runDetails"><td><code>runDetails</code>
 <td><a href="#rundetails">RunDetails</a><td>
@@ -177,11 +178,12 @@ Verifiers SHOULD reject unrecognized or unexpected fields within
 <tr id="systemParameters"><td><code>systemParameters</code>
 <td>object<td>
 
-The parameters that are under the control of the `builder`. The primary
-intention of this field is for debugging, incident response, and vulnerability
-management. The values here MAY be necessary for reproducing the build. There is
-no need to [verify][Verification] these parameters because the build system is
-already trusted, and in many cases it is not practical to do so.
+The parameters that are under the control of the entity represented by
+`builder.id`. The primary intention of this field is for debugging, incident
+response, and vulnerability management. The values here MAY be necessary for
+reproducing the build. There is no need to [verify][Verification] these
+parameters because the build system is already trusted, and in many cases it is
+not practical to do so.
 
 <tr id="resolvedDependencies"><td><code>resolvedDependencies</code>
 <td>array (<a href="#artifactreference">ArtifactReference</a>)<td>
@@ -264,10 +266,6 @@ Guidelines:
     URI and digest of artifacts that, if compromised, could impact the build. At
     SLSA Build L3, completeness is considered "best effort".
 
--   It is acceptable for a single build service to have multiple modes of
-    operation, only some of which are SLSA-compatible. In this case, each mode
-    SHOULD have a separate `builder.id`.
-
 [^digest-param]: The `externalParameters` SHOULD reflect reality. If clients
     send the evaluated configuration object directly to the build server, record
     the digest directly in `externalParameters`. If clients upload the
@@ -337,8 +335,7 @@ Example:
 
 [RunDetails]: #rundetails
 
-REQUIRED for SLSA Build L1: `builder` (unless `id` is implicit from the
-attestation envelope)
+REQUIRED for SLSA Build L1: `builder`
 
 <table>
 <tr><th>Field<th>Type<th>Description
@@ -372,7 +369,7 @@ later and that cannot be easily reproduced.
 
 [Builder]: #builder
 
-REQUIRED for SLSA Build L1: `id` (unless implicit from the attestation envelope)
+REQUIRED for SLSA Build L1: `id`
 
 <table>
 <tr><th>Field<th>Type<th>Description
@@ -380,16 +377,13 @@ REQUIRED for SLSA Build L1: `id` (unless implicit from the attestation envelope)
 <tr id="builder.id"><td><code>id</code>
 <td>string (<a href="https://github.com/in-toto/attestation/blob/main/spec/field_types.md#TypeURI">TypeURI</a>)<td>
 
-URI indicating the transitive closure of the trusted builder.
+URI indicating the transitive closure of the trusted builder. This is
+[intended][Step 1] to be the sole determiner of the SLSA Build level.
 
-**TODO:** In most cases this is implicit from the envelope layer (e.g. the
-public key or x.509 certificate), which is just one more thing to mess up. Can
-we rescope this to avoid the duplication and thus the security concern? For
-example, if the envelope identifies the build system, this might identify the
-tenant project?
-
-**TODO:** Provide guidance on how to choose a URI, what scope it SHOULD have,
-stability, how [verification] works, etc.
+If a build platform has multiple modes of operations that have differing
+security attributes or SLSA Build levels, each mode MUST have a different
+`builder.id` and SHOULD have a different signer identity. This is to minimize
+the risk that a less secure mode compromises a more secure one.
 
 <tr id="builder.version"><td><code>version</code>
 <td>map (string→string)<td>

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -420,6 +420,8 @@ in the GitHub Actions example above. The field is REQUIRED, even if it is
 implicit from the signer, to aid readability and debugging. It is an object to
 allow additional fields in the future, in case one URI is not sufficient.
 
+> ⚠ **RFC:** Do we need more explicit guidance on how to choose a URI?
+
 > ⚠ **RFC:** Would it be preferable to allow builders to set arbitrary
 > properties, rather than calling out `version` and `builderDependencies`? We
 > don't expect verifiers to use any of them, so maybe that's the simpler


### PR DESCRIPTION
- Make `builder.id` required, which is how it was in v0.2. (Before this commit, v1 said that the `id` MAY be implicit from the signer's identity.)
- Replace uses of `builder` with `builder.id`. The latter is the identity, while the former includes more information about the builder.
- Remove TODOs about `id` being optional.

Fixes #622.
