### PR TITLE
Automatically generate next/previous page links

### DIFF
--- a/docs/_data/nav/v0.1.yml
+++ b/docs/_data/nav/v0.1.yml
@@ -25,6 +25,7 @@
 
       - title: Single-page view
         url: /spec/v0.1/onepage
+        skip_next_prev: true  # don't show as a next/prev link
 
     - title: Attestations
       children:

--- a/docs/_data/nav/v0.2.yml
+++ b/docs/_data/nav/v0.2.yml
@@ -25,6 +25,7 @@
 
       - title: Single-page view
         url: /spec/v0.1/onepage
+        skip_next_prev: true  # don't show as a next/prev link
 
     - title: Attestations
       children:

--- a/docs/_data/nav/v1.0-rc1.yml
+++ b/docs/_data/nav/v1.0-rc1.yml
@@ -37,6 +37,7 @@
 
       - title: Single-page view
         url: /spec/v1.0-rc1/onepage
+        skip_next_prev: true  # don't show as a next/prev link
 
     - title: Attestations
       children:

--- a/docs/_data/nav/v1.0.yml
+++ b/docs/_data/nav/v1.0.yml
@@ -114,3 +114,4 @@
 
 - title: Single-page view
   url: /spec/v1.0/onepage
+  skip_next_prev: true  # don't show as a next/prev link

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,6 +1,8 @@
 {%- comment %}
   Look up the nav bar using the version from the URL. We need to assign
   temporary variables because liquid does not support nested []'s.
+
+  Remember to update pagination.html if you update this.
 {%- endcomment %}
 {%- assign url_parts = page.url | split: '/' %}
 {%- assign part_1 = url_parts[1] %}

--- a/docs/_includes/pagination-parse.liquid
+++ b/docs/_includes/pagination-parse.liquid
@@ -1,0 +1,15 @@
+{% comment -%}
+  For each page in `include.collection` (recursively), print:
+    [URL]<ENDURL>[TITLE]<ENDTITLE>
+{% endcomment -%}
+{% for entry in include.collection -%}
+  {% if entry.url and entry.skip_next_prev != true -%}
+    {% assign parts = entry.url | split: '/' -%}
+    {% if parts[1] == include.first_url_part -%}
+      {{entry.url}}<ENDURL>{{entry.title}}<ENDTITLE>
+    {%- endif -%}
+  {% endif -%}
+  {% if entry.children -%}
+    {% include pagination-parse.liquid first_url_part=part_1 collection=entry.children -%}
+  {% endif -%}
+{% endfor -%}

--- a/docs/_includes/pagination.html
+++ b/docs/_includes/pagination.html
@@ -1,25 +1,46 @@
-{% if page.prev_page or page.next_page %}
+{%- comment %}Render next/previous links based on the nav bar.{% endcomment %}
+
+{%- comment %}This chunk is copied from nav.html; it should be kept in sync.{%- endcomment %}
+{%- assign url_parts = page.url | split: '/' %}
+{%- assign part_1 = url_parts[1] %}
+{%- assign part_2 = url_parts[2] %}
+{%- assign key = site.data.nav.config.url_to_key[part_1]
+      | default: site.data.nav.config.url_to_key[part_2]
+      | default: site.data.nav.config.url_to_key["latest"] %}
+{%- assign nav = site.data.nav[key] %}
+
+{%- comment %}matching_pages = array of "[URL] [TITLE]"{% endcomment %}
+{%- capture matching_pages_newline_separated %}
+{%- include pagination-parse.liquid first_url_part=part_1 collection=nav %}
+{%- endcapture %}
+{%- assign matching_pages = matching_pages_newline_separated | split: "<ENDTITLE>" %}
+
+{%- for entry in matching_pages %}
+  {%- assign url = entry | split: "<ENDURL>" | first %}
+  {%- if url == page.url %}
+    {%- unless forloop.first %}
+      {%- assign prev_index = forloop.index0 | minus: 1 %}
+      {%- assign prev_entry = matching_pages[prev_index] | strip %}
+    {%- endunless %}
+    {%- unless forloop.last %}
+      {%- assign next_index = forloop.index0 | plus: 1 %}
+      {%- assign next_entry = matching_pages[next_index] | strip %}
+    {%- endunless %}
+    {%- break %}
+  {%- endif %}
+{%- endfor %}
+
+{%- if prev_entry or next_entry%}
   <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
