### PR TITLE
Explain attestation formats

### DIFF
--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -38,13 +38,13 @@ dependencies (as in the case of SLSA [Provenance]).
 
 This section explains how to choose the attestation format best for your
 situation by considering factors such as use case and who will be consuming
-the attestation. 
+the attestation.
 
 ### First party
 
 Producers of first party code might consider the following questions:
 -   Will SLSA be used only within our organization?
--   Is the primary use case to manage insider risk?
+-   Is SLSA's primary use case to manage insider risk?
 -   Are we developing entirely in a closed source environment?
 
 If these are the main considerations, the organization can choose any format
@@ -55,10 +55,10 @@ attestations and the easiest to verify using the [Generic SLSA Verifier].
 
 ### Open source
 
-Producers of open source code might consider these questions: 
--   Is the primary use case to convey trust in how your code was developed?
+Producers of open source code might consider these questions:
+-   Is SLSA's primary use case to convey trust in how your code was developed?
 -   Do you develope software with standard open source licenses?
--   Will the code be consumed by others? 
+-   Will the code be consumed by others?
 
 In these situations, it is recommended you use the [SLSA Provenance format]. The SLSA
 Provenance format offers a path towards interoperability and cohesion across the open
@@ -69,8 +69,8 @@ using the [Generic SLSA Verifier].
 
 Producers of closed source code that is consumed by others might consider
 the following questions:
--   Is my code produced for third party consumers, backed with contracts?
--   Is the primary use case to create trust in our organization or to comply with
+-   Is my code produced for the sole purpose of specific third party consumers?
+-   Is SLSA's primary use case to create trust in our organization or to comply with
 audits and legal requirements?
 
 In these situation, you may not want to make all the details of your

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -11,7 +11,7 @@ The primary intended use case is to feed into automated policy engines, such as
 
 This page provides a high-level overview of the attestation model, including
 standardized terminology, data model, layers, conventions for software
-attestations, and recommended formats for different use cases.
+attestations, and suggested formats for different use cases.
 
 ## Overview
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -60,7 +60,7 @@ Producers of open source code might consider these questions:
 -   Do you develope software with standard open source licenses?
 -   Will the code be consumed by others? 
 
-In these situations, you should use the [SLSA Provenance format]. The SLSA
+In these situations, it is recommended you use the [SLSA Provenance format]. The SLSA
 Provenance format offers interoperability and cohesion across the open
 source ecosystem. Users can verify any provenance statement in this format
 using the [Generic SLSA Verifier].

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -11,7 +11,7 @@ The primary intended use case is to feed into automated policy engines, such as
 
 This page provides a high-level overview of the attestation model, including
 standardized terminology, data model, layers, conventions for software
-attestations, and suggested formats for different use cases.
+attestations, and formats for different use cases.
 
 ## Overview
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -51,8 +51,8 @@ Producers of first party code might consider the following questions:
 If these are the main considerations, the organization can choose any format
 for internal use. To make an external claim of meeting a SLSA level, however,
 there needs to be a way for external users to consume and verify your provenance.
-Currently, [SLSA Provenance format] is the suggested format for SLSA
-attestations and the easiest to verify using the [Generic SLSA Verifier].
+Currently, SLSA recommends using the [SLSA Provenance format] for SLSA
+attestations since it is easy to verify using the [Generic SLSA Verifier].
 
 ### Open source
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -42,7 +42,7 @@ choose the format best for your situation.
 ### First party
 
 As a first party producer, you use SLSA only within your organization,
-primarily manage insider risk. If you are developering entirely in
+primarily to manage insider risk. If you are developing entirely in
 a closed source environment, no particular format is required for internal use.
 
 If you want to make an external claim of meeting a SLSA level, however, there

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -36,9 +36,9 @@ dependencies (as in the case of SLSA [Provenance]).
 
 ## Formats
 
-This section explains how to choose the attestation format best for your
-situation by considering factors such as use case and who will be consuming
-the attestation.
+This section explains how to choose the attestation format that's best suited
+for your situation by considering factors such as intended use and who will be
+consuming the attestation.
 
 ### First party
 
@@ -62,7 +62,7 @@ Producers of open source code might consider these questions:
 -   Do you develop software with standard open source licenses?
 -   Will the code be consumed by others?
 
-In these situations, it is suggested you use the [SLSA Provenance format]. The SLSA
+In these situations, we encourage you to use the [SLSA Provenance format]. The SLSA
 Provenance format offers a path towards interoperability and cohesion across the open
 source ecosystem. Users can verify any provenance statement in this format
 using the [Generic SLSA Verifier].
