### PR TITLE
Fix pagination

### DIFF
--- a/docs/_includes/pagination.html
+++ b/docs/_includes/pagination.html
@@ -1,10 +1,32 @@
 {% if page.prev_page or page.next_page %}
   <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
+    {%- assign url_parts = page.url | split: '/' %}
     {% if page.prev_page %}
-      <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ page.prev_page.title }}</a>
+    {%- if page.prev_page.url == "index" %}
+       {%- assign prevurl = page.url | replace: url_parts[-1], "" -%}
+    {% else %}
+       {%- assign prevurl = page.url | replace: url_parts[-1], page.prev_page.url -%}
     {% endif %}
+    {%- capture pattern %}page.url == "{{prevurl}}"{% endcapture -%}
+       {%- assign thepage = site.pages | where_exp: "page", pattern | first -%}
+       {%- if thepage.name == "index.md" %}
+          <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ thepage.title }}</a>
+       {%- else -%}
+          <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ thepage.title }}</a>
+       {%- endif %}
+    {%- endif %}
     {% if page.next_page %}
-      <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ page.next_page.title }} &rsaquo;</a>
-    {% endif %}
+       {%- if page.name == "index.md" %}
+          {%- assign nexturl = page.url | append: page.next_page.url -%}
+          {%- capture pattern %}page.url == "{{nexturl}}"{% endcapture -%}
+          {%- assign thepage = site.pages | where_exp: "page", pattern | first -%}
+          <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ thepage.title }} &rsaquo;</a>
+       {%- else -%}
+          {%- assign nexturl = page.url | replace: url_parts[-1], page.next_page.url -%}
+          {%- capture pattern %}page.url == "{{nexturl}}"{% endcapture -%}
+          {%- assign thepage = site.pages | where_exp: "page", pattern | first -%}
+          <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ thepage.title }} &rsaquo;</a>
+       {%- endif %}
+    {%- endif %}
   </div>
 {% endif %}

--- a/docs/_includes/pagination.html
+++ b/docs/_includes/pagination.html
@@ -2,31 +2,24 @@
   <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
     {%- assign url_parts = page.url | split: '/' %}
     {% if page.prev_page %}
-    {%- if page.prev_page.url == "index" %}
-       {%- assign prevurl = page.url | replace: url_parts[-1], "" -%}
-    {% else %}
-       {%- assign prevurl = page.url | replace: url_parts[-1], page.prev_page.url -%}
-    {% endif %}
-    {%- capture pattern %}page.url == "{{prevurl}}"{% endcapture -%}
-       {%- assign thepage = site.pages | where_exp: "page", pattern | first -%}
-       {%- if thepage.name == "index.md" %}
-          <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ thepage.title }}</a>
-       {%- else -%}
-          <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ thepage.title }}</a>
-       {%- endif %}
+        {%- if page.prev_page.url == "index" %}
+            {%- assign prevurl = page.url | replace: url_parts[-1], "" -%}
+        {% else %}
+            {%- assign prevurl = page.url | replace: url_parts[-1], page.prev_page.url -%}
+        {% endif %}
+        {%- capture pattern %}page.url == "{{prevurl}}"{% endcapture -%}
+        {%- assign prevpage = site.pages | where_exp: "page", pattern | first -%}
+        <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ prevpage.title }}</a>
     {%- endif %}
     {% if page.next_page %}
-       {%- if page.name == "index.md" %}
-          {%- assign nexturl = page.url | append: page.next_page.url -%}
-          {%- capture pattern %}page.url == "{{nexturl}}"{% endcapture -%}
-          {%- assign thepage = site.pages | where_exp: "page", pattern | first -%}
-          <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ thepage.title }} &rsaquo;</a>
-       {%- else -%}
-          {%- assign nexturl = page.url | replace: url_parts[-1], page.next_page.url -%}
-          {%- capture pattern %}page.url == "{{nexturl}}"{% endcapture -%}
-          {%- assign thepage = site.pages | where_exp: "page", pattern | first -%}
-          <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ thepage.title }} &rsaquo;</a>
-       {%- endif %}
+        {%- if page.name == "index.md" %}
+            {%- assign nexturl = page.url | append: page.next_page.url -%}
+        {%- else -%}
+            {%- assign nexturl = page.url | replace: url_parts[-1], page.next_page.url -%}
+        {%- endif %}
+        {%- capture pattern %}page.url == "{{nexturl}}"{% endcapture -%}
+        {%- assign nextpage = site.pages | where_exp: "page", pattern | first -%}
+        <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ nextpage.title }} &rsaquo;</a>
     {%- endif %}
   </div>
 {% endif %}

--- a/docs/spec/v0.1/faq.md
+++ b/docs/spec/v0.1/faq.md
@@ -2,7 +2,6 @@
 title: Frequently Asked Questions
 layout: specifications
 prev_page:
-    title: Threats and mitigations
     url: threats
 ---
 

--- a/docs/spec/v0.1/index.md
+++ b/docs/spec/v0.1/index.md
@@ -1,7 +1,6 @@
 ---
 title: Introduction
 next_page:
-    title: Terminology
     url: terminology
 layout: standard
 stages:

--- a/docs/spec/v0.1/levels.md
+++ b/docs/spec/v0.1/levels.md
@@ -1,10 +1,8 @@
 ---
 title: Security levels
 prev_page:
