### PR TITLE
impl: add convenience `/gh` redirect to our GitHub repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ node_modules
 # Ignore the following files markdownlint that are already tracked by git (thus
 # uanffected by gitignore).
 /LICENSE.md
+
+# Local Netlify folder
+.netlify

--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ specification, and overall project management. Other git repositories within the
 [slsa-framework](https://github.com/slsa-framework) organization have
 repo-specific issue trackers.
 
+## URL Aliases
+
+We have several [redirect](docs/_redirects) configured on slsa.dev for
+convenience of the team:
+
+-   https://slsa.dev/gh &rArr; SLSA GitHub repo
+    -   https://slsa.dev/gh/issues
+    -   https://slsa.dev/gh/pulls
+    -   etc...
+-   https://slsa.dev/notes &rArr; meeting notes
+    -   https://slsa.dev/notes/community
+    -   https://slsa.dev/notes/positioning
+    -   https://slsa.dev/notes/specification
+        (or [.../spec](https://slsa.dev/notes/spec))
+    -   https://slsa.dev/notes/tooling
+
 ## How to get involved
 
 See https://slsa.dev/community for ways to get involved in SLSA development.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -7,6 +7,8 @@ collections:
     layout: post
     output: true
     permalink: /blog/:year/:month/:title
+include:
+  - _redirects
 exclude:
   - CNAME
   - Gemfile

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,0 +1,4 @@
+# Documentation: https://docs.netlify.com/routing/redirects/redirect-options/
+
+# Convenience aliases for the team. Remember to document on ../README.md.
+/gh/*           https://github.com/slsa-framework/slsa/:splat


### PR DESCRIPTION
Now `https://slsa.dev/gh[/...]` is an easier-to-type alias for `https://github.com/slsa-framework/slsa[/...]`.

This is the first PR that sets up Netlify redirects. Future PRs will update our existing redirects to use this new framework.

Can be tested through deploy previews or through the Netlify CLI. (Future PR will update our dev documentation.)

Previews:

* https://deploy-preview-893--slsa.netlify.app/gh
* https://deploy-preview-893--slsa.netlify.app/gh/issues
* https://deploy-preview-893--slsa.netlify.app/gh/pulls

Signed-off-by: Mark Lodato <lodato@google.com>
