### PR TITLE
Use `gitCommit` instead of `sha1` in provenance

### DIFF
--- a/docs/github-actions-workflow/examples/v1/example.json
+++ b/docs/github-actions-workflow/examples/v1/example.json
@@ -1,4 +1,5 @@
 {
+    "_type": "https://in-toto.io/Statement/v1?draft",
     "predicateType": "https://slsa.dev/provenance/v1?draft",
     "predicate": {
         "buildDefinition": {
@@ -27,7 +28,7 @@
             "resolvedDependencies": [
                 {
                     "uri": "git+https://github.com/octocat/hello-world@refs/heads/main",
-                    "digest": { "sha1": "c27d339ee6075c1f744c5d4b200f7901aad2c369" }
+                    "digest": { "gitCommit": "c27d339ee6075c1f744c5d4b200f7901aad2c369" }
                 },
                 {
                     "uri": "https://github.com/actions/virtual-environments/releases/tag/ubuntu20/20220515.1"

--- a/docs/provenance/schema/v1/provenance.cue
+++ b/docs/provenance/schema/v1/provenance.cue
@@ -33,8 +33,7 @@
     "digest": {
         "sha256": string,
         "sha512": string,
-        "sha1": string,
-        // TODO: list the other standard algorithms
+        "gitCommit": string,
         [string]: string,
     },
     "name": string,

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -225,7 +225,7 @@ how to convert from a parameter to the dependency `uri`. For example:
 },
 "resolvedDependencies": [{
     "uri": "git+https://github.com/octocat/hello-world@refs/heads/main",
-    "digest": {"sha1": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"}
+    "digest": {"gitCommit": "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d"}
 }]
 ```
 


### PR DESCRIPTION
In in-toto Statement v1, a new `gitCommit` algorithm was added as a more specific algorithm instead of `sha1`. Use this in our provenance format and examples.

Also add missing `_type` field to the example provenance file.
