### PR TITLE
Provenance v1: re-add `completeness` and `reproducibility`

### DIFF
--- a/docs/provenance/schema/v1/provenance.cue
+++ b/docs/provenance/schema/v1/provenance.cue
@@ -22,6 +22,12 @@
                 "invocationId": string,
                 "startedOn": #Timestamp,
                 "finishedOn": #Timestamp,
+                "completeness": {
+                  "externalParameters": "COMPLETE"|"INCOMPLETE",
+                  "systemParameters": "COMPLETE"|"INCOMPLETE",
+                  "resolvedDependencies": "COMPLETE"|"INCOMPLETE",
+                },
+                "reproducibility": "FULLY_REPRODUCIBLE"|"NOT_REPRODUCIBLE",
             },
             "byproducts": [ ...#ResourceDescriptor ],
         }

--- a/docs/provenance/schema/v1/provenance.proto
+++ b/docs/provenance/schema/v1/provenance.proto
@@ -47,4 +47,24 @@ message BuildMetadata {
   string invocation_id = 1;
   google.protobuf.Timestamp started_on = 2;
   google.protobuf.Timestamp finished_on = 3;
+  Completeness completeness = 4;
+  Reproducibility reproducibility = 5;
+}
+
+message Completeness {
+  CompletenessValue external_parameters = 1;
+  CompletenessValue system_parameters = 2;
+  CompletenessValue resolved_dependencies = 3;
+}
+
+enum CompletenessValue {
+  COMPLETENESS_UNKNOWN = 0;
+  COMPLETE = 1;
+  INCOMPLETE = 2;
+}
+
+enum Reproducibility {
+  REPRODUCIBILITY_UNKNOWN = 0;
+  FULLY_REPRODUCIBLE = 1;
+  NOT_REPRODUCIBLE = 2;
 }

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -347,7 +347,8 @@ The `builder.id` URI SHOULD resolve to documentation explaining:
 
 -   The scope of what this ID represents.
 -   The claimed SLSA Build level.
--   The accuracy and completeness guarantees of the fields in the provenance.
+-   The minimum accuracy and completeness guarantees of the fields in the
+    provenance.
 
 <tr id="builder.version"><td><code>version</code>
 <td>map (string→string)<td>
@@ -431,6 +432,38 @@ The timestamp of when the build started.
 
 The timestamp of when the build completed.
 
+<tr id="completeness"><td><code>completeness.&lt;field&gt;</code>
+<td>enum<td>
+
+Indicates whether the corresponding `buildDetails.<field>` is complete. While
+implicit from `builder.id`, this MAY be used to be explicit and/or to claim
+completeness greater than that implied by `builder.id`. MUST NOT indicate a
+level of completeness less than that guaranteed by `builder.id`.
+Consumers SHOULD NOT consider this field when determining the SLSA Build level.
+Consumers MUST treat unrecognized enum values the same as unset values.
+
+Possible values:
+
+-   `COMPLETE`: The field is known to be complete.
+-   `INCOMPLETE`: The field is known to be incomplete.
+-   (unset): No claim about completeness.
+
+Possible `<field>` names: `externalParameters`, `systemParameters`,
+`resolvedDependencies`
+
+<tr id="reproducibility"><td><code>reproducibility</code>
+<td>enum<td>
+
+Indicates whether the build is reproducible.
+
+Possible values:
+
+-   `FULLY_REPRODUCIBLE`: The build is bit-for-bit reproducible, meaning that
+    re-running the build with only access to the information specified in this
+    provenance will result in an identical set of output artifacts.
+-   `NOT_REPRODUCIBLE`: The build is known to be not reproducible.
+-   (unset): No claim about reproducibility.
+
 </table>
 
 ## Verification
@@ -491,6 +524,14 @@ The meaning of each field is unchanged unless otherwise noted.
             "invocationId": old.metadata.buildInvocationId,
             "startedOn": old.metadata.buildStartedOn,
             "finishedOn": old.metadata.buildFinishedOn,
+            // "completeness" and "reproducibility" are now implicit from
+            // `builder.id`, but they MAY be optionally recorded here as well.
+            "completeness": {
+                "externalParameters": old.metadata.completeness.parameters ? "COMPLETE" : null,
+                "systemParameters": old.metadata.completeness.environment ? "COMPLETE" : null,
+                "resolvedDependencies": old.metadata.completeness.materials ? "COMPLETE" : null,
+            }
+            "reproducibility": old.metadata.reproducible ? "FULLY_REPRODUCIBLE" : null,
         },
         "byproducts": null,  // not in v0.2
     },
@@ -508,8 +549,6 @@ The following fields from v0.2 are no longer present in v1.0:
         case might be someone who wishes to parse the configuration to look for
         bad patterns, such as `curl | bash`.
     -   Else omit it.
--   `metadata.completeness`: Now implicit from `builder.id`.
--   `metadata.reproducible`: Now implicit from `builder.id`.
 
 ## Change history
 
@@ -525,13 +564,15 @@ Major refactor to reduce misinterpretation, including a minor change in model.
     -   `parameters` -> `externalParameters`
     -   `environment` -> `systemParameters`
     -   `materials` -> `resolvedDependencies`
+    -   `reproducible` -> `reproducibility`
+-   Modified:
+    -   `completeness.*` and `reproducibility` are now enums and OPTIONAL
 -   Removed:
     -   `configSource`: No longer special-cased. Now represented as
         `externalParameters`  + `resolvedDependencies`.
     -   `buildConfig`: No longer inlined into the provenance. Can be replaced
         with a reference in `externalParameters` or `byproducts`, depending on
         the semantics, or omitted if not needed.
-    -   `completeness` and `reproducible`: Now implied by `builder.id`.
 -   Added:
     -   `localName`, `downloadLocation`, and `mediaType`
     -   `builder.version`


### PR DESCRIPTION
These were removed from an earlier draft of v1 when we made it implicit from `builder.id`, but there has been feedback that it is valuable even if implicit. Now the values are enums (for extensibility) and are restricting to being strictly stronger than the implicit value from
`builder.id`.

**This is a draft for comments** based on the discussion in #716. I am not 100% confident in this, but I wanted to create this PR to see what people thought. Opinions welcome!

Fixes #716 (I hope!)

/cc  @tonistiigi @jedevc @patricklawsongoogle @bobcatfish @chitrangpatel @khalkie