### PR TITLE
VSA v1: update to in-toto attestation v1

### DIFF
--- a/docs/verification_summary/v1.md
+++ b/docs/verification_summary/v1.md
@@ -141,48 +141,25 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > URI that identifies the resource associated with the artifact being verified.
 
 <a id="policy"></a>
-`policy` _object, required_
+`policy` _object ([ResourceDescriptor]), required_
 
-> Describes the policy that was used to verify this artifact.
-
-<a id="policy.uri"></a>
-`policy.uri` _string ([ResourceURI]), required_
-
-> The URI of the policy used to perform verification.
-
-<a id="policy.digest"></a>
-`policy.digest` _object ([DigestSet]), optional_
-
-> Collection of cryptographic digests for the contents of the policy used to perform verification.
+> Describes the policy that the `subject` was verified against.
+>
+> The entry MUST contain a `uri`.
 
 <a id="inputAttestations"></a>
-`inputAttestations` _object, optional_
+`inputAttestations` _array ([ResourceDescriptor]), optional_
 
 > The collection of attestations that were used to perform verification.
-> Conceptually similar to the `resolvedDependencies` field in the [SLSA Provenance](/provenance).
+> Conceptually similar to the `resolvedDependencies` field in [SLSA Provenance].
 >
 > This field can be absent if the verifier does not support this feature;
 > If present, this field must contain information on _all_ the attestations
 > used to perform verification.
 > An empty collection indicates the decision was made without attestations.
-
-<a id="inputAttestations.uri"></a>
-`inputAttestations[*].uri` _string ([ResourceURI]), optional_
-
-> A URI that can be used (provided the requester has read permission) to fetch
-> the attestation.
 >
-> An absent field indicates the verifier does not know where to fetch the attestation
-> (e.g. it was supplied by the verification requester).
->
-> The data fetched from the URI may contain more than one attestation (e.g. an
-> attestation bundle file). In that case, the attestation is identified by
-> `digest` field values.
-
-<a id="inputAttestations.digest"></a>
-`inputAttestations[*].digest` _object ([DigestSet]), required_
-
-> Collection of cryptographic digests for this attestation.
+> Each entry MUST contain a `digest` of the attestation and SHOULD contains a
+> `uri` that can be used to fetch the attestation.
 
 <a id="verificationResult"></a>
 `verificationResult` _string, required_
@@ -272,6 +249,7 @@ SHOULD be one of these values:
 [SlsaResult]: #slsaresult
 [DigestSet]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#DigestSet
 [ResourceURI]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#ResourceURI
+[ResourceDescriptor]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/resource_descriptor.md
 [Statement]: https://github.com/in-toto/attestation/blob/main/spec/README.md#statement
 [Timestamp]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#Timestamp
 [TypeURI]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#TypeURI

--- a/docs/verification_summary/v1.md
+++ b/docs/verification_summary/v1.md
@@ -185,7 +185,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 WARNING: This is just for demonstration purposes.
 
 ```jsonc
-"_type": "https://in-toto.io/Statement/v0.1",
+"_type": "https://in-toto.io/Statement/v1",
 "subject": [{
   "name": "out/example-1.2.3.tar.gz",
   "digest": {"sha256": "5678..."}
@@ -247,11 +247,11 @@ SHOULD be one of these values:
 
 [SLSA Provenance]: /provenance
 [SlsaResult]: #slsaresult
-[DigestSet]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#DigestSet
-[ResourceURI]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#ResourceURI
+[DigestSet]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/digest_set.md
+[ResourceURI]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/field_types.md#ResourceURI
 [ResourceDescriptor]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/resource_descriptor.md
-[Statement]: https://github.com/in-toto/attestation/blob/main/spec/README.md#statement
-[Timestamp]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#Timestamp
-[TypeURI]: https://github.com/in-toto/attestation/blob/main/spec/field_types.md#TypeURI
+[Statement]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/statement.md
+[Timestamp]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/field_types.md#Timestamp
+[TypeURI]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/field_types.md#TypeURI
 [in-toto attestation]: https://github.com/in-toto/attestation
-[parsing rules]: https://github.com/in-toto/attestation/blob/main/spec/README.md#parsing-rules
+[parsing rules]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/README.md#parsing-rules


### PR DESCRIPTION
- Use ResourceDescriptor instead of re-defining the object with a uri and digest type. This brings VSA to be consistent with Provenance.
- Update `_type` to use Statement/v1.
- Fix broken links to point to v1.

No meaningful changes were intended.

/cc @AdamZWu 