### PR TITLE
Add spec level previous and next links (all versions)

### DIFF
--- a/docs/_includes/pagination.html
+++ b/docs/_includes/pagination.html
@@ -1,0 +1,10 @@
+{% if page.prev_page or page.next_page %}
+  <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
+    {% if page.prev_page %}
+      <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ page.prev_page.title }}</a>
+    {% endif %}
+    {% if page.next_page %}
+      <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ page.next_page.title }} &rsaquo;</a>
+    {% endif %}
+  </div>
+{% endif %}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -16,7 +16,19 @@
           {% include toc.html html=content %}
         </aside>
         <div class="content">
+
           {{ content }}
+
+          {% if page.prev_page or page.next_page %}
+            <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
+              {% if page.prev_page %}
+                <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ page.prev_page.title }}</a>
+              {% endif %}
+              {% if page.next_page %}
+                <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ page.next_page.title }} &rsaquo;</a>
+              {% endif %}
+            </div>
+          {% endif %}
         </div>
       </main>
       {%- include footer.html -%}

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -16,19 +16,8 @@
           {% include toc.html html=content %}
         </aside>
         <div class="content">
-
           {{ content }}
-
-          {% if page.prev_page or page.next_page %}
-            <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
-              {% if page.prev_page %}
-                <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ page.prev_page.title }}</a>
-              {% endif %}
-              {% if page.next_page %}
-                <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ page.next_page.title }} &rsaquo;</a>
-              {% endif %}
-            </div>
-          {% endif %}
+          {%- include pagination.html -%}
         </div>
       </main>
       {%- include footer.html -%}

--- a/docs/_layouts/specifications.html
+++ b/docs/_layouts/specifications.html
@@ -26,7 +26,19 @@
           </aside>
           <div class="content markdown">
             <p>{{ page.hero_text | markdownify }}</p>
+
             {{ content }}
+
+            {% if page.prev_page or page.next_page %}
+              <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
+                {% if page.prev_page %}
+                  <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ page.prev_page.title }}</a>
+                {% endif %}
+                {% if page.next_page %}
+                  <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ page.next_page.title }} &rsaquo;</a>
+                {% endif %}
+              </div>
+            {% endif %}
           </div>
         </div>
       </main>

--- a/docs/_layouts/specifications.html
+++ b/docs/_layouts/specifications.html
@@ -26,19 +26,8 @@
           </aside>
           <div class="content markdown">
             <p>{{ page.hero_text | markdownify }}</p>
-
             {{ content }}
-
-            {% if page.prev_page or page.next_page %}
-              <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
-                {% if page.prev_page %}
-                  <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ page.prev_page.title }}</a>
-                {% endif %}
-                {% if page.next_page %}
-                  <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ page.next_page.title }} &rsaquo;</a>
-                {% endif %}
-              </div>
-            {% endif %}
+            {%- include pagination.html -%}
           </div>
         </div>
       </main>

--- a/docs/_layouts/standard.html
+++ b/docs/_layouts/standard.html
@@ -26,19 +26,8 @@
           </aside>
           <div class="content main-content">
             <p>{{ page.hero_text | markdownify }}</p>
-
             {{ content }}
-
-            {% if page.prev_page or page.next_page %}
-              <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
-                {% if page.prev_page %}
-                  <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ page.prev_page.title }}</a>
-                {% endif %}
-                {% if page.next_page %}
-                  <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ page.next_page.title }} &rsaquo;</a>
-                {% endif %}
-              </div>
-            {% endif %}
+            {%- include pagination.html -%}
           </div>
         </div>
       </main>

--- a/docs/_layouts/standard.html
+++ b/docs/_layouts/standard.html
@@ -26,7 +26,19 @@
           </aside>
           <div class="content main-content">
             <p>{{ page.hero_text | markdownify }}</p>
+
             {{ content }}
+
+            {% if page.prev_page or page.next_page %}
+              <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
+                {% if page.prev_page %}
+                  <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ page.prev_page.title }}</a>
+                {% endif %}
+                {% if page.next_page %}
+                  <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ page.next_page.title }} &rsaquo;</a>
+                {% endif %}
+              </div>
+            {% endif %}
           </div>
         </div>
       </main>

--- a/docs/spec/v0.1/faq.md
+++ b/docs/spec/v0.1/faq.md
@@ -1,6 +1,9 @@
 ---
 title: Frequently Asked Questions
 layout: specifications
+prev_page:
+    title: Threats and mitigations
+    url: threats
 ---
 
 ## Q: Why is SLSA not transitive?

--- a/docs/spec/v0.1/index.md
+++ b/docs/spec/v0.1/index.md
@@ -1,5 +1,8 @@
 ---
 title: Introduction
+next_page:
+    title: Terminology
+    url: terminology
 layout: standard
 hero_text: SLSA is a set of standards and technical controls you can adopt to improve artifact integrity, and build towards completely resilient systems. It’s not a single tool, but a step-by-step outline to prevent artifacts being tampered with and tampered artifacts from being used, and at the higher levels, hardening up the platforms that make up a supply chain. These requirements are explained below, along with the rest of the essential specifications.
 stages:

