### PR TITLE
Fix some broken links

### DIFF
--- a/docs/spec/v1.0-rc1/threats.md
+++ b/docs/spec/v1.0-rc1/threats.md
@@ -131,7 +131,7 @@ This includes the threat of an authorized developer introducing an unauthorized
 change—in other words, an insider threat.
 
 SLSA v1.0 does not address source integrity, though we anticipate a [Source
-track](future-directions.md#source-track) might do so in a future version. In
+track](future-directions#source-track) might do so in a future version. In
 the meantime, the threats and potential mitigations listed here show how SLSA
 v1.0 can fit into a broader supply chain security program.
 

--- a/docs/spec/v1.0-rc1/verifying-artifacts.md
+++ b/docs/spec/v1.0-rc1/verifying-artifacts.md
@@ -189,4 +189,4 @@ package ecosystem.
 
 Consumers may either audit the build systems
 themselves using the prompts in [verifying systems](verifying-systems.md) or
-rely on the [SLSA certification program](certification.md) (coming soon).
+rely on the SLSA certification program (coming soon).

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -25,7 +25,7 @@ This includes the threat of an authorized individual introducing an unauthorized
 change---in other words, an insider threat.
 
 SLSA v1.0 does not address source integrity, though we anticipate a [Source
-track](future-directions.md#source-track) might do so in a future version. In
+track](future-directions#source-track) might do so in a future version. In
 the meantime, the threats and potential mitigations listed here show how SLSA
 v1.0 can fit into a broader supply chain security program.
 

--- a/docs/spec/v1.0/verifying-artifacts.md
+++ b/docs/spec/v1.0/verifying-artifacts.md
@@ -189,8 +189,8 @@ Once, when bootstrapping the verifier:
     Different verifiers might use different roots of trust, but usually a
     verifier uses the same roots of trust for all packages. This configuration
     is likely in the form of a map from (builder public key identity,
-    `builder.id`) to (SLSA Build level) drawn from the [SLSA Conformance
-    Program](certification.md) (coming soon).
+    `builder.id`) to (SLSA Build level) drawn from the SLSA Conformance
+    Program (coming soon).
 
     <details>
     <summary>Example root of trust configuration</summary>


### PR DESCRIPTION
This addresses Issue #747.

I'm really not sure why Jekyll doesn't like the link in threats.md but for some reason in this instance linking to the .md file with a fragment identifier fails because the .md remains in the generate html page...

@kpk47 I only found one instance of a link to the certification/conformance page.