### PR TITLE
impl: improve readability of CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,11 @@ Alternately you can look for issues with a [`shovel-ready`](https://github.com/s
 
 ## Proposing changes
 
-Unless a change is small enough to be fully discussed in a pull request, we
-recommend the following process to propose and reach agreement on changes:
+If a change is small enough to be fully discussed in a pull request, jump
+straight to [Submitting changes].
+
+Otherwise, we recommend the following process to propose and reach agreement on
+changes:
 
 1.  The proposer finds or creates a [GitHub Issue][Issues] describing the
     problem and proposes an idea to address that problem.
@@ -36,14 +39,16 @@ recommend the following process to propose and reach agreement on changes:
     to fully describe in an Issue comment.
 
 4.  Once there is general agreement that the proposal is sound, the proposer
-    [submits](#submitting-changes) a pull request implementing the idea. Final
+    [submits][submitting changes] a pull request implementing the idea. Final
     agreement happens on the pull request.
 
 [proposal document]: https://github.com/slsa-framework/slsa-proposals
 
 ## Submitting changes
 
-All changes require peer review through GitHub's pull request feature.
+[submitting changes]: #submitting-changes
+
+All changes require peer review through GitHub's pull request (PR) feature.
 
 ### Markdown style
 
@@ -58,22 +63,28 @@ this is not currently enforced).
 
 PRs are expected to meet the following conventions:
 
-    -   PR title is of the form `<tag>: <title>`, where `<tag>` is one of the
-        values in the table below.
+-   PR title is of the form `<tag>: <title>`, where:
+    -   `<tag>` is one of the values in the table below.
+    -   `<title>` concisely explains *what* the PR does.
+-   PR description explains *what* and *why* in a bit more detail, providing
+    enough context for a reader to understand the change. See
+    [Writing good CL descriptions](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
+    for more advice (in that doc, "CL" means PR and "first line" means PR title;
+    ignore the section about tags.)
+-   PR title and description use imperative tense, e.g. "update X" (not "updated
+    X" or "updates X").
+-   Every commit has a [signed-off-by] tag.
+    -   Note: Commit messages do not otherwise matter because we use the [squash
+        and merge] method, with the PR title and description as the squash
+        commit message.
+-   Example of a good PR title and description:
+    https://github.com/slsa-framework/slsa/pull/840 (predates our `<tag>`
+    convention).
 
-    -   PR title concisely explains *what* the PR does.
-
-    -   PR description explains *what* and *why* in a bit more detail, providing
-        enough context for a reader to understand the change. See
-        [Writing good CL descriptions](https://google.github.io/eng-practices/review/developer/cl-descriptions.html)
-        for more advice ("CL" = PR and "first line" = PR title; ignore the
-        section about tags.)
-
-    -   Use imperative tense, e.g. "update X" (not "updated X" or "updates X")
-
-    -   Example of a good PR title and description:
-        https://github.com/slsa-framework/slsa/pull/840 (predates our `<tag>`
-        convention).
+Every PR must use one of the following `<tag>` values. Earlier entries in the
+table have higher precedence. (See [review and approval] for the meaning of
+"waiting period" and "# approvers".) If you are not sure, take a guess and a
+maintainer will update if needed.
 
 | Tag | Description | Waiting period | # Approvers |
 |---|---|---|---|
@@ -89,7 +100,11 @@ approvers for their own PRs. For example, if the author of a PR with the
 two additional approvers before merging. However, a PR with the `impl` tag
 always requires one reviewer, even if the author has write access.
 
+[squash and merge]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits
+
 ### Review and approval
+
+[review and approval]: #review-and-approval
 
 Review process:
 
@@ -111,6 +126,8 @@ Review process:
     PR's comment thread to request the PR be merged.
 
 ### Signing your work
+
+[signed-off-by]: #signing-your-work
 
 When contributing patches to the project via pull request, please indicate that
 you wrote the patch or have permission to pass it on by including your sign-off.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,8 @@ recommend the following process to propose and reach agreement on changes:
 
 ## Submitting changes
 
+All changes require peer review through GitHub's pull request feature.
+
 ### Markdown style
 
 Changes to any of the Markdown files in the repository should meet our Markdown
@@ -50,13 +52,11 @@ style, as encoded in our [markdownlint configuration](.markdownlint.yaml). In
 addition we prefer to keep our Markdown documents wrapped at 80 columns (though
 this is not currently enforced).
 
-### Review and approval
+### Pull request conventions
 
-All changes require peer review through GitHub's pull request feature.
+[pull request conventions]: #pull-request-conventions
 
-Review process:
-
-1.  Ensure the PR title and description meet the following guidelines:
+PRs are expected to meet the following conventions:
 
     -   PR title is of the form `<tag>: <title>`, where `<tag>` is one of the
         values in the table below.
@@ -75,6 +75,26 @@ Review process:
         https://github.com/slsa-framework/slsa/pull/840 (predates our `<tag>`
         convention).
 
+| Tag | Description | Waiting period | # Approvers |
+|---|---|---|---|
+| `content` | A change to the meaning of the specification | 72h | 3 |
+| `editorial` | A clarification to the specification that does not change its meaning | 24h | 2 |
+| `nonspec` | A change to a non-specification page. | 24h | 2 |
+| `style` | A user-visible style or layout change. No context changes. | 0h | 1 |
+| `impl` | A user-invisible change, such as editing a README or the repo configuration. | 0h | 1 |
+
+Note: PR authors with write access to the repo count as second or third
+approvers for their own PRs. For example, if the author of a PR with the
+`content` tag has write access to the repo, then the PR only requires
+two additional approvers before merging. However, a PR with the `impl` tag
+always requires one reviewer, even if the author has write access.
+
+### Review and approval
+
+Review process:
+
+1.  Ensure that the PR meets the [pull request conventions].
+
 2.  GitHub will automatically assign the maintainers as reviewers. You will need
     a different number of approvals for different PR tags. Your reviewers may
     ask that you use a different PR tag.
@@ -89,20 +109,6 @@ Review process:
     If your PR has not been merged within 48h of the waiting period having
     passed, and a reason for that has not been added as a PR comment, use the
     PR's comment thread to request the PR be merged.
-
-| Tag | Description | Waiting period | # Approvers |
-|---|---|---|---|
-| `content` | A change to the meaning of the specification | 72h | 3 |
-| `editorial` | A clarification to the specification that does not change its meaning | 24h | 2 |
-| `nonspec` | A change to a non-specification page. | 24h | 2 |
-| `style` | A user-visible style or layout change. No context changes. | 0h | 1 |
-| `impl` | A user-invisible change, such as editing a README or the repo configuration. | 0h | 1 |
-
-Note: PR authors with write access to the repo count as second or third
-approvers for their own PRs. For example, if the author of a PR with the
-`content` tag has write access to the repo, then the PR only requires
-two additional approvers before merging. However, a PR with the `impl` tag
-always requires one reviewer, even if the author has write access.
 
 ### Signing your work
 


### PR DESCRIPTION
Apply some minor editorial changes to improve readability without
changing the meaning:

- Split out "pull request conventions" into a separate section, since it
  was a bit buried in "review and approval." The former is what the user
  does before the PR is sent, while the latter is what to expect after
  it is sent.
- Remind the reader in the "pull request conventions" that every commit
  needs to be signed off but otherwise does not matter due to
  squash-and-merge. This was easy to miss before.
- Explain that the table is in order of precedence and that a maintainer
  will update the tag if needed.
- Apply various wording improvements.

## Note to reviewers

This PR is hard to review as a whole since it moves AND edits the same hunk. I recommend viewing each commit individually. The first commit just moves the text verbatim while the second edits it.
