### PR TITLE
Remove unused html redirect files

### DIFF
--- a/docs/provenance/index.html
+++ b/docs/provenance/index.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html lang="en-US">
-  <title>Redirecting&hellip;</title>
-  <meta http-equiv="refresh" content="0; url=v0.2">
-  <link rel="canonical" href="v0.2">
-  <meta name="robots" content="noindex">
-</html>

--- a/docs/provenance/v0.2-draft.html
+++ b/docs/provenance/v0.2-draft.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html lang="en-US">
-  <title>Redirecting&hellip;</title>
-  <meta http-equiv="refresh" content="0; url=v0.2">
-  <link rel="canonical" href="v0.2">
-  <meta name="robots" content="noindex">
-</html>

--- a/docs/verification_summary/index.html
+++ b/docs/verification_summary/index.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html lang="en-US">
-  <title>Redirecting&hellip;</title>
-  <meta http-equiv="refresh" content="0; url=v0.2">
-  <link rel="canonical" href="v0.2">
-  <meta name="robots" content="noindex">
-</html>


### PR DESCRIPTION
There are already Markdown files that do the redirect. The html files are redundant.

Part of #513.

To test, the following two URLs should still redirect to /v0.2 as before:

- https://deploy-preview-831--slsa.netlify.app/provenance/
- https://deploy-preview-831--slsa.netlify.app/provenance/v0.2-draft
- https://deploy-preview-831--slsa.netlify.app/verification_summary/
