### PR TITLE
Set `noindex` on 'onepage' pages

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -27,4 +27,7 @@
     {%- if jekyll.environment == 'production' -%}
     {%- include analytics.html -%}
     {%- endif -%}
+    {%- if page.noindex %}
+    <meta name="robots" content="noindex">
+    {% endif -%}
 </head>

--- a/docs/spec/v0.1/onepage.md
+++ b/docs/spec/v0.1/onepage.md
@@ -2,6 +2,7 @@
 title: SLSA Specification
 description: Description of the SLSA standards and technical controls to improve artifact integrity.
 layout: standard
+noindex: true
 ---
 {%- comment -%}
 A single page containing all the following files as different sections

--- a/docs/spec/v1.0-rc1/onepage.md
+++ b/docs/spec/v1.0-rc1/onepage.md
@@ -1,5 +1,6 @@
 ---
 title: SLSA Specification
+noindex: true
 ---
 {%- comment -%}
 A single page containing all the following files as different sections

--- a/docs/spec/v1.0/onepage.md
+++ b/docs/spec/v1.0/onepage.md
@@ -1,6 +1,7 @@
 ---
 title: SLSA Specification
 description: A one-page rendering of all that is included in SLSA v1.0.
+noindex: true
 ---
 {%- comment -%}
 A single page containing all the following files as different sections


### PR DESCRIPTION
These pages duplicate content found elsewhere on the site, which is generally discouraged by search engines. Since they combine multiple pages, we can't provide a single canonical link, and because these are likely not the pages we want to show up in search results, just mark these as `noindex` instead.