### PR TITLE
Remove obsolete reference to version selector.

### DIFF
--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -8,10 +8,7 @@ security, established by industry consensus. It is organized into a series of
 levels that describe increasing security guarantees.
 
 This is **version 1.0** of the SLSA specification, which defines the SLSA
-levels. For other versions, use the chooser <span class="hidden md:inline">to
-the right</span><span class="md:hidden">at the bottom of this page</span>. For
-the recommended attestation formats, including provenance, see "Specifications"
-in the menu at the top.
+levels and recommended attestation formats, including provenance.
 
 ## About this release candidate
 


### PR DESCRIPTION
Also the spec now encompasses both the levels and the formats, so remove that part as well.
