### PR TITLE
Automatically render first paragraph as "subtitle"

### DIFF
--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -216,16 +216,10 @@ h5, .h5 {
     font-family: $header-font-family;
 }
 
-.subtitle {
-    display: block;
-    padding-bottom: 3rem;
+// Make the first paragraph of a page have bigger font.
+// To opt out, make sure the first element is not a `<p>` tag.
+.content > p:first-child {
     font-size: $subtitle-font-size;
-
-    // For making subtitles hug closely above headers
-    &.flushed {
-        padding-bottom: 0;
-        margin-bottom: -3rem;
-    }
 }
 
 .markdown {

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -3,15 +3,10 @@ title: Software attestations
 layout: specifications
 ---
 
-<div class="subtitle">
-
 A software attestation is an authenticated statement (metadata) about a
 software artifact or collection of software artifacts.
-
 The primary intended use case is to feed into automated policy engines, such as
 [in-toto] and [Binary Authorization].
-
-</div>
 
 This page provides a high-level overview of the attestation model, including
 standardized terminology, data model, layers, and conventions for software

--- a/docs/spec/v0.1/levels.md
+++ b/docs/spec/v0.1/levels.md
@@ -7,14 +7,11 @@ next_page:
   title: Requirements
   url: requirements
 ---
-<div class="subtitle">
 
 SLSA is organized into a series of levels that provide increasing
 [integrity](terminology.md) guarantees. This gives you confidence that
 software hasn’t been tampered with and can be securely traced back to its
 source.
-
-</div>
 
 This page is an informative overview of the SLSA levels, describing their
 purpose and guarantees. For the normative requirements at each level, see

--- a/docs/spec/v0.1/requirements.md
+++ b/docs/spec/v0.1/requirements.md
@@ -7,12 +7,8 @@ next_page:
     title: Threats and mitigations
     url: threats
 ---
-<div class="subtitle">
-
 This page covers all of the technical requirements for an artifact to meet the
 [SLSA Levels](levels.md).
-
-</div>
 
 For background, see [Introduction](index.md) and [Terminology](terminology.md).
 To better understand the reasoning behind the requirements, see

--- a/docs/spec/v0.1/terminology.md
+++ b/docs/spec/v0.1/terminology.md
@@ -7,12 +7,8 @@ next_page:
   title: Security levels
   url: levels
 ---
-<div class="subtitle">
-
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set
 of terminology and models to describe what we're protecting.
-
-</div>
 
 ## Software supply chain
 

--- a/docs/spec/v0.1/threats.md
+++ b/docs/spec/v0.1/threats.md
@@ -7,13 +7,9 @@ next_page:
     title: Frequently Asked Questions
     url: faq
 ---
-<div class="subtitle">
-
 Attacks can occur at every link in a typical software supply chain, and these
 kinds of attacks are increasingly public, disruptive, and costly in today's
 environment.
-
-</div>
 
 SLSA's [levels](levels.md) are designed to mitigate the risk of these attacks.
 This page enumerates possible attacks throughout the supply chain and shows how

--- a/docs/spec/v1.0-rc1/index.md
+++ b/docs/spec/v1.0-rc1/index.md
@@ -6,13 +6,9 @@ next_page:
 
 # SLSA Specification
 
-<div class="subtitle">
-
 SLSA is a specification for describing and incrementally improving supply chain
 security, established by industry consensus. It is organized into a series of
 levels that describe increasing security guarantees.
-
-</div>
 
 This is **version 1.0-rc1** of the SLSA specification, which defines the SLSA
 levels. For other versions, use the chooser <span class="hidden md:inline">to

--- a/docs/spec/v1.0-rc1/levels.md
+++ b/docs/spec/v1.0-rc1/levels.md
@@ -9,13 +9,9 @@ next_page:
 
 # Security levels
 
-<div class="subtitle">
-
 SLSA is organized into a series of levels that provide increasing supply chain
 security guarantees. This gives you confidence that software hasn’t been
 tampered with and can be securely traced back to its source.
-
-</div>
 
 This page is an informative overview of the SLSA levels, describing their
 purpose and guarantees. For the normative requirements at each level, see

--- a/docs/spec/v1.0-rc1/principles.md
+++ b/docs/spec/v1.0-rc1/principles.md
@@ -9,12 +9,8 @@ next_page:
 
 # Guiding principles
 
-<div class="subtitle">
-
 This page provides a background on the guiding principles behind SLSA. It is
 intended to help the reader better understand SLSA's design decisions.
-
-</div>
 
 ## Trust systems, verify artifacts
 

--- a/docs/spec/v1.0-rc1/requirements.md
+++ b/docs/spec/v1.0-rc1/requirements.md
@@ -8,13 +8,9 @@ next_page:
   url: verifying-systems
 ---
 
-<div class="subtitle">
-
 This page covers the detailed technical requirements for producing artifacts at
 each SLSA level. The intended audience is system implementers and security
 engineers.
-
-</div>
 
 For an informative description of the levels intended for all audiences, see
 [Levels](levels.md). For background, see [Terminology](terminology.md). To

--- a/docs/spec/v1.0-rc1/terminology.md
+++ b/docs/spec/v1.0-rc1/terminology.md
@@ -8,12 +8,8 @@ next_page:
   url: requirements
 ---
 
-<div class="subtitle">
-
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set
 of terminology and models to describe what we're protecting.
-
-</div>
 
 ## TODO: Terms we still need to define
 

--- a/docs/spec/v1.0-rc1/threats.md
+++ b/docs/spec/v1.0-rc1/threats.md
@@ -8,13 +8,9 @@ next_page:
   url: faq
 ---
 
-<div class="subtitle">
-
 Attacks can occur at every link in a typical software supply chain, and these
 kinds of attacks are increasingly public, disruptive, and costly in today's
 environment.
-
-</div>
 
 SLSA's [levels](levels.md) are designed to mitigate the risk of these attacks.
 This page enumerates possible attacks throughout the supply chain and shows how

--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -6,13 +6,9 @@ next_page:
 
 # SLSA Specification
 
-<div class="subtitle">
-
 SLSA is a specification for describing and incrementally improving supply chain
 security, established by industry consensus. It is organized into a series of
 levels that describe increasing security guarantees.
-
-</div>
 
 This is **version 1.0** of the SLSA specification, which defines the SLSA
 levels. For other versions, use the chooser <span class="hidden md:inline">to

--- a/docs/spec/v1.0/levels.md
+++ b/docs/spec/v1.0/levels.md
@@ -9,13 +9,9 @@ next_page:
 
 # Security levels
 
-<div class="subtitle">
-
 SLSA is organized into a series of levels that provide increasing supply chain
 security guarantees. This gives you confidence that software hasn’t been
 tampered with and can be securely traced back to its source.
-
-</div>
 
 This page is an informative overview of the SLSA levels, describing their
 purpose and guarantees. For the normative requirements at each level, see

--- a/docs/spec/v1.0/principles.md
+++ b/docs/spec/v1.0/principles.md
@@ -9,12 +9,8 @@ next_page:
 
 # Guiding principles
 
-<div class="subtitle">
-
 This page describes the guiding principles behind SLSA's design
 decisions.
-
-</div>
 
 ## Trust systems, verify artifacts
 

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -8,13 +8,9 @@ next_page:
   url: verifying-systems
 ---
 
-<div class="subtitle">
-
 This page covers the detailed technical requirements for producing artifacts at
 each SLSA level. The intended audience is system implementers and security
 engineers.
-
-</div>
 
 For an informative description of the levels intended for all audiences, see
 [Levels](levels.md). For background, see [Terminology](terminology.md). To

--- a/docs/spec/v1.0/terminology.md
+++ b/docs/spec/v1.0/terminology.md
@@ -8,12 +8,8 @@ next_page:
   url: requirements
 ---
 
-<div class="subtitle">
-
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set
 of terminology and models to describe what we're protecting.
-
-</div>
 
 ## TODO: Terms we still need to define
 

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -8,13 +8,9 @@ next_page:
   url: faq
 ---
 
-<div class="subtitle">
-
 Attacks can occur at every link in a typical software supply chain, and these
 kinds of attacks are increasingly public, disruptive, and costly in today's
 environment.
-
-</div>
 
 SLSA's [levels](levels.md) are designed to mitigate the risk of these attacks.
 This page enumerates possible attacks throughout the supply chain and shows how


### PR DESCRIPTION
Previously, many pages started with a `<div class="subtitle">` that rendered the first paragraph in larger font, to give an overview of the page. But this was not used consistently since some pages forgot the tag.

Now the first paragraph is always rendered larger (using CSS selectors) without need for the tag. This makes the source easier to maintain and also makes the site more consistent.
