### PR TITLE
Fix new deploy website action

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -7,8 +7,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
 
 concurrency:
   group: "pages"
@@ -28,6 +26,9 @@ jobs:
         uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187 # v1.0.8
   
   deploy:
+    permissions:
+      pages: write
+      id-token: write # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages.
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -28,6 +28,9 @@ jobs:
         uses: actions/upload-pages-artifact@64bcae551a7b18bcb9a09042ddf1960979799187 # v1.0.8
   
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
In #871 we removed the `environment` specification from the `deploy` job during code review (at [my querying](https://github.com/slsa-framework/slsa/pull/871#discussion_r1214218701)), but it turns out it _is_ required to set the environment (even if the docs for the action don't make that 100% clear).

This PR re-introduces the environment configuration for the deploy job. In addition, it moves the permissions required for the deploy job to that job (PLP).