### PR TITLE
Adds a Github Actions workflow to automate the deployment of the website

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -1,0 +1,42 @@
+name: Deploy Website
+run-name: Deploy Website
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch: # Allows to run this workflow manually from the Actions tab.
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+      runs-on: ubuntu-latest
+      steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup pages
+        uses: actions/configure-pages@v3
+      - name: Build
+        uses: actions/jekyll-build-pages@v1
+        with:
+            source: ./docs
+      - name: Upload artifacts
+        uses: actions/upload-pages-artifact@v1
+  
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy Website
+        id: deployment
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This pull request is one of the actions item from [Restructure the Versioning System for SLSA](https://github.com/slsa-framework/slsa-proposals/pull/10), specifically the "[Automate Building and Deploying The Website](https://github.com/slsa-framework/slsa-proposals/blob/main/0006/README.md#automate-building-and-deploying-the-website)" section.

I tested this action by running it on my own fork:

- Github Action workflow run: [link](https://github.com/chtiangg/slsa/actions/runs/5146549884)
- Deployed website: https://chtiangg.github.io/slsa (note: there is a "slsa" suffix and it disables the version-selection on the website).