### PR TITLE
Provenance v1: builder.id should explain itself

### DIFF
--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -339,6 +339,12 @@ security attributes or SLSA Build levels, each mode MUST have a different
 `builder.id` and SHOULD have a different signer identity. This is to minimize
 the risk that a less secure mode compromises a more secure one.
 
+The `builder.id` URI SHOULD resolve to documentation explaining:
+
+-   The scope of what this ID represents.
+-   The claimed SLSA Build level.
+-   The accuracy and completeness guarantees of the fields in the provenance.
+
 <tr id="builder.version"><td><code>version</code>
 <td>map (string→string)<td>
 


### PR DESCRIPTION
Add a recommendation for the `builder.id` URI to resolve to documentation that explains the scope, level, and accuracy of the builder.

Fixes #594.