-    {%- assign url_parts = page.url | split: '/' %}
-    {% if page.prev_page %}
-        {%- if page.prev_page.url == "index" %}
-            {%- assign prevurl = page.url | replace: url_parts[-1], "" -%}
-        {% else %}
-            {%- assign prevurl = page.url | replace: url_parts[-1], page.prev_page.url -%}
-        {% endif %}
-        {%- capture pattern %}page.url == "{{prevurl}}"{% endcapture -%}
-        {%- assign prevpage = site.pages | where_exp: "page", pattern | first -%}
-        <a href="{{ page.prev_page.url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ prevpage.title }}</a>
+    {%- if prev_entry %}
+      {%- assign url = prev_entry | split: "<ENDURL>" | first %}
+      {%- assign title = prev_entry | split: "<ENDURL>" | last | escape_once %}
+      <a href="{{ url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ title }}</a>
     {%- endif %}
-    {% if page.next_page %}
-        {%- if page.name == "index.md" %}
-            {%- assign nexturl = page.url | append: page.next_page.url -%}
-        {%- else -%}
-            {%- assign nexturl = page.url | replace: url_parts[-1], page.next_page.url -%}
-        {%- endif %}
-        {%- capture pattern %}page.url == "{{nexturl}}"{% endcapture -%}
-        {%- assign nextpage = site.pages | where_exp: "page", pattern | first -%}
-        <a href="{{ page.next_page.url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ nextpage.title }} &rsaquo;</a>
+    {%- if next_entry %}
+      {%- assign url = next_entry | split: "<ENDURL>" | first %}
+      {%- assign title = next_entry | split: "<ENDURL>" | last | escape_once %}
+      <a href="{{ url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ title }} &rsaquo;</a>
     {%- endif %}
   </div>
 {% endif %}

--- a/docs/spec/v0.1/faq.md
+++ b/docs/spec/v0.1/faq.md
@@ -2,8 +2,6 @@
 title: Frequently Asked Questions
 description: Questions and more information.
 layout: specifications
-prev_page:
-    url: threats
 ---
 
 ## Q: Why is SLSA not transitive?

--- a/docs/spec/v0.1/index.md
+++ b/docs/spec/v0.1/index.md
@@ -1,8 +1,6 @@
 ---
 title: Introduction
 description: Overview of the SLSA standards and technical controls to improve artifact integrity.
-next_page:
-    url: terminology
 layout: standard
 stages:
     - 1:

--- a/docs/spec/v0.1/levels.md
+++ b/docs/spec/v0.1/levels.md
@@ -1,10 +1,6 @@
 ---
 title: Security levels
 description: Ladder of increasing security guarantees.
-prev_page:
-  url: terminology
-next_page:
-  url: requirements
 ---
 
 SLSA is organized into a series of levels that provide increasing

--- a/docs/spec/v0.1/requirements.md
+++ b/docs/spec/v0.1/requirements.md
@@ -1,10 +1,6 @@
 ---
 title: Requirements
 description: Technical requirements to reach each level.
-prev_page:
-    url: levels
-next_page:
-    url: threats
 ---
 This page covers all of the technical requirements for an artifact to meet the
 [SLSA Levels](levels.md).

--- a/docs/spec/v0.1/terminology.md
+++ b/docs/spec/v0.1/terminology.md
@@ -1,10 +1,6 @@
 ---
 title: Terminology
 description: Start here to understand how we model supply chains.
-prev_page:
-  url: index
-next_page:
-  url: levels
 ---
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set
 of terminology and models to describe what we're protecting.

--- a/docs/spec/v0.1/threats.md
+++ b/docs/spec/v0.1/threats.md
@@ -1,10 +1,6 @@
 ---
 title: Threats and mitigations
 description: Specific supply chain attacks and how SLSA helps.
-prev_page:
-    url: requirements
-next_page:
-    url: faq
 ---
 Attacks can occur at every link in a typical software supply chain, and these
 kinds of attacks are increasingly public, disruptive, and costly in today's

--- a/docs/spec/v1.0-rc1/faq.md
+++ b/docs/spec/v1.0-rc1/faq.md
@@ -1,12 +1,6 @@
 ---
 title: Frequently Asked Questions
 layout: specifications
-prev_page:
-  title: Threats and mitigations
-  url: threats
-next_page:
-  title: Future directions
-  url: future-directions
 ---
 
 ## Q: Why is SLSA not transitive?

--- a/docs/spec/v1.0-rc1/future-directions.md
+++ b/docs/spec/v1.0-rc1/future-directions.md
@@ -1,9 +1,3 @@
----
-prev_page:
-  title: Frequently Asked Questions
-  url: faq
----
-
 # Future directions
 
 The initial [draft version (v0.1)] of SLSA had a larger scope including

--- a/docs/spec/v1.0-rc1/index.md
+++ b/docs/spec/v1.0-rc1/index.md
@@ -1,9 +1,3 @@
----
-next_page:
-  title: Security levels
-  url: levels
----
-
 # SLSA Specification
 
 SLSA is a specification for describing and incrementally improving supply chain

