### PR TITLE
VSA v1: remove difference between empty and unset

### DIFF
--- a/docs/verification_summary/v1.md
+++ b/docs/verification_summary/v1.md
@@ -153,10 +153,9 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > The collection of attestations that were used to perform verification.
 > Conceptually similar to the `resolvedDependencies` field in [SLSA Provenance].
 >
-> This field can be absent if the verifier does not support this feature;
-> If present, this field must contain information on _all_ the attestations
+> This field MAY be absent if the verifier does not support this feature.
+> If non-empty, this field MUST contain information on _all_ the attestations
 > used to perform verification.
-> An empty collection indicates the decision was made without attestations.
 >
 > Each entry MUST contain a `digest` of the attestation and SHOULD contains a
 > `uri` that can be used to fetch the attestation.


### PR DESCRIPTION
Our parsing rules say that we should not differentiate between a set-but-empty field and an unset field, but `inputAttestations` violated this rule.

Since we do not have a use case for distinguishing between these two cases, just merge them together in the spec.

Fixes #753.