@@ -159,4 +159,4 @@ recognize that other choices MAY be necessary in various cases.
 [SLSA Provenance format]: /provenance/v1.md
 [sigstore/cosign]: https://github.com/sigstore/cosign
 [SPDX]: https://github.com/in-toto/attestation/blob/main/spec/predicates/spdx.md
-[Verification Summary Attestation]: /attestation-model.md
+[Verification Summary Attestation]: /verification_summary/v1.md

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -59,7 +59,7 @@ attestations since it is easy to verify using the [Generic SLSA Verifier].
 Producers of open source code might consider these questions:
 
 -   Is SLSA's primary use case to convey trust in how your code was developed?
--   Do you develope software with standard open source licenses?
+-   Do you develop software with standard open source licenses?
 -   Will the code be consumed by others?
 
 In these situations, it is suggested you use the [SLSA Provenance format]. The SLSA

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -50,7 +50,7 @@ Producers of first party code might consider the following questions:
 If these are the main considerations, the organization can choose any format
 for internal use. To make an external claim of meeting a SLSA level, however,
 there must be a way for external users to consume and verify your provenance.
-Currently, [SLSA Provenance format] is the most widely used format for SLSA
+Currently, [SLSA Provenance format] is the recommended format for SLSA
 attestations and the easiest to verify using the [Generic SLSA Verifier].
 
 ### Open source

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -61,7 +61,7 @@ Producers of open source code might consider these questions:
 -   Will the code be consumed by others? 
 
 In these situations, it is recommended you use the [SLSA Provenance format]. The SLSA
-Provenance format offers interoperability and cohesion across the open
+Provenance format offers a path towards interoperability and cohesion across the open
 source ecosystem. Users can verify any provenance statement in this format
 using the [Generic SLSA Verifier].
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -76,7 +76,7 @@ the following questions:
 -   Is SLSA's primary use case to create trust in our organization or to comply with
 audits and legal requirements?
 
-In these situation, you may not want to make all the details of your
+In these situations, you may not want to make all the details of your
 provenance available externally. Consider using Verification Summary
 Attestations (VSAs) to summarize provenance information in a sanitized way
 that's safe for external consumption. For more about VSAs, see the [Verification

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -47,10 +47,9 @@ Producers of first party code might consider the following questions:
 -   Is the primary use case to manage insider risk?
 -   Are we developing entirely in a closed source environment?
 
-In these situations, no particular format is required for internal use.
-
-If you want to make an external claim of meeting a SLSA level, however, there
-must be a way for external users to consume and verify your provenance.
+If these are the main considerations, the organization can choose any format
+for internal use. To make an external claim of meeting a SLSA level, however,
+there must be a way for external users to consume and verify your provenance.
 Currently, [SLSA Provenance format] is the most widely used format for SLSA
 attestations and the easiest to verify using the [Generic SLSA Verifier].
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -70,7 +70,7 @@ using the [Generic SLSA Verifier].
 
 Producers of closed source code that is consumed by others might consider
 the following questions:
--   Is my code produced for third party consumers, back with contracts?
+-   Is my code produced for third party consumers, backed with contracts?
 -   Is the primary use case to create trust in our organization or to comply with
 audits and legal requirements?
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -50,7 +50,7 @@ Producers of first party code might consider the following questions:
 
 If these are the main considerations, the organization can choose any format
 for internal use. To make an external claim of meeting a SLSA level, however,
-there must be a way for external users to consume and verify your provenance.
+there needs to be a way for external users to consume and verify your provenance.
 Currently, [SLSA Provenance format] is the recommended format for SLSA
 attestations and the easiest to verify using the [Generic SLSA Verifier].
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -36,14 +36,18 @@ dependencies (as in the case of SLSA [Provenance]).
 
 ## Formats
 
-There is no single required attestation format. This section explains how to
-choose the format best for your situation.
+This section explains how to choose the attestation format best for your
+situation by considering factors such as use case and who will be consuming
+the attestation. 
 
 ### First party
 
-As a first party producer, you use SLSA only within your organization,
-primarily to manage insider risk. If you are developing entirely in
-a closed source environment, no particular format is required for internal use.
+Producers of first party code might consider the following questions:
+-   Will SLSA be used only within our organization?
+-   Is the primary use case to manage insider risk?
+-   Are we developing entirely in a closed source environment?
+
+In these situations, no particular format is required for internal use.
 
 If you want to make an external claim of meeting a SLSA level, however, there
 must be a way for external users to consume and verify your provenance.
@@ -52,26 +56,29 @@ attestations and the easiest to verify using the [Generic SLSA Verifier].
 
 ### Open source
 
