### PR TITLE
Combine ephemeral and isolated to isolated

### DIFF
--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -60,7 +60,7 @@ Responsibility to implement SLSA is spread across the following parties.
   <td><a href="#build-service">Build service</a>
   <td> <td>✓<td>✓
 <tr>
-  <td><a href="#ephemeral-isolated">Ephemeral and isolated</a>
+  <td><a href="#isolated">Isolated</a>
   <td> <td> <td>✓
 </table>
 
@@ -262,23 +262,48 @@ workstation.
 Examples: GitHub Actions, Google Cloud Build, Travis CI.
 
 <td> <td>✓<td>✓
-<tr id="ephemeral-isolated">
-<td>Ephemeral and isolated
+<tr id="isolated">
+<td>Isolated
 <td>
 
-The build service ensured that the build steps ran in an ephemeral and isolated
-environment provisioned solely for this build, free of influence from other
-build instances, whether prior or concurrent.
+The build service ensured that the build steps ran in an isolated environment,
+free of unintended external influence. In other words, any external influence on
+the build was specifically requested by the build itself. This MUST hold true
+even between builds within the same tenant project.
 
--   It MUST NOT be possible for a build to access any secrets of the build service, such as the provenance signing key.
--   It MUST NOT be possible for two builds that overlap in time to influence one another.
--   It MUST NOT be possible for one build to persist or influence the build environment of a subsequent build.
--   Build caches, if used, MUST be purely content-addressable to prevent tampering.
--   The build SHOULD NOT call out to remote execution unless it's considered part of the "builder" within the trust boundary.
--   The build SHOULD NOT open services that allow for remote influence.
+The build system MUST guarantee the following:
 
-Note: This requirement was split into "Isolated" and "Ephemeral Environment"
+-   It MUST NOT be possible for a build to access any secrets of the build
+    service, such as the provenance signing key, because doing so would
+    compromise the authenticity of the provenance.
+-   It MUST NOT be possible for two builds that overlap in time to influence one
+    another, such as by altering the memory of a different build process running
+    on the same machine.
+-   It MUST NOT be possible for one build to persist or influence the build
+    environment of a subsequent build. In other words, an ephemeral build
+    environment MUST be provisioned for each build.
+-   It MUST NOT be possible for one build to inject false entries into a build
+    cache used by another build, also known as "cache poisoning". In other
+    words, the output of the build MUST be identical whether or not the cache is
+    used.
+-   The build system MUST NOT open services that allow for remote influence
+    unless all such interactions are captured as `externalParameters` in the
+    provenance.
+
+There are no sub-requirements on the build itself. Build L3 is limited to
+ensuring that a well-intentioned build runs securely. It does not require that
+build systems prevent a producer from performing a risky or insecure build. In
+particular, the "Isolated" requirement does not prohibit a build from calling
+out to a remote execution service or a "self-hosted runner" that is outside the
+trust boundary of the build platform.
+
+NOTE: This requirement was split into "Isolated" and "Ephemeral Environment"
 in the initial [draft version (v0.1)](../v0.1/requirements.md).
+
+NOTE: This requirement is not to be confused with "Hermetic", which roughly
+means that the build ran with no network access. Such a requirement requires
+substantial changes to both the build system and each individual build, and is
+considered in the [future directions](future-directions.md).
 
 <td> <td> <td>✓
 </table>

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -386,33 +386,25 @@ provenance.
 
 These threats are directly addressed by the SLSA Build track.
 
-<details><summary>Compromise build environment of subsequent build <span>(Build L3)</span></summary>
-
-*Threat:* Perform a "bad" build that persists a change in the build environment,
-then run a subsequent "good" build using that environment.
-
-*Mitigation:* Builder ensures that each build environment is [ephemeral], with
-no way to persist changes between subsequent builds.
-
-*Example:* Build service uses the same machine for subsequent builds. Adversary
-first runs a build that replaces the `make` binary with a malicious version,
-then runs a subsequent build that otherwise would pass expectations. Solution:
-Builder changes architecture to start each build with a clean machine image.
-
-</details>
-<details><summary>Compromise parallel build <span>(Build L3)</span></summary>
+<details><summary>Compromise other build <span>(Build L3)</span></summary>
 
 *Threat:* Perform a "bad" build that alters the behavior of another "good" build
-running in parallel.
+running in parallel or subsequent environments.
 
 *Mitigation:* Builds are [isolated] from one another, with no way for one to
-affect the other.
+affect the other or persist changes.
 
-*Example:* Build service runs all builds for project MyPackage on the same
-machine as the same Linux user. Adversary starts a "bad" build that listens for
-the "good" build and swaps out source files, then starts a "good" build that
-would otherwise pass expectations. Solution: Builder changes architecture to
-isolate each build in a separate VM or similar.
+*Example 1:* Build service runs all builds for project MyPackage on
+the same machine as the same Linux user. Adversary starts a "bad" build that
+listens for the "good" build and swaps out source files, then starts a "good"
+build that would otherwise pass expectations. Solution: Builder changes
+architecture to isolate each build in a separate VM or similar.
+
+*Example 2:* Build service uses the same machine for subsequent
+builds. Adversary first runs a build that replaces the `make` binary with a
+malicious version, then runs a subsequent build that otherwise would pass
+expectations. Solution: Builder changes architecture to start each build with a
+clean machine image.
 
 </details>
 <details><summary>Steal cryptographic secrets <span>(Build L3)</span></summary>
@@ -663,9 +655,8 @@ accept cryptographic hashes with strong collision resistance.
 <!-- Links -->
 
 [authentic]: requirements.md#provenance-authentic
-[ephemeral]: requirements.md#ephemeral-isolated
 [exists]: requirements.md#provenance-exists
-[isolated]: requirements.md#ephemeral-isolated
+[isolated]: requirements.md#isolated
 [non-forgeable]: requirements.md#provenance-non-forgeable
 [service]: requirements.md#build-service
 [supply-chain threats]: threats-overview


### PR DESCRIPTION
In order to help reduce confusion around ephemeral and isolated properties, these have been merged into a single isolated property. Additional clarity is added to the isolated build requirement, relating it to the previous hermetic requirement.

Relates to #657

Fixes #291 by being more specific around build caches.

Fixes #321 and addresses comments about self-hosted GitHub runners

Some content taken from https://github.com/slsa-framework/slsa/pull/685#discussion_r1140522178 by @MarkLodato.