--- a/docs/spec/v1.0-rc1/levels.md
+++ b/docs/spec/v1.0-rc1/levels.md
@@ -1,12 +1,3 @@
----
-prev_page:
-  title: Introduction
-  url: ./
-next_page:
-  title: Guiding principles
-  url: principles
----
-
 # Security levels
 
 SLSA is organized into a series of levels that provide increasing supply chain

--- a/docs/spec/v1.0-rc1/principles.md
+++ b/docs/spec/v1.0-rc1/principles.md
@@ -1,12 +1,3 @@
----
-prev_page:
-  title: Security levels
-  url: levels
-next_page:
-  title: Terminology
-  url: terminology
----
-
 # Guiding principles
 
 This page provides a background on the guiding principles behind SLSA. It is

--- a/docs/spec/v1.0-rc1/requirements.md
+++ b/docs/spec/v1.0-rc1/requirements.md
@@ -1,11 +1,5 @@
 ---
 title: Producing artifacts
-prev_page:
-  title: Terminology
-  url: terminology
-next_page:
-  title: Verifying Build Systems
-  url: verifying-systems
 ---
 
 This page covers the detailed technical requirements for producing artifacts at

--- a/docs/spec/v1.0-rc1/terminology.md
+++ b/docs/spec/v1.0-rc1/terminology.md
@@ -1,11 +1,5 @@
 ---
 title: Terminology
-prev_page:
-  title: Guiding principles
-  url: principles
-next_page:
-  title: Producing artifacts
-  url: requirements
 ---
 
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set

--- a/docs/spec/v1.0-rc1/threats.md
+++ b/docs/spec/v1.0-rc1/threats.md
@@ -1,11 +1,5 @@
 ---
 title: Threats and mitigations
-prev_page:
-  title: Verifying Build Systems
-  url: verifying-systems
-next_page:
-  title: Frequently Asked Questions
-  url: faq
 ---
 
 Attacks can occur at every link in a typical software supply chain, and these

--- a/docs/spec/v1.0-rc1/verifying-systems.md
+++ b/docs/spec/v1.0-rc1/verifying-systems.md
@@ -1,12 +1,3 @@
----
-prev_page:
-  title: Producing artifacts
-  url: requirements
-next_page:
-  title: Threats and mitigations
-  url: threats
----
-
 # Verifying Build Systems
 
 The provenance consumer is responsible for deciding whether they trust a builder to produce SLSA Build L3 provenance. However, assessing Build L3 capabilities requires information about a builder's construction and operating procedures that the consumer cannot glean from the provenance itself. To aid with such assessments, we provide a common threat model and builder model for reasoning about builders' security. We also provide a questionnaire that organizations can use to describe their builders to consumers along with sample answers that do and do not satisfy the SLSA Build L3 requirements.

--- a/docs/spec/v1.0/faq.md
+++ b/docs/spec/v1.0/faq.md
@@ -2,10 +2,6 @@
 title: Frequently asked questions
 descriptions: Answers to questions frequently asked about the SLSA specification.
 layout: specifications
-prev_page:
-  url:  threats-overview
-next_page:
-  url: future-directions
 ---
 
 ## Q: Why is SLSA not transitive?

--- a/docs/spec/v1.0/future-directions.md
+++ b/docs/spec/v1.0/future-directions.md
@@ -1,10 +1,6 @@
 ---
 title: Future directions
 description: The initial draft version (v0.1) of SLSA had a larger scope including protections against tampering with source code and a higher level of build integrity (Build L4). This page collects some early thoughts on how SLSA **might** evolve in future versios to re-introduce these notions and add other additional aspects of automatable supply chain security.
-prev_page:
-  url: faq
-next_page:
-  url: terminology
 ---
 
 The initial [draft version (v0.1)] of SLSA had a larger scope including

--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -1,9 +1,6 @@
 ---
 title: SLSA specification
 description: SLSA is a specification for describing and incrementally improving supply chain security, established by industry consensus. It is organized into a series of levels that describe increasing security guarantees. This is **version 1.0** of the SLSA specification, which defines the SLSA levels.
-next_page:
-  title: What's New in SLSA v1.0
-  url: whats-new
 ---
 
 SLSA is a specification for describing and incrementally improving supply chain

--- a/docs/spec/v1.0/levels.md
+++ b/docs/spec/v1.0/levels.md
@@ -1,10 +1,6 @@
 ---
 title: Security levels
 description: SLSA is organized into a series of levels that provide increasing supply chain security guarantees. This gives you confidence that software hasn’t been tampered with and can be securely traced back to its source. This page is a descriptive overview of the SLSA levels and tracks, describing their intent.
