### PR TITLE
Add missing link to the spec

### DIFF
--- a/docs/_posts/2023-02-24-slsa-v1-rc.md
+++ b/docs/_posts/2023-02-24-slsa-v1-rc.md
@@ -10,9 +10,9 @@ release in June 2021, and the RC finalizes multiple revisions to the SLSA
 specifications and requirements. We're grateful for the huge community
 engagement that went into shaping this work.
 
-We're requesting community feedback on the RC Specification by **March 24,
-2023**, with a view towards releasing a 1.0 Stable revision at the end of
-March.
+We're requesting community feedback on the
+[SLSA v1.0 RC1 Specification](/spec/v1.0-rc1) by **March 24, 2023**,
+with a view towards releasing a 1.0 Stable revision at the end of March.
 
 ## What's changed
 


### PR DESCRIPTION
The blog post is missing one crucial piece of info: a link to the spec!
It does link to various parts of it but not the spec directly. This PR fixes that.