### PR TITLE
editorial: fix typo on threats and mitigations page

### DIFF
--- a/docs/spec/v1.0-rc2/threats.md
+++ b/docs/spec/v1.0-rc2/threats.md
@@ -5,7 +5,7 @@ description: A comprehensive technical analysis of supply chain threats and thei
 
 What follows is a comprehensive technical analysis of supply chain threats and
 their corresponding mitigations in SLSA. For an introduction to the
-supply chain threats that SLSA protects agains, see [Supply chain threats].
+supply chain threats that SLSA protects against, see [Supply chain threats].
 
 The examples on this page are meant to:
 

--- a/docs/spec/v1.0/threats.md
+++ b/docs/spec/v1.0/threats.md
@@ -5,7 +5,7 @@ description: A comprehensive technical analysis of supply chain threats and thei
 
 What follows is a comprehensive technical analysis of supply chain threats and
 their corresponding mitigations in SLSA. For an introduction to the
-supply chain threats that SLSA protects agains, see [Supply chain threats].
+supply chain threats that SLSA protects against, see [Supply chain threats].
 
 The examples on this page are meant to:
 


### PR DESCRIPTION
The v1.0 and v1.0-rc2 versions of the page have the same typo: "protects agains"

Signed-off-by: Joshua Lock <joshuagloe@gmail.com>