### PR TITLE
Provenance v1: rename `systemParameters` to `internalParameters`

### DIFF
--- a/docs/provenance/schema/v1/provenance.cue
+++ b/docs/provenance/schema/v1/provenance.cue
@@ -9,7 +9,7 @@
         "buildDefinition": {
             "buildType": string,
             "externalParameters": object,
-            "systemParameters": object,
+            "internalParameters": object,
             "resolvedDependencies": [ ...#ResourceDescriptor ],
         },
         "runDetails": {

--- a/docs/provenance/schema/v1/provenance.proto
+++ b/docs/provenance/schema/v1/provenance.proto
@@ -17,7 +17,7 @@ message Provenance {
 message BuildDefinition {
   string build_type = 1;
   google.protobuf.Struct external_parameters = 2;
-  google.protobuf.Struct system_parameters = 3;
+  google.protobuf.Struct internal_parameters = 3;
   repeated ResourceDescriptor resolved_dependencies = 4;
 }
 

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -62,7 +62,7 @@ The model is as follows:
         these values are untrusted; they MUST be included in the provenance and
         MUST be verified downstream.
 
-    -   `systemParameters`: set internally by the platform. In SLSA, these
+    -   `internalParameters`: set internally by the platform. In SLSA, these
         values are trusted because the platform is trusted; they are OPTIONAL
         and need not be verified downstream. They MAY be included to enable
         reproducible builds, debugging, or incident response.
@@ -161,7 +161,7 @@ parameters and dependencies.
 
 The URI SHOULD resolve to a human-readable specification that includes: overall
 description of the build type; schema for `externalParameters` and
-`systemParameters`; unambiguous instructions for how to initiate the build given
+`internalParameters`; unambiguous instructions for how to initiate the build given
 this BuildDefinition, and a complete example. Example:
 https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1
 
@@ -181,7 +181,7 @@ information that they need to check, the harder that task becomes.
 Verifiers SHOULD reject unrecognized or unexpected fields within
 `externalParameters`.
 
-<tr id="systemParameters"><td><code>systemParameters</code>
+<tr id="internalParameters"><td><code>internalParameters</code>
 <td>object<td>
 
 The parameters that are under the control of the entity represented by
@@ -206,11 +206,11 @@ The BuildDefinition describes all of the inputs to the build. It SHOULD contain
 all the information necessary and sufficient to initialize the build and begin
 execution.
 
-The `externalParameters` and `systemParameters` are the top-level inputs to the
+The `externalParameters` and `internalParameters` are the top-level inputs to the
 template, meaning inputs not derived from another input. Each is an arbitrary
 JSON object, though it is RECOMMENDED to keep the structure simple with string
 values to aid verification. The same field name SHOULD NOT be used for both
-`externalParameters` and `systemParameters`.
+`externalParameters` and `internalParameters`.
 
 The parameters SHOULD only contain the actual values passed in through the
 interface to the build system. Metadata about those parameter values,
@@ -478,7 +478,7 @@ The meaning of each field is unchanged unless otherwise noted.
             // especially if "source" is ambiguous or confusing.
             "source": old.invocation.configSource.uri,
         },
-        "systemParameters": old.invocation.environment,
+        "internalParameters": old.invocation.environment,
         "resolvedDependencies":
             old.materials + [
             {
@@ -529,7 +529,7 @@ Major refactor to reduce misinterpretation, including a minor change in model.
 -   Grouped fields into `buildDefinition` vs `runDetails`.
 -   Renamed:
     -   `parameters` -> `externalParameters` (slight change in semantics)
-    -   `environment` -> `systemParameters` (slight change in semantics)
+    -   `environment` -> `systemParameters` (RC1 + RC2) -> `internalParameters` (slight change in semantics)
     -   `materials` -> `resolvedDependencies` (slight change in semantics)
     -   `buildInvocationId` -> `invocationId`
     -   `buildStartedOn` -> `startedOn`


### PR DESCRIPTION
Action item from community meeting 4/10/2023 - fixes #815
I specifically left the RC1 and RC2 files alone and only updated the "v1" files- please let me know if you think that is wrong and we can correct that.