### PR TITLE
impl: remove obsolete README for GHA buildtype

### DIFF
--- a/docs/github-actions-workflow/README.md
+++ b/docs/github-actions-workflow/README.md
@@ -1,3 +1,0 @@
-# Redirects
-
-The redirects in this directory are to keep old URLs working.


### PR DESCRIPTION
The README is obsolete as of 46673cf, which replaced `.md` redirects
with the central `_redirects` file.
