### PR TITLE
nonspec: community meeting is no longer biweekly

### DIFF
--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -10,7 +10,7 @@ meeting link, etc. at the top.
 
 URL                            | Alias        | Meeting
 ------------------------------ | ------------ | ---------------------------
-[community](community)         |              | Bi-weekly community meeting
+[community](community)         |              | General community meeting
 [positioning](positioning)     |              | Positioning SIG
 [specification](specification) | [spec](spec) | Specification SIG
 [tooling](tooling)             |              | Tooling SIG


### PR DESCRIPTION
Update the list of meeting notes on slsa.dev/notes to no longer say
"bi-weekly".
