### PR TITLE
Link to Terminology beneath each supply chain diagram

### DIFF
--- a/docs/spec/v1.0/threats-overview.md
+++ b/docs/spec/v1.0/threats-overview.md
@@ -14,8 +14,8 @@ SLSA can help. For a more technical discussion, see [Threats & mitigations](thre
 
 ![Supply Chain Threats](../../images/v1.0/supply-chain-threats.svg)
 
-(See [Terminology](terminology.md) for an explanation of the supply chain
-model.)
+See [Terminology](terminology.md) for an explanation of the supply chain
+model.
 
 SLSA's primary focus is supply chain integrity, with a secondary focus on
 availability. Integrity means protection against tampering or unauthorized

--- a/docs/spec/v1.0/threats-overview.md
+++ b/docs/spec/v1.0/threats-overview.md
@@ -14,6 +14,9 @@ SLSA can help. For a more technical discussion, see [Threats & mitigations](thre
 
 ![Supply Chain Threats](../../images/v1.0/supply-chain-threats.svg)
 
+(See [Terminology](terminology.md) for an explanation of the supply chain
+model.)
+
 SLSA's primary focus is supply chain integrity, with a secondary focus on
 availability. Integrity means protection against tampering or unauthorized
 modification at any stage of the software lifecycle. Within SLSA, we divide

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -19,6 +19,8 @@ The examples on this page are meant to:
 
 ![Supply Chain Threats](../../images/v1.0/supply-chain-threats.svg)
 
+See [Terminology](terminology.md) for an explanation of supply chain model.
+
 ## Source threats
 
 A source integrity threat is a potential for an adversary to introduce a change

--- a/docs/spec/v1.0/verifying-artifacts.md
+++ b/docs/spec/v1.0/verifying-artifacts.md
@@ -28,7 +28,10 @@ Verification SHOULD include the following steps:
 
 ![Threats covered by each step](/images/v1.0/supply-chain-threats-build-verification.svg)
 
-Note: This section assumes that the provenance is in the recommended
+See [Terminology](terminology.md) for an explanation of supply chain model and
+[Threats & mitigations](threats.md) for a detailed explanation of each threat.
+
+**Note:** This section assumes that the provenance is in the recommended
 [provenance format](/provenance/v1). If it is not, then the verifier SHOULD
 perform equivalent checks on provenance fields that correspond to the ones
 referenced here.


### PR DESCRIPTION
The diagram assumes familiarity with the SLSA supply chain model. Remind the reader that the Terminology page explains the components of the diagram.

Fixes #844.
