### PR TITLE
Explicitly mention identifying package by digest

### DIFF
--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -159,16 +159,18 @@ minimum requirements on its:
 <tr id="provenance-exists"><td>Provenance Exists<td>
 
 The build process MUST generate provenance that unambiguously identifies the
-output package and describes how that package was produced.
+output package by cryptographic digest and describes how that package was
+produced. The format MUST be acceptable to the [package ecosystem] and/or
+[consumer](verifying-artifacts.md#consumer).
 
-The format MUST be acceptable to the
-[package ecosystem] and/or [consumer](verifying-artifacts.md#consumer). It
-is RECOMMENDED to use the [SLSA Provenance] format and [associated suite]
+It is RECOMMENDED to use the [SLSA Provenance] format and [associated suite]
 because it is designed to be interoperable, universal, and unambiguous when
 used for SLSA. See that format's documentation for requirements and
-implementation guidelines. If using an alternate format, it MUST contain the
-equivalent information as SLSA Provenance at each level and SHOULD be
-bi-directionally translatable to SLSA Provenance.
+implementation guidelines.
+
+If using an alternate format, it MUST contain the equivalent information as SLSA
+Provenance at each level and SHOULD be bi-directionally translatable to SLSA
+Provenance.
 
 -   *Completeness:* Best effort. The provenance at L1 SHOULD contain sufficient
     information to catch mistakes and simulate the user experience at higher


### PR DESCRIPTION
In SLSA v0.1 we had said that the provenance MUST identify the package by cryptographic digest, but this was implicit in v1.0 from "unambiguously identifies the output package" and "equivalent information as SLSA Provenance". Still, there is room for misinterpretation, so this change calls out identifying the output artifact by cryptographic digest so there is no room for misinterpretation.

Also splits the paragraphs to be more readable.

Fixes #601.
