### PR TITLE
spec-editorial: fix provence->provenance typo in threats

### DIFF
--- a/docs/spec/v0.1/threats.md
+++ b/docs/spec/v0.1/threats.md
@@ -535,7 +535,7 @@ cryptographic secret that should only be available to the build service.
 and only the control plane has access to cryptographic secrets. <sup>[[Isolated]
 @ SLSA 3]</sup>
 
-*Example:* Provence is signed on the build worker, which the adversary has
+*Example:* Provenance is signed on the build worker, which the adversary has
 control over. Adversary uses a malicious process that generates false provenance
 and signs it using the provenance signing key. Solution: Builder generates and
 signs provenance in the trusted control plane; the worker has no access to the

--- a/docs/spec/v1.0-rc1/threats.md
+++ b/docs/spec/v1.0-rc1/threats.md
@@ -525,7 +525,7 @@ cryptographic secret that should only be available to the build service.
 plane, and only the control plane has [access][non-forgeable] to cryptographic
 secrets.
 
-*Example:* Provence is signed on the build worker, which the adversary has
+*Example:* Provenance is signed on the build worker, which the adversary has
 control over. Adversary uses a malicious process that generates false provenance
 and signs it using the provenance signing key. Solution: Builder generates and
 signs provenance in the trusted control plane; the worker has no access to the

--- a/docs/spec/v1.0-rc2/threats.md
+++ b/docs/spec/v1.0-rc2/threats.md
@@ -289,7 +289,7 @@ cryptographic secret that should only be available to the build service.
 plane, and only the control plane has [access][unforgeable] to cryptographic
 secrets.
 
-*Example:* Provence is signed on the build worker, which the adversary has
+*Example:* Provenance is signed on the build worker, which the adversary has
 control over. Adversary uses a malicious process that generates false provenance
 and signs it using the provenance signing key. Solution: Builder generates and
 signs provenance in the trusted control plane; the worker has no access to the

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -291,7 +291,7 @@ cryptographic secret that should only be available to the build platform.
 plane, and only the control plane has [access][unforgeable] to cryptographic
 secrets.
 
-*Example:* Provence is signed on the build worker, which the adversary has
+*Example:* Provenance is signed on the build worker, which the adversary has
 control over. Adversary uses a malicious process that generates false provenance
 and signs it using the provenance signing key. Solution: Builder generates and
 signs provenance in the trusted control plane; the worker has no access to the


### PR DESCRIPTION
Each version of the threats page features a typo in an example where provenance is spelled provence, this change fixes each instance of the typo.