### PR TITLE
SLSA v1: Mark as Approved specification

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -19,14 +19,15 @@ spec:
       status: Approved
     v1.0-rc1:
       name: Version 1.0 RC1
-      status: Candidate
+      status: Retired
+      hidden: true
     v1.0-rc2:
       name: Version 1.0 RC2
-      status: Candidate
+      status: Retired
+      hidden: true
     v1.0:
-      name: Version 1.0 (DRAFT)
-      status: Draft
-      draft: true
+      name: Version 1.0
+      status: Approved
 
 provenance:
   versions:
@@ -38,14 +39,15 @@ provenance:
       status: Approved
     v1-rc1:
       name: Version 1.0 RC1
-      status: Candidate
+      status: Retired
+      hidden: true
     v1-rc2:
       name: Version 1.0 RC2
-      status: Candidate
+      status: Retired
+      hidden: true
     v1:
-      name: Version 1.0 (DRAFT)
-      status: Draft
-      draft: true
+      name: Version 1.0
+      status: Approved
 
 verification_summary:
   versions:
@@ -57,8 +59,8 @@ verification_summary:
       status: Approved
     v1-rc2:
       name: Version 1.0 RC2
-      status: Candidate
+      status: Retired
+      hidden: true
     v1:
-      name: Version 1.0 (DRAFT)
-      status: Draft
-      draft: true
+      name: Version 1.0
+      status: Approved

--- a/docs/provenance/schema/v1/provenance.cue
+++ b/docs/provenance/schema/v1/provenance.cue
@@ -4,7 +4,7 @@
     "subject": [...],
 
     // Predicate:
-    "predicateType": "https://slsa.dev/provenance/v1?draft",
+    "predicateType": "https://slsa.dev/provenance/v1",
     "predicate": {
         "buildDefinition": {
             "buildType": string,

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -517,7 +517,7 @@ The following fields from v0.2 are no longer present in v1.0:
 
 ## Change history
 
-### v1.0 (DRAFT)
+### v1.0
 
 Major refactor to reduce misinterpretation, including a minor change in model.
 

--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -10,10 +10,6 @@ levels that describe increasing security guarantees.
 This is **version 1.0** of the SLSA specification, which defines the SLSA
 levels and recommended attestation formats, including provenance.
 
-## About this release candidate
-
-This release candidate is a preview of version 1.0.
-
 {%- for section in site.data.nav.v10 %}
 {%- if section.children %}
 

--- a/docs/spec/v1.0/verifying-artifacts.md
+++ b/docs/spec/v1.0/verifying-artifacts.md
@@ -95,7 +95,7 @@ Given an artifact and its provenance:
     trust, resulting in a list of recognized public keys (or equivalent).
 2.  [Verify][processing-model] that statement's `subject` matches the digest of
     the artifact in question.
-3.  Verify that the `predicateType` is `https://slsa.dev/provenance/v1?draft`.
+3.  Verify that the `predicateType` is `https://slsa.dev/provenance/v1`.
 4.  Look up the SLSA Build Level in the roots of trust, using the recognized
     public keys and the `builder.id`, defaulting to SLSA Build L1.
 


### PR DESCRIPTION
- Mark SLSA v1.0, Provenance v1, and VSA v1 as Approved.
- Mark release candidates as Retired and hide them from the dropdown.
- Remove `?draft` from `predicateType`.

Part of #513.

**Important:** We cannot merge this until Tuesday, April 18, which is after the end of the mandatory [two-week review period](https://github.com/slsa-framework/governance/blob/main/5._Governance.md#4-specification-development-process). In the meantime, please review and approve so that we can merge on the 18th.

**Note:** This just marks v1.0 as approved. PR #832 sets the default version to v1.0.