### PR TITLE
Color nav bar section titles differently from links

### DIFF
--- a/docs/_includes/nav-level.html
+++ b/docs/_includes/nav-level.html
@@ -11,7 +11,7 @@
           {{ subitem.title | escape }}
         </a>
       {%- elsif subitem.children.size > 0 %}
-        {{ subitem.title | escape }}
+        <span class="section-title">{{ subitem.title | escape }}</span>
         {% include nav-level.html collection=subitem.children %}
       {%- else %}
         <em>{{ subitem.title | escape }}</em>

--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -682,6 +682,10 @@ body {
             color: $text-color;
         }
     }
+
+    .section-title {
+        color: $green-light
+    }
 }
 
 .site-content {

--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -669,13 +669,6 @@ body {
         text-decoration: none;
         text-indent: 0;
 
-        &:hover,
-        &:focus,
-        &.is-active {
-            color: $green-light;
-            text-decoration: none;
-        }
-
         &.is-active {
             background: $green-light;
             border-radius: 2px;


### PR DESCRIPTION
Previously all nav bar text entries were rendered identically, whether or not it was clickable. (Section titles are not clickable.) This made it a little hard to read.

Now (non-clickable) section titles are rendered differently from (clickable) links. The new color is light green, the same color as the prior hover text. This seems like a decent compromise to me. I experimented with bold, small caps, and others, but a slight change in color seemed the most subtle and useful.

To make this distinct from hover, hover/focus is now rendered the same as on the main page: with an underline rather than a change of color.

**For reviewers:** Do you think this is better?

In the screenshots below, "About SLSA" is the current page and the mouse is over "Verifying build systems" (i.e. hover/focus).

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/58860/228283652-d5fecb6f-d500-43b9-ba51-804ffceeadcd.png) | ![after](https://user-images.githubusercontent.com/58860/228283577-a027df65-43ac-409b-a3e1-d1422133a18c.png)
