### PR TITLE
impl: fix broken link to in-toto

### DIFF
--- a/docs/_posts/2023-05-02-in-toto-and-slsa.md
+++ b/docs/_posts/2023-05-02-in-toto-and-slsa.md
@@ -69,7 +69,7 @@ predicates they generate during the execution of their software supply chain.
 For example, they can embed SLSA Provenance specific checks alongside others
 that verify best practices such as two party code reviews, successful test runs,
 and so on were adhered to. Taken together, a
-[bundle of in-toto attestations](https://github.com/in-toto/attestation/blob/main/spec/v1.0/bundle.md)
+[bundle of in-toto attestations](https://github.com/in-toto/attestation/blob/main/spec/v1/bundle.md)
 and a layout can be used to comprehensively verify a software supply chain’s
 security posture.
 

--- a/docs/attestation-model.md
+++ b/docs/attestation-model.md
@@ -144,7 +144,7 @@ recognize that other choices MAY be necessary in various cases.
 | Bundle | **[JSON Lines]**, see [attestation bundle] |
 | Storage/Lookup | **TBD** |
 
-[attestation bundle]: https://github.com/in-toto/attestation/blob/main/spec/v1.0/bundle.md
+[attestation bundle]: https://github.com/in-toto/attestation/blob/main/spec/v1/bundle.md
 [Binary Authorization]: https://cloud.google.com/binary-authorization
 [DSSE]: https://github.com/secure-systems-lab/dsse/
 [Generic SLSA Verifier]: https://github.com/slsa-framework/slsa-verifier


### PR DESCRIPTION
Fixing a broken link.

Broken link: https://github.com/in-toto/attestation/blob/main/spec/v1.0/bundle.md
Fixed link: https://github.com/in-toto/attestation/blob/main/spec/v1/bundle.md