-As an open source producer, you produce software with standard open source
-licenses (no contracts or warranties). You probably use SLSA so that others can
-trust how your code was developed. If you develop open source projects that
-will be consumed by others, you should use the [SLSA Provenance format].  
+Producers of open source code might consider these questions: 
+-   Is the primary use case to convey trust in how your code was developed?
+-   Do you develope software with standard open source licenses?
+-   Will the code be consumed by others? 
 
-The SLSA Provenance format offers interoperability and cohesion across the open
+In these situations, you should use the [SLSA Provenance format]. The SLSA
+Provenance format offers interoperability and cohesion across the open
 source ecosystem. Users can verify any provenance statement in this format
 using the [Generic SLSA Verifier].
 
 ### Closed source, third party
 
-If you develop closed source code that is consumed by others, you may not want
-to make all the details of your provenance available externally. This might
-apply to vendors who produce code (usually closed source) for third-party
-consumers, backed with contracts. You likely use SLSA for creating trust in
-your organization and to comply with audits and legal requirements.
+Producers of closed source code that is consumed by others might consider
+the following questions:
+-   Is my code produced for third party consumers, back with contracts?
+-   Is the primary use case to create trust in our organization or to comply with
+audits and legal requirements?
 
-Consider using Verification Summary Attestations (VSAs) to summarize provenance
-information in a sanitized way that's safe for external consumption. For more
-about VSAs, see the [Verification Summary Attestation] page.
+In these situation, you may not want to make all the details of your
+provenance available externally. Consider using Verification Summary
+Attestations (VSAs) to summarize provenance information in a sanitized way
+that's safe for external consumption. For more about VSAs, see the [Verification
+Summary Attestation] page.
 
 ## Model and Terminology
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -10,8 +10,8 @@ The primary intended use case is to feed into automated policy engines, such as
 [in-toto] and [Binary Authorization].
 
 This page provides a high-level overview of the attestation model, including
-standardized terminology, data model, layers, and conventions for software
-attestations.
+standardized terminology, data model, layers, conventions for software
+attestations, and recommended formats for different use cases.
 
 ## Overview
 
@@ -33,6 +33,45 @@ arbitrary amount of information, including things that are not possible with
 raw signing. For example, an attestation might state exactly how an artifact
 was produced, including the build command that was run and all of its
 dependencies (as in the case of SLSA [Provenance]).
+
+## Formats
+
+There is no single required attestation format. This section explains how to
+choose the format best for your situation. 
+
+### First party
+
+As a first party producer, you use SLSA only within your organization,
+primarily manage insider risk. If you are developering entirely in
+a closed source environment, no particular format is required for internal use. 
+
+If you want to make an external claim of meeting a SLSA level, however, there
+must be a way for external users to consume and verify your provenance.
+Currently, [SLSA Provenance format] is the most widely used format for SLSA
+attestations and the easiest to verify using the [Generic SLSA Verifier]. 
+
+### Open source 
+
+As an open source producer, you produce software with standard open source
+licenses (no contracts or warranties). You probably use SLSA so that others can
+trust how your code was developed. If you develop open source projects that
+will be consumed by others, you should use the [SLSA Provenance format].  
+
+The SLSA Provenance format offers interoperability and cohesion across the open
+source ecosystem. Users can verify any provenance statement in this format
+using the [Generic SLSA Verifier].
+
+### Closed source, third party 
+
+If you develop closed source code that is consumed by others, you may not want
+to make all the details of your provenance available externally. This might
+apply to vendors who produce code (usually closed source) for third-party
+consumers, backed with contracts. You likely use SLSA for creating trust in
+your organization and to comply with audits and legal requirements. 
+
+Consider using Verification Summary Attestations (VSAs) to summarize provenance
+information in a sanitized way that's safe for external consumption. For more
+about VSAs, see the [Verification Summary Attestation] page.
 
 ## Model and Terminology
 
@@ -99,6 +138,7 @@ recognize that other choices MAY be necessary in various cases.
 [attestation bundle]: https://github.com/in-toto/attestation/blob/main/spec/bundle.md
 [Binary Authorization]: https://cloud.google.com/binary-authorization
 [DSSE]: https://github.com/secure-systems-lab/dsse/
+[Generic SLSA Verifier]: https://github.com/slsa-framework/slsa-verifier
 [hypergraph]: https://en.wikipedia.org/wiki/Hypergraph
 [in-toto]: https://in-toto.io
 [in-toto attestations]: https://github.com/in-toto/attestation/
@@ -107,5 +147,7 @@ recognize that other choices MAY be necessary in various cases.
 [Provenance]: /provenance
 [remote attestation]: https://en.wikipedia.org/wiki/Trusted_Computing#Remote_attestation
 [RFC 2119]: https://tools.ietf.org/html/rfc2119