--- a/docs/spec/v0.1/levels.md
+++ b/docs/spec/v0.1/levels.md
@@ -1,5 +1,11 @@
 ---
 title: Security levels
+prev_page:
+  title: Terminology
+  url: terminology
+next_page:
+  title: Requirements
+  url: requirements
 ---
 <div class="subtitle">
 

--- a/docs/spec/v0.1/requirements.md
+++ b/docs/spec/v0.1/requirements.md
@@ -1,5 +1,11 @@
 ---
 title: Requirements
+prev_page:
+    title: Security levels
+    url: levels
+next_page:
+    title: Threats and mitigations
+    url: threats
 ---
 <div class="subtitle">
 

--- a/docs/spec/v0.1/terminology.md
+++ b/docs/spec/v0.1/terminology.md
@@ -1,5 +1,11 @@
 ---
 title: Terminology
+prev_page:
+  title: Introduction
+  url: ./
+next_page:
+  title: Security levels
+  url: levels
 ---
 <div class="subtitle">
 

--- a/docs/spec/v0.1/threats.md
+++ b/docs/spec/v0.1/threats.md
@@ -1,5 +1,11 @@
 ---
 title: Threats and mitigations
+prev_page:
+    title: Requirements
+    url: requirements
+next_page:
+    title: Frequently Asked Questions
+    url: faq
 ---
 <div class="subtitle">
 

--- a/docs/spec/v1.0-rc1/faq.md
+++ b/docs/spec/v1.0-rc1/faq.md
@@ -1,6 +1,12 @@
 ---
 title: Frequently Asked Questions
 layout: specifications
+prev_page:
+  title: Threats and mitigations
+  url: threats
+next_page:
+  title: Future directions
+  url: future-directions
 ---
 
 ## Q: Why is SLSA not transitive?

--- a/docs/spec/v1.0-rc1/future-directions.md
+++ b/docs/spec/v1.0-rc1/future-directions.md
@@ -1,3 +1,9 @@
+---
+prev_page:
+  title: Frequently Asked Questions
+  url: faq
+---
+
 # Future directions
 
 The initial [draft version (v0.1)] of SLSA had a larger scope including

--- a/docs/spec/v1.0-rc1/index.md
+++ b/docs/spec/v1.0-rc1/index.md
@@ -1,3 +1,9 @@
+---
+next_page:
+  title: Security levels
+  url: levels
+---
+
 # SLSA Specification
 
 <div class="subtitle">

--- a/docs/spec/v1.0-rc1/levels.md
+++ b/docs/spec/v1.0-rc1/levels.md
@@ -1,3 +1,12 @@
+---
+prev_page:
+  title: Introduction
+  url: ./
+next_page:
+  title: Guiding principles
+  url: principles
+---
+
 # Security levels
 
 <div class="subtitle">

--- a/docs/spec/v1.0-rc1/principles.md
+++ b/docs/spec/v1.0-rc1/principles.md
@@ -1,3 +1,12 @@
+---
+prev_page:
+  title: Security levels
+  url: levels
+next_page:
+  title: Terminology
+  url: terminology
+---
+
 # Guiding principles
 
 <div class="subtitle">

--- a/docs/spec/v1.0-rc1/requirements.md
+++ b/docs/spec/v1.0-rc1/requirements.md
@@ -1,6 +1,13 @@
 ---
 title: Producing artifacts
+prev_page:
+  title: Terminology
+  url: terminology
+next_page:
+  title: Verifying Build Systems
+  url: verifying-systems
 ---
+
 <div class="subtitle">
 
 This page covers the detailed technical requirements for producing artifacts at

--- a/docs/spec/v1.0-rc1/terminology.md
+++ b/docs/spec/v1.0-rc1/terminology.md
@@ -1,6 +1,13 @@
 ---
 title: Terminology
+prev_page:
+  title: Guiding principles
+  url: principles
+next_page:
+  title: Producing artifacts
+  url: requirements
 ---
+
 <div class="subtitle">
 
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set

--- a/docs/spec/v1.0-rc1/threats.md
+++ b/docs/spec/v1.0-rc1/threats.md
@@ -1,6 +1,13 @@
 ---
 title: Threats and mitigations
+prev_page:
+  title: Verifying Build Systems
+  url: verifying-systems
+next_page:
+  title: Frequently Asked Questions
+  url: faq
 ---
+
 <div class="subtitle">
 
 Attacks can occur at every link in a typical software supply chain, and these

--- a/docs/spec/v1.0-rc1/verifying-systems.md
+++ b/docs/spec/v1.0-rc1/verifying-systems.md
@@ -1,3 +1,12 @@
+---
+prev_page:
+  title: Producing artifacts
+  url: requirements
+next_page:
+  title: Threats and mitigations
+  url: threats
+---
+
 # Verifying Build Systems
 
 The provenance consumer is responsible for deciding whether they trust a builder to produce SLSA Build L3 provenance. However, assessing Build L3 capabilities requires information about a builder's construction and operating procedures that the consumer cannot glean from the provenance itself. To aid with such assessments, we provide a common threat model and builder model for reasoning about builders' security. We also provide a questionnaire that organizations can use to describe their builders to consumers along with sample answers that do and do not satisfy the SLSA Build L3 requirements.

