### PR TITLE
Add @di to CODEOWNERS as reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 # Reviewers
 /docs/provenance/ @TomHennen
 /docs/verification_summary/ @TomHennen
+/docs/spec/**/distributing-provenance.md @di


### PR DESCRIPTION
Adds myself as a reviewer for all current and future `distributing-provenance.md` pages.