+[SLSA Provenance format]: /provenance/v1.md
 [sigstore/cosign]: https://github.com/sigstore/cosign
 [SPDX]: https://github.com/in-toto/attestation/blob/main/spec/predicates/spdx.md
+[Verification Summary Attestation]: /attestation-model.md

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -76,7 +76,7 @@ the following questions:
 -   Is SLSA's primary use case to create trust in our organization or to comply with
 audits and legal requirements?
 
-In these situations, you may not want to make all the details of your
+In these situations, you might not want to make all the details of your
 provenance available externally. Consider using Verification Summary
 Attestations (VSAs) to summarize provenance information in a sanitized way
 that's safe for external consumption. For more about VSAs, see the [Verification

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -37,20 +37,20 @@ dependencies (as in the case of SLSA [Provenance]).
 ## Formats
 
 There is no single required attestation format. This section explains how to
-choose the format best for your situation. 
+choose the format best for your situation.
 
 ### First party
 
 As a first party producer, you use SLSA only within your organization,
 primarily manage insider risk. If you are developering entirely in
-a closed source environment, no particular format is required for internal use. 
+a closed source environment, no particular format is required for internal use.
 
 If you want to make an external claim of meeting a SLSA level, however, there
 must be a way for external users to consume and verify your provenance.
 Currently, [SLSA Provenance format] is the most widely used format for SLSA
-attestations and the easiest to verify using the [Generic SLSA Verifier]. 
+attestations and the easiest to verify using the [Generic SLSA Verifier].
 
-### Open source 
+### Open source
 
 As an open source producer, you produce software with standard open source
 licenses (no contracts or warranties). You probably use SLSA so that others can
@@ -61,13 +61,13 @@ The SLSA Provenance format offers interoperability and cohesion across the open
 source ecosystem. Users can verify any provenance statement in this format
 using the [Generic SLSA Verifier].
 
-### Closed source, third party 
+### Closed source, third party
 
 If you develop closed source code that is consumed by others, you may not want
 to make all the details of your provenance available externally. This might
 apply to vendors who produce code (usually closed source) for third-party
 consumers, backed with contracts. You likely use SLSA for creating trust in
-your organization and to comply with audits and legal requirements. 
+your organization and to comply with audits and legal requirements.
 
 Consider using Verification Summary Attestations (VSAs) to summarize provenance
 information in a sanitized way that's safe for external consumption. For more

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -43,6 +43,7 @@ the attestation.
 ### First party
 
 Producers of first party code might consider the following questions:
+
 -   Will SLSA be used only within our organization?
 -   Is SLSA's primary use case to manage insider risk?
 -   Are we developing entirely in a closed source environment?
@@ -56,6 +57,7 @@ attestations and the easiest to verify using the [Generic SLSA Verifier].
 ### Open source
 
 Producers of open source code might consider these questions:
+
 -   Is SLSA's primary use case to convey trust in how your code was developed?
 -   Do you develope software with standard open source licenses?
 -   Will the code be consumed by others?
@@ -69,6 +71,7 @@ using the [Generic SLSA Verifier].
 
 Producers of closed source code that is consumed by others might consider
 the following questions:
+
 -   Is my code produced for the sole purpose of specific third party consumers?
 -   Is SLSA's primary use case to create trust in our organization or to comply with
 audits and legal requirements?

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -62,7 +62,7 @@ Producers of open source code might consider these questions:
 -   Do you develope software with standard open source licenses?
 -   Will the code be consumed by others?
 
-In these situations, it is recommended you use the [SLSA Provenance format]. The SLSA
+In these situations, it is suggested you use the [SLSA Provenance format]. The SLSA
 Provenance format offers a path towards interoperability and cohesion across the open
 source ecosystem. Users can verify any provenance statement in this format
 using the [Generic SLSA Verifier].

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -51,7 +51,7 @@ Producers of first party code might consider the following questions:
 If these are the main considerations, the organization can choose any format
 for internal use. To make an external claim of meeting a SLSA level, however,
 there needs to be a way for external users to consume and verify your provenance.
-Currently, [SLSA Provenance format] is the recommended format for SLSA
+Currently, [SLSA Provenance format] is the suggested format for SLSA
 attestations and the easiest to verify using the [Generic SLSA Verifier].
 
 ### Open source


### PR DESCRIPTION
PR to explain attestations in a series of documentation updates outlined in Issue #672.

Adds a section telling users how to choose among attestations formats based on whether they are using SLSA for first party, open source, or third party close source code.

@MarkLodato @kpk47 @arewm @lehors 