-  title: Terminology
   url: terminology
 next_page:
-  title: Requirements
   url: requirements
 ---
 

--- a/docs/spec/v0.1/requirements.md
+++ b/docs/spec/v0.1/requirements.md
@@ -1,10 +1,8 @@
 ---
 title: Requirements
 prev_page:
-    title: Security levels
     url: levels
 next_page:
-    title: Threats and mitigations
     url: threats
 ---
 This page covers all of the technical requirements for an artifact to meet the

--- a/docs/spec/v0.1/terminology.md
+++ b/docs/spec/v0.1/terminology.md
@@ -1,10 +1,8 @@
 ---
 title: Terminology
 prev_page:
-  title: Introduction
-  url: ./
+  url: index
 next_page:
-  title: Security levels
   url: levels
 ---
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set

--- a/docs/spec/v0.1/threats.md
+++ b/docs/spec/v0.1/threats.md
@@ -1,10 +1,8 @@
 ---
 title: Threats and mitigations
 prev_page:
-    title: Requirements
     url: requirements
 next_page:
-    title: Frequently Asked Questions
     url: faq
 ---
 Attacks can occur at every link in a typical software supply chain, and these

--- a/docs/spec/v1.0/faq.md
+++ b/docs/spec/v1.0/faq.md
@@ -1,10 +1,8 @@
 ---
 layout: specifications
 prev_page:
-  title: Supply-chain threats
   url:  threats-overview
 next_page:
-  title: Future directions
   url: future-directions
 ---
 # FAQ

--- a/docs/spec/v1.0/future-directions.md
+++ b/docs/spec/v1.0/future-directions.md
@@ -1,9 +1,7 @@
 ---
 prev_page:
-  title: Frequently Asked Questions
   url: faq
 next_page:
-  title: Terminology
   url: terminology
 ---
 

--- a/docs/spec/v1.0/levels.md
+++ b/docs/spec/v1.0/levels.md
@@ -1,9 +1,7 @@
 ---
 prev_page:
-  title: Terminology
   url: terminology
 next_page:
-  title: Producing artifacts
   url: requirements
 ---
 

--- a/docs/spec/v1.0/onepage.md
+++ b/docs/spec/v1.0/onepage.md
@@ -6,6 +6,6 @@ A single page containing all the following files as different sections
 {%- endcomment -%}
 
 {% assign dir = "/spec/v1.0/" %}
-{% assign filenames = "whats-new,levels,principles,terminology,requirements,verifying-systems,threats,faq,future-directions" %}
+{% assign filenames = "whats-new,principles,threats-overview,faq,future-directions,terminology,levels,requirements,verifying-systems,verifying-artifacts,threats" %}
 
 {% include onepage.liquid dir=dir filenames=filenames %}

--- a/docs/spec/v1.0/principles.md
+++ b/docs/spec/v1.0/principles.md
@@ -1,9 +1,7 @@
 ---
 prev_page:
-  title: What's new in SLSA v1.0
   url: whats-new
 next_page:
-  title: Supply-chain threats
   url: threats-overview
 ---
 

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -1,9 +1,7 @@
 ---
 prev_page:
-  title: Security levels
   url: levels
 next_page:
-  title: Verifying build systems
   url: verifying-systems
 ---
 

--- a/docs/spec/v1.0/terminology.md
+++ b/docs/spec/v1.0/terminology.md
@@ -1,9 +1,7 @@
 ---
 prev_page:
-  title: Future directions
   url: future-directions
 next_page:
-  title: Security levels
   url: levels
 ---
 

--- a/docs/spec/v1.0/threats-overview.md
+++ b/docs/spec/v1.0/threats-overview.md
@@ -1,9 +1,7 @@
 ---
 prev_page:
-  title: About SLSA
   url: principles
 next_page:
-  title: FAQ
   url: faq
 ---
 # Supply-chain threats

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -1,10 +1,6 @@
 ---
 prev_page:
-  title: Verifying artifacts
   url: verifying-artifacts
-next_page:
-  title: 
-  url: 
 ---
 # Threats & mitigations
 

--- a/docs/spec/v1.0/verifying-artifacts.md
+++ b/docs/spec/v1.0/verifying-artifacts.md
@@ -1,9 +1,7 @@
 ---
 prev_page:
-  title: Verifying build systems
-  url: verifying-artifacts
+  url: verifying-systems
 next_page:
-  title: Threats & mitigations
   url: threats
 ---
 # Verifying artifacts

--- a/docs/spec/v1.0/verifying-systems.md
+++ b/docs/spec/v1.0/verifying-systems.md
@@ -1,9 +1,7 @@
 ---
 prev_page:
-  title: Producing artifacts
   url: requirements
 next_page:
-  title: Verifying artifacts
   url: verifying-artifacts
 ---
 

--- a/docs/spec/v1.0/whats-new.md
+++ b/docs/spec/v1.0/whats-new.md
@@ -1,10 +1,8 @@
 ---
 prev_page:
-  title: SLSA v1.0
   url: index
 
 next_page:
-  title: About SLSA
   url: principles
 ---
 


### PR DESCRIPTION
With this change the titles of the pages used in the prev/next pagination links are retrieved directly from the pages themselves so that they don't need to be repeated in the front matter, eliminating a source of error and simplifying maintenance.

It also fixes a few broken pagination links and onepage v1.0 (although not completely).