### PR TITLE
Redirect between "v1" and "v1.0"

### DIFF
--- a/docs/github-actions-workflow/v1.0.md
+++ b/docs/github-actions-workflow/v1.0.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_to_url: /github-actions-workflow/v1
+sitemap: false
+---

--- a/docs/provenance/v1.0.md
+++ b/docs/provenance/v1.0.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_to_url: /provenance/v1
+sitemap: false
+---

--- a/docs/spec/v1.md
+++ b/docs/spec/v1.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+redirect_to_url: /spec/v1.0
+sitemap: false
+---


### PR DESCRIPTION
I keep mistyping `/spec/v1` when it's really `/spec/v1.0` and similarly `/provenance/v1.0` when it's really `/provenance/v1`. This commit creates simple redirects to jump to the right one.
