### PR TITLE
Update parsing rules to match latest in-toto extension field rules

### DIFF
--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -93,9 +93,12 @@ This predicate follows the in-toto attestation [parsing rules]. Summary:
 -   Consumers MUST ignore unrecognized fields unless otherwise noted.
 -   The `predicateType` URI includes the major version number and will always
     change whenever there is a backwards incompatible change.
--   Minor version changes are always backwards compatible and "monotonic." Such
-    changes do not update the `predicateType`.
--   Producers MAY add extension fields using field names that are URIs.
+-   Minor version changes are always backwards compatible and "monotonic."
+    Such changes do not update the `predicateType`.
+-   Producers MAY add extension fields using names that are unlikely to
+    collide with names used by other orgs. Field names SHOULD avoid special
+    characters like `.` and `$` as these can make querying these fields in
+    some databases more difficult.
 -   Unset, null, and empty field values MUST be interpreted equivalently.
 
 ## Schema
@@ -557,9 +560,9 @@ Renamed to "slsa.dev/provenance".
 
 Initial version, named "in-toto.io/Provenance"
 
-[Statement]: https://github.com/in-toto/attestation/blob/main/spec/README.md#statement
+[Statement]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/statement.md
 [in-toto attestation]: https://github.com/in-toto/attestation
-[parsing rules]: https://github.com/in-toto/attestation/blob/main/spec/README.md#parsing-rules
+[parsing rules]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/README.md#parsing-rules
 [purl]: https://github.com/package-url/purl-spec
 [threats]: /spec/v1.0/threats
 [trusted]: /spec/v1.0/principles#trust-systems-verify-artifacts


### PR DESCRIPTION
Updates the SLSA Provenance parsing rules for extension fields to match the latest parsing guidelines from the in-toto Attestation Framework. In particular, the new rules remove the recommendation to use TypeURIs and add an explanation to avoid certain special characters in extension field names.

Fixes #670