### PR TITLE
Describe SLSA's versioning conventions.

### DIFF
--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -1,8 +1,10 @@
 ---
-title: Specification Stages
+title: Specification Stages and Versioning
 description: SLSA specifications go through various stages of development from which you should have different expectations. This document defines the different stages the SLSA project uses and their meaning for readers and contributors.
 layout: specifications
 ---
+
+## Specification Stages
 
 Specifications go through various stages of development from which you
 should have different expectations. This document defines the different
@@ -13,7 +15,7 @@ Every specification page should prominently display a *Status* section
 stating which stage the specification is in with a link to its
 definition.
 
-## Draft
+### Draft
 
 This is the first stage of development a specification goes
 through. At this point, not much should be expected of it. The
@@ -31,7 +33,7 @@ See the
 for other considerations related to a
 [Draft Specification](https://github.com/slsa-framework/governance/blob/main/1._Community_Specification_License-v1.md).
 
-## Candidate
+### Candidate
 
 At this stage the document is considered to be feature complete and is
 published as a way to invite final reviews. Editorial changes may
@@ -44,7 +46,7 @@ See the
 for other considerations related to a
 [Candidate for Approved Specification](https://github.com/slsa-framework/governance/blob/main/1._Community_Specification_License-v1.md).
 
-## Approved
+### Approved
 
 At this stage the document is considered stable. No changes that would
 constitute a significant departure from the existing specification are
@@ -56,10 +58,28 @@ See the
 for other considerations related to an
 [Approved Specification](https://github.com/slsa-framework/governance/blob/main/1._Community_Specification_License-v1.md).
 
-## Retired
+### Retired
 
 This stage indicates that the specification is no longer maintained.
 It has been either rendered obsolete by a newer version or
 abandoned for some reason. The status of the document may provide
 additional information and point to the new document to use intead if
 there is one.
+
+## Versioning
+
+SLSA uses a variant of [Semantic Versioning](https://www.semvar.org) to assign
+version numbers to the Core Specification and Attestation Formats, collectivly
+known as the SLSA Specification.
+
+Given a version MAJOR.MINOR.PATCH, we will increment
+
+-   MAJOR version when making backwards incompatible changes to the Core
+  Specification.
+-   MINOR version when making backwards compatible changes to the Core
+  Specification.
+-   PATCH version when making changes to the Attestation Formats.
+
+We expect to release a MINOR version at least every three (3) months, and we
+expect to release a MAJOR version at most once per calendar year. We will
+release PTACH versions as often as necessary.

--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -68,18 +68,24 @@ there is one.
 
 ## Versioning
 
-SLSA uses a variant of [Semantic Versioning](https://www.semvar.org) to assign
+SLSA needs revision from time to time, so we version the specification to
+facilitate conformance efforts and prevent confusion. We assign
 version numbers to the Core Specification and Attestation Formats, collectivly
 known as the SLSA Specification.
 
-Given a version MAJOR.MINOR.PATCH, we will increment
-
+Given a version MAJOR.MINOR, we will increment
 -   MAJOR version when making backwards incompatible changes to the Core
-  Specification.
+  Specification. 
 -   MINOR version when making backwards compatible changes to the Core
-  Specification.
--   PATCH version when making changes to the Attestation Formats.
+  Specification, or  when making changes to the Attestation Formats.
 
-We expect to release a MINOR version at least every three (3) months, and we
-expect to release a MAJOR version at most once per calendar year. We will
-release PTACH versions as often as necessary.
+Backwards incompatible changes to the core specification
+include adding a new track and either adding or removing requirements
+from an existing track. All other changes to the Core
+Specification are considered backwards compatible. 
+
+Although we may revise the meaning of level, we will never fundamentally
+change it (e.g. SLSA Build Level 2 will retain its general meaning between
+versions). If you require precision when referring to SLSA levels, then include
+their version number using the syntax "SLSA <Track> <Level> (<Version>)" (e.g.
+"SLSA Build L3 (v1.0)").

--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -70,7 +70,7 @@ there is one.
 
 SLSA needs revision from time to time, so we version the specification to
 facilitate conformance efforts and prevent confusion. We assign a single
-version number to the Core Specification and Attestation Formats, collectivly
+version number to the Core Specification and Attestation Formats, collectively
 known as the SLSA Specification.
 
 Given a version MAJOR.MINOR, we will increment

--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -81,13 +81,13 @@ Given a version MAJOR.MINOR, we will increment
 -   MINOR version when adding new tracks or levels to the Core Specification,
     modifying an existing level without fundamentally changing its meaning, or
     adding new fields to an Attestation Format in a backwards-compatible way.
-    For more details on Attestation Format versioning, see the [intoto
+    For more details on Attestation Format versioning, see the [in-toto
     Versioning Rules](https://github.com/in-toto/attestation/blob/main/spec/versioning.md).
 
 Although we can revise the contents of level, we will never change a level's
 high-level meaning after publication (e.g. SLSA Build Level 2 will retain its
 general meaning between major versions). If you require precision when referring
 to SLSA levels, then include their version number using the syntax `SLSA
-[Track] [Level] ([Version]` (e.g. `SLSA Build L3 (v1.0)`). For more
+[Track] [Level] ([Version])` (e.g. `SLSA Build L3 (v1.0)`). For more
 details on SLSA versioning, see the
 [SLSA v1.0 Proposal](https://github.com/slsa-framework/slsa-proposals/tree/main/0003#versioning).

--- a/docs/spec-stages.md
+++ b/docs/spec-stages.md
@@ -69,23 +69,25 @@ there is one.
 ## Versioning
 
 SLSA needs revision from time to time, so we version the specification to
-facilitate conformance efforts and prevent confusion. We assign
-version numbers to the Core Specification and Attestation Formats, collectivly
+facilitate conformance efforts and prevent confusion. We assign a single
+version number to the Core Specification and Attestation Formats, collectivly
 known as the SLSA Specification.
 
 Given a version MAJOR.MINOR, we will increment
--   MAJOR version when making backwards incompatible changes to the Core
-  Specification. 
--   MINOR version when making backwards compatible changes to the Core
-  Specification, or  when making changes to the Attestation Formats.
 
-Backwards incompatible changes to the core specification
-include adding a new track and either adding or removing requirements
-from an existing track. All other changes to the Core
-Specification are considered backwards compatible. 
+-   MAJOR version when making backwards incompatible changes to an
+    Attestation Format or adding new requirements to an existing level
+    in the Core Specification.
+-   MINOR version when adding new tracks or levels to the Core Specification,
+    modifying an existing level without fundamentally changing its meaning, or
+    adding new fields to an Attestation Format in a backwards-compatible way.
+    For more details on Attestation Format versioning, see the [intoto
+    Versioning Rules](https://github.com/in-toto/attestation/blob/main/spec/versioning.md).
 
-Although we may revise the meaning of level, we will never fundamentally
-change it (e.g. SLSA Build Level 2 will retain its general meaning between
-versions). If you require precision when referring to SLSA levels, then include
-their version number using the syntax "SLSA <Track> <Level> (<Version>)" (e.g.
-"SLSA Build L3 (v1.0)").
+Although we can revise the contents of level, we will never change a level's
+high-level meaning after publication (e.g. SLSA Build Level 2 will retain its
+general meaning between major versions). If you require precision when referring
+to SLSA levels, then include their version number using the syntax `SLSA
+[Track] [Level] ([Version]` (e.g. `SLSA Build L3 (v1.0)`). For more
+details on SLSA versioning, see the
+[SLSA v1.0 Proposal](https://github.com/slsa-framework/slsa-proposals/tree/main/0003#versioning).


### PR DESCRIPTION
This change clarifies when/why SLSA will increment its version number and how users should refer to SLSA levels in context where the version number matters.

Fixes #570