### PR TITLE
impl: only call enforce-tags on relevant events

### DIFF
--- a/.github/workflows/enforce-tags.yml
+++ b/.github/workflows/enforce-tags.yml
@@ -2,6 +2,10 @@ name: "Lint PR name"
 
 on:
   pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 permissions:
   pull-requests: read


### PR DESCRIPTION
The action's documentation says that only these three events are needed.
Without that, the action is called unnecessarily.

Signed-off-by: Mark Lodato <lodato@google.com>
