### PR TITLE
impl: relax review requirements during Draft stage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,14 @@ maintainer will update if needed. See [review and approval] for the meaning of
 | `style` | A user-visible style or layout change. No content changes. | 0h | 1 |
 | `impl` | A user-invisible change, such as editing a README or the repo configuration. | 0h | 1 |
 
-Note: PR authors with write access to the repo count as second or third
+Note 1: PR authors with write access to the repo count as second or third
 approvers for their own PRs. For example, if the author of a PR with the
 `content` tag has write access to the repo, then the PR only requires
 two additional approvers before merging. However, a PR with the `impl` tag
 always requires one reviewer, even if the author has write access.
+
+Note 2: The "waiting period" and "# reviewers" are relaxed during the Draft
+specification stage, leaving it up to Maintainer discretion.
 
 [squash and merge]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,9 +109,10 @@ approvers for their own PRs. For example, if the author of a PR with the
 two additional approvers before merging. However, a PR with the `impl` tag
 always requires one reviewer, even if the author has write access.
 
-Note 2: The "waiting period" and "# reviewers" are relaxed during the
-[Draft](docs/spec-stages.md) specification stage, leaving it up to Maintainer
-discretion.
+Note 2: If the PR only touches files in the [Draft](docs/spec-stages.md)
+specification stage, then the "waiting period" and "# reviewers" are relaxed and
+up to Maintainer discretion. Files in the Draft stage have a large banner at the
+top of each rendered page, as well as the text "Status: Draft".
 
 [squash and merge]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,8 +109,9 @@ approvers for their own PRs. For example, if the author of a PR with the
 two additional approvers before merging. However, a PR with the `impl` tag
 always requires one reviewer, even if the author has write access.
 
-Note 2: The "waiting period" and "# reviewers" are relaxed during the Draft
-specification stage, leaving it up to Maintainer discretion.
+Note 2: The "waiting period" and "# reviewers" are relaxed during the
+[Draft](docs/spec-stages.md) specification stage, leaving it up to Maintainer
+discretion.
 
 [squash and merge]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits
 


### PR DESCRIPTION
As discussed at the 2023-08-21 specification meeting, we do not want to
require a 72h waiting period + 3 reviewers for changes to Draft
specifications, since that will make the iteration speed painfully slow.
Draft specifications are clearly marked as unapproved, and there is
still a Candidate approval process to review the whole spec. Therefore,
change CONTRIBUTING to note that Draft versions are manager discretion
regarding waiting period and number of reviewers.

Fixes #953.

Signed-off-by: Mark Lodato <lodato@google.com>
