### PR TITLE
impl: use Netlify redirects instead of HTML

### DIFF
--- a/docs/_layouts/redirect.html
+++ b/docs/_layouts/redirect.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html lang="en-US">
-  <title>Redirecting&hellip;</title>
-  <meta http-equiv="refresh" content="0; url={{ page.redirect_to_url }}">
-  <link rel="canonical" href="{{ page.redirect_to_url }}">
-  <meta name="robots" content="noindex">
-</html>

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,4 +1,49 @@
 # Documentation: https://docs.netlify.com/routing/redirects/redirect-options/
+# vim: set sw=4 sts=4:
+#
+# Guidance:
+# - Always specify 301 vs 302. (301 is the default, but better to be explicit.)
+# - Only use 301 when it's OK for client to cache indefinitely. Common use case
+#   is for moved content, e.g. /foo is renamed to /bar.
+# - Rule of thumb: if it's an alias, e.g. /foo -> /foo/v1, use 302.
+# - Align columns on multiples of 4.
 
-# Convenience aliases for the team. Remember to document on ../README.md.
-/gh/*           https://github.com/slsa-framework/slsa/:splat
+# --- Team-internal convenience aliases ---
+#
+# Remember to document on ../README.md.
+
+/gh/*                   https://github.com/slsa-framework/slsa/:splat   301
+
+/notes/community        https://docs.google.com/document/d/1JbJZxeZOWE7rxT24iEozX35LIUl_Yoqd-DeSm6309GA/edit    302
+/notes/positioning      https://docs.google.com/document/d/1tpPOXVzNSwtpWA7cXhTPLAO6HIP50obUvoP85XqgVHM/edit    302
+/notes/spec             https://docs.google.com/document/d/1PwhekVB1iDpcgCQRNVN_aesoVdOiTruoebCs896aGxw/edit    302
+/notes/specification    https://docs.google.com/document/d/1PwhekVB1iDpcgCQRNVN_aesoVdOiTruoebCs896aGxw/edit    302
+/notes/tooling          https://docs.google.com/document/d/18oj3CLJQhZj1dMHKDTq_1kKg0syysKCS7pLyXlw1SRc/edit    302
+
+# --- Page renames and user-facing convenience aliases ---
+
+# Quick links to the latest version.
+/faq                    /spec/v1.0/faq          302
+/levels                 /spec/v1.0/levels       302
+/terminology            /spec/v1.0/terminology  302
+/threats                /spec/v1.0/threats      302
+/use-cases              /spec/v1.0/use-cases    302
+
+# Renamed files.
+/getinvolved            /community              301
+
+/github-actions-workflow            https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1    301
+/github-actions-workflow/v1-rc1     https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1    301
+/github-actions-workflow/v1         https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1    301
+/github-actions-workflow/v1.0       https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1    301
+
+/provenance             /provenance/v1          302
+/provenance/v0.2-draft  /provenance/v0.2        301
+/provenance/v1.0        /provenance/v1          302
+
+/spec                   /spec/v1.0              302
+/spec/faq               /spec/v1.0/faq          302
+/spec/v1/*              /spec/v1.0/:splat       302
+
+/verification_summary       /verification_summary/v1    302
+/verification_summary/v1.0  /verification_summary/v1    302

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: spec/v1.0/faq
-sitemap: false
----

--- a/docs/getinvolved.md
+++ b/docs/getinvolved.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: community
-sitemap: false
----

--- a/docs/github-actions-workflow/index.md
+++ b/docs/github-actions-workflow/index.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1
-sitemap: false
----

--- a/docs/github-actions-workflow/v1-rc1.md
+++ b/docs/github-actions-workflow/v1-rc1.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1
-sitemap: false
----

--- a/docs/github-actions-workflow/v1.0.md
+++ b/docs/github-actions-workflow/v1.0.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1
-sitemap: false
----

--- a/docs/github-actions-workflow/v1.md
+++ b/docs/github-actions-workflow/v1.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: https://slsa-framework.github.io/github-actions-buildtypes/workflow/v1
-sitemap: false
----

--- a/docs/levels.md
+++ b/docs/levels.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: spec/v1.0/levels
-sitemap: false
----

--- a/docs/notes/community.md
+++ b/docs/notes/community.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: https://docs.google.com/document/d/1JbJZxeZOWE7rxT24iEozX35LIUl_Yoqd-DeSm6309GA/edit
-sitemap: false
----

--- a/docs/notes/positioning.md
+++ b/docs/notes/positioning.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: https://docs.google.com/document/d/1tpPOXVzNSwtpWA7cXhTPLAO6HIP50obUvoP85XqgVHM/edit
-sitemap: false
----

--- a/docs/notes/spec.md
+++ b/docs/notes/spec.md
@@ -1,1 +1,0 @@
-specification.md

--- a/docs/notes/specification.md
+++ b/docs/notes/specification.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: https://docs.google.com/document/d/1PwhekVB1iDpcgCQRNVN_aesoVdOiTruoebCs896aGxw/edit
-sitemap: false
----

--- a/docs/notes/tooling.md
+++ b/docs/notes/tooling.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: https://docs.google.com/document/d/18oj3CLJQhZj1dMHKDTq_1kKg0syysKCS7pLyXlw1SRc/edit
-sitemap: false
----

--- a/docs/provenance/index.md
+++ b/docs/provenance/index.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: v1
-sitemap: false
----

--- a/docs/provenance/v0.2-draft.md
+++ b/docs/provenance/v0.2-draft.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: v0.2
-sitemap: false
----

--- a/docs/provenance/v1.0.md
+++ b/docs/provenance/v1.0.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: /provenance/v1
-sitemap: false
----

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: spec/v1.0/requirements
-sitemap: false
----

--- a/docs/spec/faq.md
+++ b/docs/spec/faq.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: v1.0/faq
-sitemap: false
----

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -1,4 +1,0 @@
----
-layout: redirect
-redirect_to_url: v1.0
----

--- a/docs/spec/v1.md
+++ b/docs/spec/v1.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: /spec/v1.0
-sitemap: false
----

--- a/docs/terminology.md
+++ b/docs/terminology.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: spec/v1.0/terminology
-sitemap: false
----

--- a/docs/threats.md
+++ b/docs/threats.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: spec/v1.0/threats
-sitemap: false
----

--- a/docs/use-cases.md
+++ b/docs/use-cases.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: spec/v1.0/use-cases
-sitemap: false
----

--- a/docs/verification_summary/index.md
+++ b/docs/verification_summary/index.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: v1
-sitemap: false
----

--- a/docs/verification_summary/v1.0.md
+++ b/docs/verification_summary/v1.0.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-redirect_to_url: /verification_summary/v1
-sitemap: false
----


### PR DESCRIPTION
Switch to Netlify's HTTP-level redirects instead of HTML-level
`<meta refresh>` redirects. (Historical note: we originally used the
latter because GitHub Pages did not support HTTP-level redirects.)

Advantages:

- Preserves URL fragments.
  Example: slsa.dev/levels#build-l3 no longer drops the `#build-l3`.
- Supports directory redirection path components after the redirect.
  Example: slsa.dev/spec/v1/levels now works.
- Supports temporary redirects (302). The problem with `<meta refresh>`
  is that they are always interpreted as permanent, which is a problem
  when we do a version bump (e.g. /levels -> /spec/v1.0/levels).
- Cleans up our directory tree, which now only contains true content.

Signed-off-by: Mark Lodato <lodato@google.com>
