### PR TITLE
fix: add redirect for removed example.md

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -70,4 +70,5 @@
 /verification_summary/v1.1      /spec/v1.1/verification_summary     301
 
 # Removed files. Keep URLs working forever.
-/example    https://github.com/slsa-framework/slsa/blob/a25364a3b312f572e4620c812820249853bb40e5/docs/example.md  301
+/example       https://github.com/slsa-framework/slsa/blob/a25364a3b312f572e4620c812820249853bb40e5/docs/example.md  301
+/example.md    https://github.com/slsa-framework/slsa/blob/a25364a3b312f572e4620c812820249853bb40e5/docs/example.md  301


### PR DESCRIPTION
fixes link [hypothetical curl example](https://slsa.dev/example.md) to example.md at https://slsa.dev/spec/v1.0/use-cases#motivating-example