### PR TITLE
css: improve look of :target element

### DIFF
--- a/docs/_sass/minima.scss
+++ b/docs/_sass/minima.scss
@@ -18,6 +18,7 @@ $grey-border: #dedede;
 
 $green-dark: #155757;
 $green-light: #58DA95;
+$green-lighter: #B4F3C9;
 $green-darkest: #102B2D;
 $green-pastel: #ECF8F2;
 $green-button: #23907E;

--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -556,6 +556,22 @@ body {
     }
 }
 
+// When a link is clicked, add enough scroll-padding to sure the header does not
+// occlude it, and briefly highlight it with a different color.
+html {
+    scroll-padding-top: $header-height+$spacer-m;
+    @include media-query-min($on-laptop) {
+        scroll-padding-top: $spacer-m;
+    }
+}
+.site-content :target {
+  animation: briefHighlight 2s;
+}
+@keyframes briefHighlight {
+  0% { background: $green-lighter; }
+  100% { background: none; }
+}
+
 .site-header-inner {
     background: $green-dark;
     height: $header-height;


### PR DESCRIPTION
When loading a link to a section within the page:

- Add enough scroll margin at the top to ensure that the header does not hide the target of the link.
- Briefly highlight the target of the link with a subtle background color to make it more clear what was actually clicked on.

Known limitations:

- Visually the highlight would look nicer the `line-height` of `h2` and family were about 1.6 (right now `h2` is 1 and `h3` and up are 1.3) but changing that would require some adjusting of other margins which I don't feel like doing right now.
- This doesn't fix the "draft" banner from being drawn over the link target. Fixing that would require either always setting a larger scroll margin (which would be too big once the banner is dismissed) or some more complicated solution. What is in this commit seemed like a good first step, at least.

To preview:

1.  Open a spec page, e.g. /spec/v1.0/requirements.
2.  Resize the window to less than 1200 px so that the header appears on scroll.
3.  Click on a link in the TOC to jump around within the page.
