### PR TITLE
Add link to GCB definition

### DIFF
--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -614,7 +614,10 @@ basis.
 The following is an partial index of build type definitions. Each contains a
 complete example predicate.
 
+<!-- Sort alphabetically -->
+
 -   [GitHub Actions Workflow (community-maintained)](https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1)
+-   [Google Cloud Build (community-maintained)](https://slsa-framework.github.io/gcb-buildtypes/triggered-build/v1)
 
 To add an entry here, please send a pull request on GitHub.
 


### PR DESCRIPTION
This follows #707 which did the same for GitHub Actions.

Fixes #662.
