### PR TITLE
provenance v1: use non-empty builderId in example

### DIFF
--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -512,13 +512,13 @@ Up front:
             "builderId": "https://differentbuilder.example.com/slsa/l3",
             "slsaBuildLevel": 2
         },
-        // A builder that uses Sigstore for authentication, without a builder.id
+        // A builder that uses Sigstore for authentication.
         {
             "sigstore": {
                 "root": "global",  // identifies fulcio/rekor roots
                 "subjectAlternativeNamePattern": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v*.*.*"
             }
-            "builderId": "",  // empty for this particular builder
+            "builderId": "https://github.com/slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@refs/tags/v*.*.*",
             "slsaBuildLevel": 3,
         }
         ...


### PR DESCRIPTION
Commit f96aac7a made `builder.id` a required field but forgot to update the example root of trust accordingly.
