### PR TITLE
Add recommended crypto algorithms for DSSE.

### DIFF
--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -90,7 +90,7 @@ recognize that other choices MAY be necessary in various cases.
 
 | Component | Recommendation |
 | --- | --- |
-| Envelope | **[DSSE]** (ECDSA over NIST P-256 and SHA-256) |
+| Envelope | **[DSSE]** (ECDSA over NIST P-256 (or stronger) and SHA-256.) |
 | Statement | **[in-toto attestations]** |
 | Predicate | Choose as appropriate, i.e.; [Provenance], [SPDX], [other predicates defined by third-parties]. If none are a good fit, invent a new one |
 | Bundle | **[JSON Lines]**, see [attestation bundle] |

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -90,7 +90,7 @@ recognize that other choices MAY be necessary in various cases.
 
 | Component | Recommendation |
 | --- | --- |
-| Envelope | **[DSSE]** (**TODO**: Recommend Crypto/PKI) |
+| Envelope | **[DSSE]** (ECDSA over NIST P-256 and SHA-256) |
 | Statement | **[in-toto attestations]** |
 | Predicate | Choose as appropriate, i.e.; [Provenance], [SPDX], [other predicates defined by third-parties]. If none are a good fit, invent a new one |
 | Bundle | **[JSON Lines]**, see [attestation bundle] |


### PR DESCRIPTION
This closes out the TODO on the Attestation Model page.

I chose these algorithms because we recommend SHA-256 elsewhere in the spec and ECDSA over P-256 has the same security strength. I'm open to other suggestions.