### PR TITLE
Remove unused `current` version setting

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -7,7 +7,6 @@
 #           status: <string> # one of: Draft, Candidate, Approved, Retired
 #           draft: <bool, optional> # if true, display a "draft" warning banner
 #           hidden: <bool, optional> # if true, do not show in dropdown
-#       current: <version>
 #
 # Where:
 #   <spec> = specification name, i.e. first component of the URL
@@ -28,7 +27,6 @@ spec:
       name: Version 1.0 (DRAFT)
       status: Draft
       draft: true
-  current: v0.1
 
 provenance:
   versions:
@@ -48,7 +46,6 @@ provenance:
       name: Version 1.0 (DRAFT)
       status: Draft
       draft: true
-  current: v0.2
 
 verification_summary:
   versions:
@@ -65,4 +62,3 @@ verification_summary:
       name: Version 1.0 (DRAFT)
       status: Draft
       draft: true
-  current: v0.2

--- a/docs/_includes/status.html
+++ b/docs/_includes/status.html
@@ -1,9 +1,6 @@
 {%- assign url_parts = page.url | split: '/' %}
 {%- assign spec_name = url_parts[1] %}
 {%- assign spec_version = url_parts[2] %}
-{%- assign spec_version_num = spec_version | remove: 'v' %}
-{%- assign current_version = site.data.versions[spec_name].current %}
-{%- assign current_version_num = current_version | remove: 'v' %}
 
 {%- if site.data.versions[spec_name].versions[spec_version].status %}
 


### PR DESCRIPTION
This configuration setting is not used anywhere. Remove it for code health.

(The configuration for what shows the default left-hand nav menu is controlled by 

Part of #513.

Note: The default version for the left-hand nav menu is configured in [`data.nav.config.url_to_key.latest`](https://github.com/slsa-framework/slsa/blob/f7b23441fc6394a9062c69b149fbe236972a747f/docs/_data/nav/config.yml#L11), which is used as the default in [_includes/nav.html](https://github.com/slsa-framework/slsa/blob/f7b23441fc6394a9062c69b149fbe236972a747f/docs/_includes/nav.html#L10-L13).