### PR TITLE
Provenance: raise visibility of changes since RCs

### DIFF
--- a/docs/provenance/v1-rc1.md
+++ b/docs/provenance/v1-rc1.md
@@ -192,6 +192,8 @@ reproducing the build. There is no need to [verify][Verification] these
 parameters because the build system is already trusted, and in many cases it is
 not practical to do so.
 
+***NOTE:** This field is named `internalParameters` in [v1](v1.md) final.*
+
 <tr id="resolvedDependencies"><td><code>resolvedDependencies</code>
 <td>array (<a href="#artifactreference">ArtifactReference</a>)<td>
 

--- a/docs/provenance/v1-rc2.md
+++ b/docs/provenance/v1-rc2.md
@@ -191,6 +191,8 @@ reproducing the build. There is no need to [verify][Verification] these
 parameters because the build system is already trusted, and in many cases it is
 not practical to do so.
 
+***NOTE:** This field is named `internalParameters` in [v1](v1.md) final.*
+
 <tr id="resolvedDependencies"><td><code>resolvedDependencies</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/main/spec/v1.0/resource_descriptor.md">ResourceDescriptor</a>)<td>
 

--- a/docs/provenance/v1.md
+++ b/docs/provenance/v1.md
@@ -527,7 +527,7 @@ Major refactor to reduce misinterpretation, including a minor change in model.
 -   Grouped fields into `buildDefinition` vs `runDetails`.
 -   Renamed:
     -   `parameters` -> `externalParameters` (slight change in semantics)
-    -   `environment` -> `systemParameters` (RC1 + RC2) -> `internalParameters` (slight change in semantics)
+    -   `environment` -> `internalParameters` (slight change in semantics)
     -   `materials` -> `resolvedDependencies` (slight change in semantics)
     -   `buildInvocationId` -> `invocationId`
     -   `buildStartedOn` -> `startedOn`
@@ -545,6 +545,13 @@ Major refactor to reduce misinterpretation, including a minor change in model.
     -   Builder: `builderDependencies` and `version`
     -   `byproducts`
 -   Changed naming convention for extension fields.
+
+Differences from RC1 and RC2:
+
+-   Renamed `systemParameters` (RC1 + RC2) -> `internalParameters` (final).
+-   Changed naming convention for extension fields (in RC2).
+-   Renamed `localName` (RC1) -> `name` (RC2).
+-   Added `annotations` and `content` (in RC2).
 
 ### v0.2
 


### PR DESCRIPTION
Previously it was not obvious what the changes were between RC1, RC2, and final. Now readers who are interested can see the specific section. Also call out the rename in v1-rc1 and v1-rc2 documentation, since some readers may get caught off-guard.

The current design shows all changes from the previous stable release (v0.2), then repeats the changes since RC1 and RC2. Most readers likely care about the former, so making the RC1/RC2 differences less prominent seems worthwhile. An alternative is to list RC1 and RC2 in the change history, but that is probably a loss of readability for most readers.
