### PR TITLE
Remove current_spec_version and unused code

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -39,8 +39,6 @@ plugins:
   - jekyll-readme-index
   - jekyll-titles-from-headings
   - jekyll-relative-links
-# WARNING: Remember to update _data/nav.yml as well.
-current_spec_version: "v0.1"
 relative_links:
   collections: true
 defaults:

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -1,10 +1,7 @@
 
 
 <header
-  class="site-header flex-none
-    {% if page.url != '/spec/{{ site.current_spec_version }}/' and page.url != {{ site.baseurl }} and page.url != '/' or page.url == '/spec/{{ site.current_spec_version }}/' -%}
-      is-specification-markdown
-    {%- endif %}"
+  class="site-header flex-none"
   x-data="{
     fixed: false,
     hidden: false,

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ testimonials:
             </div>
             <div class="w-full md:w-1/2 md:mt-0 mt-8">
                 <p>Any software can introduce vulnerabilities into a supply chain. As a system gets more complex, it’s critical to already have checks and best practices in place to guarantee artifact integrity, that the source code you’re relying on is the code you’re actually using. Without solid foundations and a plan for the system as it grows, it’s difficult to focus your efforts against tomorrow’s next hack, breach or compromise.</p>
-                <a href="spec/{{ site.current_spec_version }}/#supply-chain-threats" class="cta-link h5 font-semibold mt-8">More about supply chain attacks</a>
+                <a href="spec/v0.1/#supply-chain-threats" class="cta-link h5 font-semibold mt-8">More about supply chain attacks</a>
             </div>
         </div>
         <img class="mt-16 mx-auto w-full md:w-3/4" src="images/SupplyChainDiagram.svg" alt="the supply chain problem image">
@@ -99,7 +99,7 @@ testimonials:
                 <h4 class="h2 mb-8">Levels of assurance</h4>
                 <p>SLSA levels are like a common language to talk about how secure software, supply chains and their component parts really are. From source to platform, the levels blend together industry-recognized best practices to create four compliance levels of increasing assurance.
                 These look at the builds, sources and dependencies in open source or commercial software. Starting with easy, basic steps at the lower levels to build up and protect against advanced threats later, bringing SLSA into your work means prioritized, practical measures to prevent unauthorized modifications to software, and a plan to harden that security over time.</p>
-                <a href="spec/{{ site.current_spec_version }}/levels" class="cta-link h5 font-semibold mt-8">Read the level specifications</a>
+                <a href="spec/v0.1/levels" class="cta-link h5 font-semibold mt-8">Read the level specifications</a>
             </div>
             <div class="w-full md:w-2/4 md:mt-0 mt-8 pl-12">
                 <img class="w-3/4 mx-auto" src="images/badge-exploded.svg" alt="SLSA levels badge">
@@ -224,7 +224,7 @@ It’s adaptable, and it’s been designed with the wider security ecosystem in 
                 </a>
             </div>
             <div class="w-full md:w-1/2 getting_started_card md:pl-4">
-              <a href="spec/{{ site.current_spec_version }}/#specifications" class="hover:no-underline">
+              <a href="spec/v0.1/#specifications" class="hover:no-underline">
                   <div class="bg-white h-full rounded-lg p-10 flex flex-col">
                       <p class="h3 font-semibold mb-8 md:mb-6">Review the specifications</p>
                       <p>Want to learn about how it fits your organization’s security? Here’s the documentation behind the framework, with use cases, specific threats (and their prevention), provenance and fully detailed requirements.</p>

--- a/docs/levels.md
+++ b/docs/levels.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/levels # WARNING: This is brittle and will not update as per {{ site.current_spec_version }}
+redirect_to_url: spec/v0.1/levels
 sitemap: false
 ---

--- a/docs/provenance/v0.1.md
+++ b/docs/provenance/v0.1.md
@@ -506,4 +506,4 @@ Execution of arbitrary commands:
 [Timestamp]: https://github.com/in-toto/attestation/blob/main/spec/v0.1.0/field_types.md#Timestamp
 [TypeURI]: https://github.com/in-toto/attestation/blob/main/spec/v0.1.0/field_types.md#TypeURI
 [parsing rules]: https://github.com/in-toto/attestation/blob/main/spec/v0.1.0/README.md#parsing-rules
-[provenance requirements]: ../spec/{{ site.current_spec_version }}/requirements#provenance-requirements
+[provenance requirements]: ../spec/v0.1/requirements#provenance-requirements

--- a/docs/provenance/v0.2.md
+++ b/docs/provenance/v0.2.md
@@ -652,4 +652,4 @@ To migrate from [version 0.1][0.1] (`old`):
 [TypeURI]: https://github.com/in-toto/attestation/blob/main/spec/v0.1.0/field_types.md#TypeURI
 [in-toto attestation]: https://github.com/in-toto/attestation
 [parsing rules]: https://github.com/in-toto/attestation/blob/main/spec/v0.1.0/README.md#parsing-rules
-[provenance requirements]: ../spec/{{ site.current_spec_version }}/requirements#provenance-requirements
+[provenance requirements]: ../spec/v0.1/requirements#provenance-requirements

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/requirements # WARNING: This is brittle and will not update as per {{ site.current_spec_version }}
+redirect_to_url: spec/v0.1/requirements
 sitemap: false
 ---

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_to_url: v0.1 # WARNING: This is brittle and will not update as per {{ site.current_spec_version }}
+redirect_to_url: v0.1
 ---

--- a/docs/spec/v0.1/index.md
+++ b/docs/spec/v0.1/index.md
@@ -187,7 +187,7 @@ below, along with the rest of the essential specifications.
     </div>
 </a>
 </section>
-<section x-data="{ specificationPages: [], currentVersion: `{{site.current_spec_version|replace: "v", ""}}` }" class="section flex flex-col justify-center items-center">
+<section class="section flex flex-col justify-center items-center">
     <div class="wrapper inner w-full">
         <div class="md:flex justify-between items-start">
 <!-- no indentation here to get markdown working with jekyll commonmark for styling the headings better -->

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/terminology # WARNING: This is brittle and will not update as per {{ site.current_spec_version }}
+redirect_to_url: spec/v0.1/terminology
 sitemap: false
 ---

--- a/docs/threats.md
+++ b/docs/threats.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/threats # WARNING: This is brittle and will not update as per {{ site.current_spec_version }}
+redirect_to_url: spec/v0.1/threats
 sitemap: false
 ---

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/use-cases # WARNING: This is brittle and will not update as per {{ site.current_spec_version }}
+redirect_to_url: spec/v0.1/use-cases
 sitemap: false
 ---


### PR DESCRIPTION
This was intended to be an easy-to-use configuration parameter to point to the latest version of the spec, but in practice it was not actually helpful. In practice all of the pages have change between versions, so it's not helpful to have such a variable.

- It is only actually used in two places, neither of which are valuable:
  - The top-level index: this tried to point dynamically at the latest version but that won't work because all of the pages have changed between versions. We really do need to hard-code it here.
  - Provenance v0.1 and v0.2: we have since decided to tie the provenance and spec versions together, so these ought to be hard-coded to v0.1.
- All other uses are either comments or dead code. (The dead code is also removed in this commit.)

Part of #513.
