### PR TITLE
Make the draft banner more useful.

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -50,7 +50,6 @@
 </header>
 
 {%- assign url_parts = page.url | split: '/' %}
-{%- assign baseurl = url_parts[0] %}
 {%- assign spec_name = url_parts[1] %}
 {%- assign spec_version = url_parts[2] %}
 {%- if site.data.versions[spec_name].versions[spec_version].draft %}
@@ -58,14 +57,9 @@
   <input id="important-messages-checkbox" type="checkbox" hidden>
   <div>
     <label for="important-messages-checkbox" title="dismiss">✕</label>
-    <p>This is an unpublished draft that is subject to change.</p>
-    {%- assign other_version = page.url | replace: spec_version, site.data.versions[spec_name].current %}
-    {%- assign p = site.pages | where_exp: "page", "page.url contains other_version" | first %}
-    {%- comment %}if the page doesn't exist go to the main one{%- endcomment %}
-    {%- unless p %}
-      {%- capture other_version %}{{baseurl}}/{{spec_name}}/{{site.data.versions[spec_name].current}}/{%- endcapture %}
-    {%- endunless %}
-    <p><a href="{{other_version | relative_url}}">View latest published version</a></p>
+    <p>This is a working draft of {{ spec_version }}.</p>
+    <p style="font-size: smaller">For the latest release candidate or approved
+      version, please use the version selector.</p>
   </div>
 </section>
 {%- endif %}


### PR DESCRIPTION
Most readers probably don't want to be taken to the latest approved version, but they might want to select a release candidate (or even know that a release candidate exists). So refer them to the version selector rather than adding a link.

Also display what version it is a draft of, to make it more clear to readers.

I'm thinking that when we send out a call to review v1.0, the current banner would be confusing to people.
