### PR TITLE
Provenance v1: raise prominence of extensions + other cleanups

### DIFF
--- a/docs/provenance/schema/v1/provenance.cue
+++ b/docs/provenance/schema/v1/provenance.cue
@@ -15,8 +15,8 @@
         "runDetails": {
             "builder": {
                 "id": string,
-                "version": string,
                 "builderDependencies": [ ...#ResourceDescriptor ],
+                "version": { ...string },
             },
             "metadata": {
                 "invocationId": string,

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -279,11 +279,6 @@ Guidelines:
     to the build server, record the location in `externalParameters` as a URI
     and record the `uri` and `digest` in `resolvedDependencies`.
 
-> ⚠ **RFC:** We are particularly looking for feedback on this schema from
-> potential implementers. Does this model map cleanly to existing build systems?
-> Is it natural to identify and express the external parameters? Is anything
-> confusing or ambiguous?
-
 ### RunDetails
 
 [RunDetails]: #rundetails
@@ -385,8 +380,6 @@ the case where one signer generates attestations for more than one builder, as
 in the GitHub Actions example above. The field is REQUIRED, even if it is
 implicit from the signer, to aid readability and debugging. It is an object to
 allow additional fields in the future, in case one URI is not sufficient.
-
-> ⚠ **RFC:** Do we need more explicit guidance on how to choose a URI?
 
 > ⚠ **RFC:** Do we want/need to identify the tenant of the build system,
 > separately from the build system itself? If so, a single `id`

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -526,10 +526,13 @@ Major refactor to reduce misinterpretation, including a minor change in model.
 -   Altered the model slightly to better align with real-world build systems,
     align with reproducible builds, and make verification easier.
 -   Grouped fields into `buildDefinition` vs `runDetails`.
--   Renamed, with slight changes in semantics:
-    -   `parameters` -> `externalParameters`
-    -   `environment` -> `systemParameters`
-    -   `materials` -> `resolvedDependencies`
+-   Renamed:
+    -   `parameters` -> `externalParameters` (slight change in semantics)
+    -   `environment` -> `systemParameters` (slight change in semantics)
+    -   `materials` -> `resolvedDependencies` (slight change in semantics)
+    -   `buildInvocationId` -> `invocationId`
+    -   `buildStartedOn` -> `startedOn`
+    -   `buildFinishedOn` -> `finishedOn`
 -   Removed:
     -   `configSource`: No longer special-cased. Now represented as
         `externalParameters`  + `resolvedDependencies`.
@@ -538,8 +541,9 @@ Major refactor to reduce misinterpretation, including a minor change in model.
         the semantics, or omitted if not needed.
     -   `completeness` and `reproducible`: Now implied by `builder.id`.
 -   Added:
-    -   `localName`, `downloadLocation`, and `mediaType`
-    -   `builder.version`
+    -   ResourceDescriptor:  `annotations`, `content`, `downloadLocation`,
+        `mediaType`, `name`
+    -   Builder: `builderDependencies` and `version`
     -   `byproducts`
 
 ### v0.2

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -95,10 +95,6 @@ This predicate follows the in-toto attestation [parsing rules]. Summary:
     change whenever there is a backwards incompatible change.
 -   Minor version changes are always backwards compatible and "monotonic."
     Such changes do not update the `predicateType`.
--   Producers MAY add extension fields using names that are unlikely to
-    collide with names used by other orgs. Field names SHOULD avoid special
-    characters like `.` and `$` as these can make querying these fields in
-    some databases more difficult.
 -   Unset, null, and empty field values MUST be interpreted equivalently.
 
 ## Schema
@@ -348,6 +344,7 @@ The `builder.id` URI SHOULD resolve to documentation explaining:
 -   The scope of what this ID represents.
 -   The claimed SLSA Build level.
 -   The accuracy and completeness guarantees of the fields in the provenance.
+-   The interpretation of any extension fields.
 
 <tr id="builderDependencies"><td><code>builderDependencies</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/main/spec/v1.0/resource_descriptor.md">ResourceDescriptor</a>)<td>
@@ -391,11 +388,6 @@ allow additional fields in the future, in case one URI is not sufficient.
 
 > ⚠ **RFC:** Do we need more explicit guidance on how to choose a URI?
 
-> ⚠ **RFC:** Would it be preferable to allow builders to set arbitrary
-> properties, rather than calling out `version` and `builderDependencies`? We
-> don't expect verifiers to use any of them, so maybe that's the simpler
-> approach? Or have a `properties` that is an arbitrary object? (#319)
-
 > ⚠ **RFC:** Do we want/need to identify the tenant of the build system,
 > separately from the build system itself? If so, a single `id`
 > that combines both (e.g.
@@ -432,6 +424,26 @@ The timestamp of when the build started.
 The timestamp of when the build completed.
 
 </table>
+
+### Extension fields
+
+[Extension fields]: #extension-fields
+
+Implementations MAY add extension fields to any JSON object to describe
+information that is not captured in a standard field. Guidelines:
+
+-   Extension fields MUST NOT alter the meaning of any other field. In other
+    words, an attestation with an absent extension field MUST be interpreted
+    identically to an attestation with an unrecognized (and thus ignored)
+    extension field.
+-   Extension fields SHOULD follow the [monotonic principle][parsing rules],
+    meaning that deleting or ignoring the extension SHOULD NOT turn a DENY
+    decision into an ALLOW.
+-   Extension fields SHOULD use names that are unlikely to collide with names
+    used by other orgs or by future minor versions of this specification.
+-   Extension fields SHOULD use names that avoid special characters like `.` and
+    `$` because these can make querying these fields in some databases more
+    difficult.
 
 ## Verification
 

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -349,17 +349,17 @@ The `builder.id` URI SHOULD resolve to documentation explaining:
 -   The claimed SLSA Build level.
 -   The accuracy and completeness guarantees of the fields in the provenance.
 
-<tr id="builder.version"><td><code>version</code>
-<td>map (string→string)<td>
-
-Version numbers of components of the build platform.
-
 <tr id="builderDependencies"><td><code>builderDependencies</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/main/spec/v1.0/resource_descriptor.md">ResourceDescriptor</a>)<td>
 
 Dependencies used by the orchestrator that are not run within the workload
 and that do not affect the build, but might affect the provenance generation
 or security guarantees.
+
+<tr id="builder.version"><td><code>version</code>
+<td>map (string→string)<td>
+
+Version numbers of components of the build platform.
 
 </table>
 
@@ -484,8 +484,8 @@ The meaning of each field is unchanged unless otherwise noted.
     "runDetails": {
         "builder": {
             "id": old.builder.id,
-            "version": null,  // not in v0.2
             "builderDependencies": null,  // not in v0.2
+            "version": null,  // not in v0.2
         },
         "metadata": {
             "invocationId": old.metadata.buildInvocationId,


### PR DESCRIPTION
- Fix type of `builder.version`
- Sort fields of Builder alphabetically
- Better document extension fields so that it is more prominent
- Remove stale RFC tags
- Update changelog to reflect latest changes.

The main change is to raise the prominence of extension fields so that implementers know that it's an option.
