### PR TITLE
Update redirect for tooling notes

### DIFF
--- a/docs/notes/tooling.md
+++ b/docs/notes/tooling.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: https://docs.google.com/document/d/15Xp8-0Ff_BPg_LMKr1RIKtwAavXGdrgb1BoX4Cl2bE4/edit
+redirect_to_url: https://docs.google.com/document/d/18oj3CLJQhZj1dMHKDTq_1kKg0syysKCS7pLyXlw1SRc/edit
 sitemap: false
 ---


### PR DESCRIPTION
The tooling group switched to a different notes document when they lost access to the prior one. Update the redirect to point to the active notes document.