### PR TITLE
editorial: clarify requirements around cache use by the build platform

### DIFF
--- a/docs/spec/v1.0/provenance.md
+++ b/docs/spec/v1.0/provenance.md
@@ -87,8 +87,7 @@ The model is as follows:
     captured directly in the provenance, but is instead implied by `builder.id`
     and subject to [SLSA Requirements](requirements.md). Such
     communication SHOULD NOT influence the definition of the build; if it does,
-    it SHOULD go in `resolvedDependencies` instead. Cache communications MUST NOT
-    be present at SLSA Build L3.
+    it SHOULD go in `resolvedDependencies` instead.
 
 -   Finally, the build process outputs one or more artifacts, identified by
     `subject`.

--- a/docs/spec/v1.0/provenance.md
+++ b/docs/spec/v1.0/provenance.md
@@ -87,7 +87,8 @@ The model is as follows:
     captured directly in the provenance, but is instead implied by `builder.id`
     and subject to [SLSA Requirements](requirements.md). Such
     communication SHOULD NOT influence the definition of the build; if it does,
-    it SHOULD go in `resolvedDependencies` instead.
+    it SHOULD go in `resolvedDependencies` instead. Cache communications MUST NOT
+    be present at SLSA Build L3.
 
 -   Finally, the build process outputs one or more artifacts, identified by
     `subject`.

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -318,7 +318,7 @@ If the build platform leverages a cache for builds, it MUST guarantee the follow
     words, the output of the build MUST be identical whether or not the cache is
     used.
 -   If the build platform is capable of providing the provenance for an external
-    resource without a cache, then the provenance SHOULD remain unchanged if a cache
+    resource without a cache, then the provenance MUST remain unchanged if a cache
     is used. In other words, the output of the provenance MUST be identical whether
     or not the cache is used.
 

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -317,11 +317,12 @@ If the build platform leverages a cache for builds, it MUST guarantee the follow
     cache used by another build, also known as "cache poisoning". In other
     words, the output of the build MUST be identical whether or not the cache is
     used.
--   If the build platform is capable of providing the provenance for an external
-    resource without a cache, then the provenance MUST remain unchanged if a cache
-    is used. In other words, the output of the provenance MUST be identical whether
-    or not the cache is used. Communication with the build cache MUST NOT be present
-    in `resolvedDependencies`.
+-   If the build platform is capable of providing the provenance information for
+    an external resource when a cache is not in use, then the provenance
+    information MUST remain unchanged if a cache is used. In other words, the
+    information in the provenance MUST be identical whether or not the cache is
+    used. Communication with the build cache MUST NOT be represented in
+    `resolvedDependencies`.
 
 There are no sub-requirements on the build itself. Build L3 is limited to
 ensuring that a well-intentioned build runs securely. It does not require that

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -328,8 +328,7 @@ ensuring that a well-intentioned build runs securely. It does not require that
 a build platform prevents a producer from performing a risky or insecure build. In
 particular, the "Isolated" requirement does not prohibit a build from calling
 out to a remote execution service or a "self-hosted runner" that is outside the
-trust boundary of the build platform. Additionally, build L3 does not prohibit
-builds from resolving dependencies outside of the knowledge of the build platform.
+trust boundary of the build platform.
 
 NOTE: This requirement was split into "Isolated" and "Ephemeral Environment"
 in the initial [draft version (v0.1)](../v0.1/requirements.md).

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -317,15 +317,18 @@ If the build platform leverages a cache for builds, it MUST guarantee the follow
     cache used by another build, also known as "cache poisoning". In other
     words, the output of the build MUST be identical whether or not the cache is
     used.
--   The resolved dependencies used to generate the cached artifacts MUST be captured
-    in the provenance.
+-   If the build platform is capable of providing the provenance for an external
+    resource without a cache, then the provenance SHOULD remain unchanged if a cache
+    is used. In other words, the output of the provenance MUST be identical whether
+    or not the cache is used.
 
 There are no sub-requirements on the build itself. Build L3 is limited to
 ensuring that a well-intentioned build runs securely. It does not require that
 a build platform prevents a producer from performing a risky or insecure build. In
 particular, the "Isolated" requirement does not prohibit a build from calling
 out to a remote execution service or a "self-hosted runner" that is outside the
-trust boundary of the build platform.
+trust boundary of the build platform. Additionally, build L3 does not prohibit
+builds from resolving dependencies outside of the knowledge of the build platform.
 
 NOTE: This requirement was split into "Isolated" and "Ephemeral Environment"
 in the initial [draft version (v0.1)](../v0.1/requirements.md).

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -307,13 +307,18 @@ The build platform MUST guarantee the following:
 -   It MUST NOT be possible for one build to persist or influence the build
     environment of a subsequent build. In other words, an ephemeral build
     environment MUST be provisioned for each build.
+-   The build platform MUST NOT open services that allow for remote influence
+    unless all such interactions are captured as `externalParameters` in the
+    provenance.
+
+If the build platform leverages a cache for builds, it MUST guarantee the following:
+
 -   It MUST NOT be possible for one build to inject false entries into a build
     cache used by another build, also known as "cache poisoning". In other
     words, the output of the build MUST be identical whether or not the cache is
     used.
--   The build platform MUST NOT open services that allow for remote influence
-    unless all such interactions are captured as `externalParameters` in the
-    provenance.
+-   The resolved dependencies used to generate the cached artifacts MUST be captured
+    in the provenance.
 
 There are no sub-requirements on the build itself. Build L3 is limited to
 ensuring that a well-intentioned build runs securely. It does not require that

--- a/docs/spec/v1.0/requirements.md
+++ b/docs/spec/v1.0/requirements.md
@@ -320,7 +320,8 @@ If the build platform leverages a cache for builds, it MUST guarantee the follow
 -   If the build platform is capable of providing the provenance for an external
     resource without a cache, then the provenance MUST remain unchanged if a cache
     is used. In other words, the output of the provenance MUST be identical whether
-    or not the cache is used.
+    or not the cache is used. Communication with the build cache MUST NOT be present
+    in `resolvedDependencies`.
 
 There are no sub-requirements on the build itself. Build L3 is limited to
 ensuring that a well-intentioned build runs securely. It does not require that


### PR DESCRIPTION
There was an inconsistency between the provenance model and build L3 requirements for how build caches might affect a build:

* The provenance model indicated that communication with a cache MAY influence the definition of a build (and if it does, then the communication SHOULD go in `resolvedDependencies`).
* The build isolation requirements indicated that the build output MUST be identical whether a cache is used.

Clarification includes:

* At build L3, the provenance MUST be identical whether a build platform's cache is used or not.
* This implies that all communication with the build cache is to leverage `byproducts` which should not be present in the provenance.
* Builds are not precluded from using a cache outside the build platform and therefore outside these isolation requirements.

Clarification does NOT include:

* Requirements between cache utilization and reproducible builds as reproducibility is not covered in the build track.

Addresses #894

Signed-off-by: arewm <arewm@users.noreply.github.com>