-prev_page:
-  url: terminology
-next_page:
-  url: requirements
 ---
 
 SLSA is organized into a series of levels that provide increasing supply chain

--- a/docs/spec/v1.0/principles.md
+++ b/docs/spec/v1.0/principles.md
@@ -1,10 +1,6 @@
 ---
 title: SLSA overview
 description: This page is an introduction to SLSA and its guiding principles. If you're new to SLSA, start here!
-prev_page:
-  url: whats-new
-next_page:
-  url: threats-overview
 ---
 
 This page is an introduction to SLSA and its guiding principles. If you're new

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -1,10 +1,6 @@
 ---
 title: Producing artifacts
 description: This page covers the detailed technical requirements for producing artifacts at each SLSA level. The intended audience is system implementers and security engineers.
-prev_page:
-  url: levels
-next_page:
-  url: verifying-systems
 ---
 
 

--- a/docs/spec/v1.0/terminology.md
+++ b/docs/spec/v1.0/terminology.md
@@ -1,10 +1,6 @@
 ---
 title: Terminology
 description: Before diving into the SLSA specification levels, we need to establish a core set of terminology and models to describe what we're protecting.
-prev_page:
-  url: future-directions
-next_page:
-  url: levels
 ---
 
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set

--- a/docs/spec/v1.0/threats-overview.md
+++ b/docs/spec/v1.0/threats-overview.md
@@ -1,10 +1,6 @@
 ---
 title: Supply-chain threats
 description: Attacks can occur at every link in a typical software supply chain, and these kinds of attacks are increasingly public, disruptive, and costly in today's environment. This page is an introduction to possible attacks throughout the supply chain and how SLSA can help.
-prev_page:
-  url: principles
-next_page:
-  url: faq
 ---
 
 Attacks can occur at every link in a typical software supply chain, and these

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -1,8 +1,6 @@
 ---
 title: Threats & mitigations
 description: A comprehensive technical analysis of supply chain threats and their corresponding mitigations in SLSA.
-prev_page:
-  url: verifying-artifacts
 ---
 
 What follows is a comprehensive technical analysis of supply chain threats and

--- a/docs/spec/v1.0/verifying-artifacts.md
+++ b/docs/spec/v1.0/verifying-artifacts.md
@@ -1,10 +1,6 @@
 ---
 title: Verifying artifacts
 description: SLSA uses provenance to indicate whether an artifact is authentic or not, but provenance doesn't do anything unless somebody inspects it. SLSA calls that inspection verification, and this page describes how to verify artifacts and their SLSA provenenance. The intended audience is system implementers, security engineers, and software consumers.
-prev_page:
-  url: verifying-systems
-next_page:
-  url: threats
 ---
 
 SLSA uses provenance to indicate whether an artifact is authentic or not, but

--- a/docs/spec/v1.0/verifying-systems.md
+++ b/docs/spec/v1.0/verifying-systems.md
@@ -1,10 +1,6 @@
 ---
 title: Verifying build systems
 description: The provenance consumer is responsible for deciding whether they trust a builder to produce SLSA Build L3 provenance. However, assessing Build L3 capabilities requires information about a builder's construction and operating procedures that the consumer cannot glean from the provenance itself. To aid with such assessments, we provide a common threat model and builder model for reasoning about builders' security. We also provide a questionnaire that organizations can use to describe their builders to consumers along with sample answers that do and do not satisfy the SLSA Build L3 requirements.
-prev_page:
-  url: requirements
-next_page:
-  url: verifying-artifacts
 ---
 
 The provenance consumer is responsible for deciding whether they trust a builder to produce SLSA Build L3 provenance. However, assessing Build L3 capabilities requires information about a builder's construction and operating procedures that the consumer cannot glean from the provenance itself. To aid with such assessments, we provide a common threat model and builder model for reasoning about builders' security. We also provide a questionnaire that organizations can use to describe their builders to consumers along with sample answers that do and do not satisfy the SLSA Build L3 requirements.

--- a/docs/spec/v1.0/whats-new.md
+++ b/docs/spec/v1.0/whats-new.md
@@ -1,11 +1,6 @@
 ---
 title: What's new in SLSA v1.0
 description: SLSA v1.0 represents changes made in response to feedback from the SLSA community and early adopters of SLSA v0.1. Overall, these changes prioritize simplicity and practicality.
-prev_page:
-  url: index
-
-next_page:
-  url: principles
 ---
 
 SLSA v1.0 represents changes made in response to feedback from the SLSA


### PR DESCRIPTION
Now the "next page" and "previous page" links automatically generate from the same data source as the nav bar, so that we have a single source of truth. This avoids the error-prone process of manually changing the `next_page`/`prev_page` linked lists.

NOTE: The "use cases" link is currently broken in the nav. I'll fix that via a separate PR.