### PR TITLE
Clarify insider threats on "About SLSA"

### DIFF
--- a/docs/spec/v1.0/about.md
+++ b/docs/spec/v1.0/about.md
@@ -131,7 +131,7 @@ important to consider together with SLSA such as:
     source code followed secure coding practices.
 -   Producer trust: SLSA does not address organizations that intentionally
     produce malicious software, but it can reduce insider risks within an
-    organization you trust. SLSA's Build track protects against tampering during
+    organization you trust. SLSA's Build Track protects against tampering during
     or after the build, and [future SLSA tracks](future-directions.md) intend to
     protect against unauthorized modifications of source code and dependencies.
 -   Transitive trust for dependencies: the SLSA level of an artifact is

--- a/docs/spec/v1.0/about.md
+++ b/docs/spec/v1.0/about.md
@@ -85,7 +85,7 @@ infrastructure for software.
 
 **Software producers**, such as an open source project, a software vendor, or a
 team writing first-party code for use within the same company. SLSA gives you
-protection against tampering along the supply chain to your consumers, thereby
+protection against tampering along the supply chain to your consumers, both
 reducing insider risk and increasing confidence that the software you produce
 reaches your consumers as you intended.
 
@@ -133,7 +133,7 @@ important to consider together with SLSA such as:
     produce malicious software, but it can reduce insider risks within an
     organization you trust. SLSA's Build track protects against tampering during
     or after the build, and [future SLSA tracks](future-directions.md) intend to
-    protect against unauthorized modifications of source code and dependenies.
+    protect against unauthorized modifications of source code and dependencies.
 -   Transitive trust for dependencies: the SLSA level of an artifact is
     independent of the level of its dependencies. You can use SLSA recursively to
     also judge an artifact's dependencies on their own, but there is

--- a/docs/spec/v1.0/about.md
+++ b/docs/spec/v1.0/about.md
@@ -131,11 +131,9 @@ important to consider together with SLSA such as:
     source code followed secure coding practices.
 -   Producer trust: SLSA does not address organizations that intentionally
     produce malicious software, but it can reduce insider risks within an
-    organization you trust. Currently SLSA's build track protects against
-    tampering during or after the build; a
-    [future SLSA Source track](future-directions#source-track) will also protect
-    against tampering before the build, particularly modifications to source
-    code.
+    organization you trust. SLSA's Build track protects against tampering during
+    or after the build, and [future SLSA tracks](future-directions.md) intend to
+    protect against unauthorized modifications of source code and dependenies.
 -   Transitive trust for dependencies: the SLSA level of an artifact is
     independent of the level of its dependencies. You can use SLSA recursively to
     also judge an artifact's dependencies on their own, but there is

--- a/docs/spec/v1.0/about.md
+++ b/docs/spec/v1.0/about.md
@@ -83,10 +83,11 @@ For more exploration of this analogy, see the blog post
 In short: everyone involved in producing and consuming software, or providing
 infrastructure for software.
 
-**Software producers**, such as a development team or open
-source maintainers. SLSA gives you protection against insider risk and tampering
-along the supply chain to your consumers, increasing confidence that the
-software you produce reaches your consumers as you intended.
+**Software producers**, such as an open source project, a software vendor, or a
+team writing first-party code for use within the same company. SLSA gives you
+protection against tampering along the supply chain to your consumers, thereby
+reducing insider risk and increasing confidence that the software you produce
+reaches your consumers as you intended.
 
 **Software consumers**, such as a development team using open source packages, a
 government agency using vendored software, or a CISO judging organizational
@@ -128,10 +129,13 @@ important to consider together with SLSA such as:
 
 -   Code quality: SLSA does not tell you whether the developers writing the
     source code followed secure coding practices.
--   Developer trust: SLSA cannot tell you whether a developer is
-    intentionally writing malicious code. If you trust a developer to write
-    code you want to consume, though, SLSA can guarantee that the code will
-    reach you without another party tampering with it.
+-   Producer trust: SLSA does not address organizations that intentionally
+    produce malicious software, but it can reduce insider risks within an
+    organization you trust. Currently SLSA's build track protects against
+    tampering during or after the build; a
+    [future SLSA Source track](future-directions#source-track) will also protect
+    against tampering before the build, particularly modifications to source
+    code.
 -   Transitive trust for dependencies: the SLSA level of an artifact is
     independent of the level of its dependencies. You can use SLSA recursively to
     also judge an artifact's dependencies on their own, but there is


### PR DESCRIPTION
Previously the "Who is SLSA for? / Software producers" bullet described producers as individuals rather than organizations, and said "insider risk and tampering" as though they were distinct threats. Similarly, the "What SLSA doesn't cover / Developer trust" bullet talked about the threat of individuals writing malicious code, which seems to be exactly the kind of "insider risk and tampering" threat described above.

This change fixes that by distinguishing between individuals and organizations. SLSA addresses the threat of individuals subverting the organization's goals, but does not address the organization having bad goals.

Addresses most of #805. There are still pending discussion around "insider" and "producer trust."
