### PR TITLE
Remove final "RFC" comment in provenance.md

### DIFF
--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -383,14 +383,6 @@ in the GitHub Actions example above. The field is REQUIRED, even if it is
 implicit from the signer, to aid readability and debugging. It is an object to
 allow additional fields in the future, in case one URI is not sufficient.
 
-> ⚠ **RFC:** Do we want/need to identify the tenant of the build system,
-> separately from the build system itself? If so, a single `id`
-> that combines both (e.g.
-> `https://builder.example/tenants/company1.example/project1`) or two separate
-> fields (e.g. `{"id": "https://builder.example", "tenant":
-> "https://company1.example/project1"}`)? What would the use case be for this?
-> How does [verification] work?
-
 ### BuildMetadata
 
 [BuildMetadata]: #buildmetadata


### PR DESCRIPTION
The last TODO or RFC comment was asking about adding a "tenant" field. I had anticipated sending out a PR to add such a field before RC2 but I didn't get it out in time. Let's remove the RFC since we're no longer asking for comments on this. Users who want this can file an issue.