--- a/docs/spec/v1.0/faq.md
+++ b/docs/spec/v1.0/faq.md
@@ -1,6 +1,12 @@
 ---
 title: Frequently Asked Questions
 layout: specifications
+prev_page:
+  title: Threats and mitigations
+  url: threats
+next_page:
+  title: Future directions
+  url: future-directions
 ---
 
 ## Q: Why is SLSA not transitive?

--- a/docs/spec/v1.0/future-directions.md
+++ b/docs/spec/v1.0/future-directions.md
@@ -1,3 +1,9 @@
+---
+prev_page:
+  title: Frequently Asked Questions
+  url: faq
+---
+
 # Future directions
 
 The initial [draft version (v0.1)] of SLSA had a larger scope including

--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -1,3 +1,9 @@
+---
+next_page:
+  title: What's New in SLSA v1.0
+  url: whats-new
+---
+
 # SLSA Specification
 
 <div class="subtitle">

--- a/docs/spec/v1.0/levels.md
+++ b/docs/spec/v1.0/levels.md
@@ -1,3 +1,12 @@
+---
+prev_page:
+  title: What's New in SLSA v1.0
+  url: whats-new
+next_page:
+  title: Guiding principles
+  url: principles
+---
+
 # Security levels
 
 <div class="subtitle">

--- a/docs/spec/v1.0/principles.md
+++ b/docs/spec/v1.0/principles.md
@@ -1,3 +1,12 @@
+---
+prev_page:
+  title: Security levels
+  url: levels
+next_page:
+  title: Terminology
+  url: terminology
+---
+
 # Guiding principles
 
 <div class="subtitle">

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -1,6 +1,13 @@
 ---
 title: Producing artifacts
+prev_page:
+  title: Terminology
+  url: terminology
+next_page:
+  title: Verifying Build Systems
+  url: verifying-systems
 ---
+
 <div class="subtitle">
 
 This page covers the detailed technical requirements for producing artifacts at

--- a/docs/spec/v1.0/terminology.md
+++ b/docs/spec/v1.0/terminology.md
@@ -1,6 +1,13 @@
 ---
 title: Terminology
+prev_page:
+  title: Guiding principles
+  url: principles
+next_page:
+  title: Producing artifacts
+  url: requirements
 ---
+
 <div class="subtitle">
 
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -1,6 +1,13 @@
 ---
 title: Threats and mitigations
+prev_page:
+  title: Verifying Build Systems
+  url: verifying-systems
+next_page:
+  title: Frequently Asked Questions
+  url: faq
 ---
+
 <div class="subtitle">
 
 Attacks can occur at every link in a typical software supply chain, and these

--- a/docs/spec/v1.0/verifying-systems.md
+++ b/docs/spec/v1.0/verifying-systems.md
@@ -1,3 +1,12 @@
+---
+prev_page:
+  title: Producing artifacts
+  url: requirements
+next_page:
+  title: Threats and mitigations
+  url: threats
+---
+
 # Verifying Build Systems
 
 The provenance consumer is responsible for deciding whether they trust a builder to produce SLSA Build L3 provenance. However, assessing Build L3 capabilities requires information about a builder's construction and operating procedures that the consumer cannot glean from the provenance itself. To aid with such assessments, we provide a common threat model and builder model for reasoning about builders' security. We also provide a questionnaire that organizations can use to describe their builders to consumers along with sample answers that do and do not satisfy the SLSA Build L3 requirements.

--- a/docs/spec/v1.0/whats-new.md
+++ b/docs/spec/v1.0/whats-new.md
@@ -1,3 +1,12 @@
+---
+prev_page:
+  title: Introduction
+  url: ./
+next_page:
+  title: Security levels
+  url: levels
+---
+
 # What's New in SLSA v1.0
 
 SLSA v1.0 represents changes made in response to feedback from the SLSA


### PR DESCRIPTION
- Added `prev_page` and `next_page` config to each spec page `.md` file (across all versions)
- Added logic to output links in `standard`, `default` and `specifications` layout templates

### Please Note...
- This has been done in a more manual/hardcoded way to ensure the flexibility needed to name/link to all spec pages. It could technically be done using Jeykell "Collections" and a more dynamic implimentation, but doing so would mean a larger rework of the folder structure and would be impacted by the current method of versioning. This hardcoded method seemed the safer option in the short term
- We have taken the order of pages in versions `1.0` and `1.0-rc1` from that shown in their respective `onepage` templates
- Both `1.0` and `1.0-rc1` specs have pages in their directories which don't appear in the `onepage` versions, so we have left them out for now (please feel free to add them in in the correct order if needed):
 - `1.0`: `verifying-artifacts`
 - `1.0-rc1`: `verifying-artifacts`, `whats-new`