### PR TITLE
css: prevent "draft" banner from occluding :target

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -54,8 +54,8 @@
 {%- assign spec_name = url_parts[1] %}
 {%- assign spec_version = url_parts[2] %}
 {%- if site.data.versions[spec_name].versions[spec_version].draft %}
+<input id="important-messages-checkbox" type="checkbox" hidden>
 <section class="important-messages">
-  <input id="important-messages-checkbox" type="checkbox" hidden>
   <div>
     <label for="important-messages-checkbox" title="dismiss">✕</label>
     <p>This is a working draft of {{ spec_version }}.</p>

--- a/docs/_sass/minima/_custom.scss
+++ b/docs/_sass/minima/_custom.scss
@@ -503,7 +503,7 @@ dl.as-table {
     top: $spacer-l !important;
   }
 
-  > input[type=checkbox]:checked + div {
+  #important-messages-checkbox:checked + & {
     display: none;
   }
 
@@ -529,6 +529,12 @@ dl.as-table {
       width: 1rem;
     }
   }
+}
+
+// When the banner is shown, add enough scroll-margin to all clickable links so
+// that the clicked element is not occluded by the banner.
+#important-messages-checkbox:not(:checked) ~ main *[id] {
+  scroll-margin-top: 100px;
 }
 
 body {


### PR DESCRIPTION
This is a follow-on to 9492b35 (#811).

When loading a link to a section within the page, add enough scroll padding to prevent the header from overlapping with the target.

While 9492b35 set the `scroll-padding-top` of `<html>` statically, this change sets the `scroll-margin-top` of all clickable elements dynamically based on whether or not the banner is visible. It's not possible to dynamically set the style of `<html>` based on the state of a checkbox (inside the `<html>`) since there is no CSS parent selector.

Preview: https://deploy-preview-822--slsa.netlify.app/spec/v1.0/requirements#provenance-unforgeable

In the following screenshot, the "Provenance is Unforgeable" link was clicked:

| Description | Screenshot |
| --- | --- |
| Before | ![before](https://user-images.githubusercontent.com/58860/231224438-5380409a-7b94-4e2d-a370-f5004fbcbfaf.png) |
| After | ![after](https://user-images.githubusercontent.com/58860/231224366-ed9178b3-17db-4746-9f7d-79eee4c43589.png) |


