### PR TITLE
Add section on Build Platform Operations track to future directions

### DIFF
--- a/docs/spec/v1.0/future-directions.md
+++ b/docs/spec/v1.0/future-directions.md
@@ -66,11 +66,11 @@ the foundation of the guidance for
 [verifying build systems](verifying-systems.md), which **may or may not** form
 the basis for a future Build Platform Operations track:
 
--   Controls for access to build infrastructure and secrets along with records
-    when access is used.
--   Systems meet a to be determined set of security practices to minimize the
-    attack surface.
--   How cryptographic secrets used by the build system are stored and managed.
+-   Controls for approval, logging, and auditing of all physical and remote
+    access to platform infrastructure, cryptographic secrets, and privileged
+    debugging interfaces.
+-   Conformance to security best practices to minimize the risk of compromise.
+-   Protection of cryptographic secrets used by the build platform.
 
 </section>
 

--- a/docs/spec/v1.0/future-directions.md
+++ b/docs/spec/v1.0/future-directions.md
@@ -53,4 +53,25 @@ form the basis for a future Source track:
 
 </section>
 
+<section id="build-platform-operations-track">
+
+## Build Platform Operations track
+
+A Build Platform Operations track could provide assurances around the hardening
+of build platforms as they are operated.
+
+The initial [draft version (v0.1)] of SLSA included a section on
+[common requirements](../v0.1/requirements.md#common-requirements) that formed
+the foundation of the guidance for
+[verifying build systems](verifying-systems.md), which **may or may not** form
+the basis for a future Build Platform Operations track:
+
+-   Controls for access to build infrastructure and secrets along with records
+    when access is used.
+-   Systems meet a to be determined set of security practices to minimize the
+    attack surface.
+-   How cryptographic secrets used by the build system are stored and managed.
+
+</section>
+
 [draft version (v0.1)]: ../v0.1/requirements.md


### PR DESCRIPTION
This change was proposed in the SLSA Specification meeting on April 10, 2023 from a discussion on issue #802.

Secure build systems are essential for building secure artifacts. While the work leading up to the 1.0 release for the SLSA build track was not able to come to concensus around verifying build systems, there is potential for a future track that addresses build system concerns.

There is an opportunity for concerns to be met for those building and operating build systems, those checking conformance of those systems, and end-user of those systems. Each has their own needs.

Fixes #802

cc @MarkLodato 