### PR TITLE
SLSA v1: make v1.0 the default version

### DIFF
--- a/docs/_data/nav/config.yml
+++ b/docs/_data/nav/config.yml
@@ -8,7 +8,7 @@ url_to_key:
   v1: v10
   v1-rc1: v10-rc1
   v1-rc2: v10-rc2
-  latest: v02
+  latest: v10
 
 # TODO: when viewing spec v0.1, it would be better to link to attestations v0.2.
 # Not sure how to implement that though.

--- a/docs/community.md
+++ b/docs/community.md
@@ -79,8 +79,12 @@ developing tooling, we welcome your contributions.
 </div>
             </div>
             <div class="w-full md:w-1/2">
-                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is coming soon!</div>
-                <p>The SLSA v1.0 release candidate specification is out and <a href="/blog/2023/02/slsa-v1-rc">available for community review</a>. We anticipate a stable release soon. <br><br>
+                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is available now!</div>
+                <p>
+                <a href="spec/v1.0/">SLSA v1.0</a> is now available, released in April 2023.
+                We expect the specification to remain stable, with future versions expanding its breadth and depth.
+                For more information about this release, see <a href="/spec/v1.0/whats-new">What's new in v1.0</a>.
+                <br><br>
 Google has been using an internal version of SLSA since 2013 and requires it for all of their production workloads.</p>
             </div>
         </div>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/faq
+redirect_to_url: spec/v1.0/faq
 sitemap: false
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -86,7 +86,7 @@ testimonials:
             </div>
             <div class="w-full md:w-1/2 md:mt-0 mt-8">
                 <p>Any software can introduce vulnerabilities into a supply chain. As a system gets more complex, it’s critical to already have checks and best practices in place to guarantee artifact integrity, that the source code you’re relying on is the code you’re actually using. Without solid foundations and a plan for the system as it grows, it’s difficult to focus your efforts against tomorrow’s next hack, breach or compromise.</p>
-                <a href="spec/v0.1/#supply-chain-threats" class="cta-link h5 font-semibold mt-8">More about supply chain attacks</a>
+                <a href="spec/v1.0/threats-overview" class="cta-link h5 font-semibold mt-8">More about supply chain attacks</a>
             </div>
         </div>
         <img class="mt-16 mx-auto w-full md:w-3/4" src="images/SupplyChainDiagram.svg" alt="the supply chain problem image">
@@ -99,7 +99,7 @@ testimonials:
                 <h4 class="h2 mb-8">Levels of assurance</h4>
                 <p>SLSA levels are like a common language to talk about how secure software, supply chains and their component parts really are. From source to platform, the levels blend together industry-recognized best practices to create four compliance levels of increasing assurance.
                 These look at the builds, sources and dependencies in open source or commercial software. Starting with easy, basic steps at the lower levels to build up and protect against advanced threats later, bringing SLSA into your work means prioritized, practical measures to prevent unauthorized modifications to software, and a plan to harden that security over time.</p>
-                <a href="spec/v0.1/levels" class="cta-link h5 font-semibold mt-8">Read the level specifications</a>
+                <a href="spec/v1.0/levels" class="cta-link h5 font-semibold mt-8">Read the level specifications</a>
             </div>
             <div class="w-full md:w-2/4 md:mt-0 mt-8 pl-12">
                 <img class="w-3/4 mx-auto" src="images/badge-exploded.svg" alt="SLSA levels badge">
@@ -224,7 +224,7 @@ It’s adaptable, and it’s been designed with the wider security ecosystem in 
                 </a>
             </div>
             <div class="w-full md:w-1/2 getting_started_card md:pl-4">
-              <a href="spec/v0.1/#specifications" class="hover:no-underline">
+              <a href="spec/v1.0/" class="hover:no-underline">
                   <div class="bg-white h-full rounded-lg p-10 flex flex-col">
                       <p class="h3 font-semibold mb-8 md:mb-6">Review the specifications</p>
                       <p>Want to learn about how it fits your organization’s security? Here’s the documentation behind the framework, with use cases, specific threats (and their prevention), provenance and fully detailed requirements.</p>

--- a/docs/index.md
+++ b/docs/index.md
@@ -242,8 +242,12 @@ It’s adaptable, and it’s been designed with the wider security ecosystem in 
                 <p class="h2 p-0">Project status</p>
             </div>
             <div class="w-full md:w-1/2">
-                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mt-8 md:mt-0 mb-8 h4 font-semibold">SLSA v1.0 is coming soon!</div>
-                <p>The SLSA v1.0 release candidate specification is out and <a href="/blog/2023/02/slsa-v1-rc">available for community review</a>. We anticipate a stable release soon. <br><br>
+                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mt-8 md:mt-0 mb-8 h4 font-semibold">SLSA v1.0 is available now!</div>
+                <p>
+                <a href="spec/v1.0/">SLSA v1.0</a> is now available, released in April 2023.
+                We expect the specification to remain stable, with future versions expanding its breadth and depth.
+                For more information about this release, see <a href="/spec/v1.0/whats-new">What's new in v1.0</a>.
+                <br><br>
 Google has been using an internal version of SLSA since 2013 and requires it for all of their production workloads.</p>
             </div>
         </div>

--- a/docs/levels.md
+++ b/docs/levels.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/levels
+redirect_to_url: spec/v1.0/levels
 sitemap: false
 ---

--- a/docs/provenance/index.md
+++ b/docs/provenance/index.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: v0.2
+redirect_to_url: v1
 sitemap: false
 ---

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/requirements
+redirect_to_url: spec/v1.0/requirements
 sitemap: false
 ---

--- a/docs/spec/faq.md
+++ b/docs/spec/faq.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: v0.1/faq
+redirect_to_url: v1.0/faq
 sitemap: false
 ---

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,4 +1,4 @@
 ---
 layout: redirect
-redirect_to_url: v0.1
+redirect_to_url: v1.0
 ---

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/terminology
+redirect_to_url: spec/v1.0/terminology
 sitemap: false
 ---

--- a/docs/threats.md
+++ b/docs/threats.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/threats
+redirect_to_url: spec/v1.0/threats
 sitemap: false
 ---

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: spec/v0.1/use-cases
+redirect_to_url: spec/v1.0/use-cases
 sitemap: false
 ---

--- a/docs/verification_summary/index.md
+++ b/docs/verification_summary/index.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: v0.2
+redirect_to_url: v1
 sitemap: false
 ---


### PR DESCRIPTION
- Make v1.0 the default nav version.
- Update front page to link to v1.0.
- Update redirects to point to v1.0.
- Update "project status" on index and community to say that v1.0 is stable.

Part of #513.

**Imprortant:** We will not merge this until after #829 (on Tuesday, April 18).

**Note:** This just sets the default version to v1.0. PR #829 marks it as Approved.
