### PR TITLE
Update notes redirects following recent Google Doc moves

### DIFF
--- a/docs/notes/community.md
+++ b/docs/notes/community.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: https://docs.google.com/document/d/1cx3fOBfic6A0xc2on25ITK4vQHUdxgBmJoSS1LPqDJo/edit
+redirect_to_url: https://docs.google.com/document/d/1JbJZxeZOWE7rxT24iEozX35LIUl_Yoqd-DeSm6309GA/edit
 sitemap: false
 ---

--- a/docs/notes/specification.md
+++ b/docs/notes/specification.md
@@ -1,5 +1,5 @@
 ---
 layout: redirect
-redirect_to_url: https://docs.google.com/document/d/1kMP62o3KI0IqjPRSNtUqADodBqpEL_wlL1PEOsl6u20/edit
+redirect_to_url: https://docs.google.com/document/d/1PwhekVB1iDpcgCQRNVN_aesoVdOiTruoebCs896aGxw/edit
 sitemap: false
 ---


### PR DESCRIPTION
The Google Docs for the community and specification meetings were recently changed to be documents in the OpenSSF Shared Google Drive to avoid ownership issues. Update the notes/ redirects to point to the new locations.

Fixes: #879