### PR TITLE
fix: in-toto attestation "processing model" moved

### DIFF
--- a/docs/spec/v1.0-rc2/verifying-artifacts.md
+++ b/docs/spec/v1.0-rc2/verifying-artifacts.md
@@ -91,9 +91,9 @@ Once, when bootstrapping the verifier:
 
 Given an artifact and its provenance:
 
-1.  [Verify][processing-model] the envelope's signature using the roots of
+1.  [Verify][validation-model] the envelope's signature using the roots of
     trust, resulting in a list of recognized public keys (or equivalent).
-2.  [Verify][processing-model] that statement's `subject` matches the digest of
+2.  [Verify][validation-model] that statement's `subject` matches the digest of
     the artifact in question.
 3.  Verify that the `predicateType` is `https://slsa.dev/provenance/v1-rc2`.
 4.  Look up the SLSA Build Level in the roots of trust, using the recognized
@@ -129,7 +129,7 @@ Resulting threat mitigation:
 [Threat "G"]: threats#g-compromise-package-repo
 [Threat "H"]: threats#h-use-compromised-package
 
-[processing-model]: https://github.com/in-toto/attestation/tree/main/spec#processing-model
+[validation-model]: https://github.com/in-toto/attestation/blob/main/docs/validation.md#validation-model
 
 ### Step 2: Check expectations
 

--- a/docs/spec/v1.0/verifying-artifacts.md
+++ b/docs/spec/v1.0/verifying-artifacts.md
@@ -94,9 +94,9 @@ Once, when bootstrapping the verifier:
 
 Given an artifact and its provenance:
 
-1.  [Verify][processing-model] the envelope's signature using the roots of
+1.  [Verify][validation-model] the envelope's signature using the roots of
     trust, resulting in a list of recognized public keys (or equivalent).
-2.  [Verify][processing-model] that statement's `subject` matches the digest of
+2.  [Verify][validation-model] that statement's `subject` matches the digest of
     the artifact in question.
 3.  Verify that the `predicateType` is `https://slsa.dev/provenance/v1`.
 4.  Look up the SLSA Build Level in the roots of trust, using the recognized
@@ -132,7 +132,7 @@ Resulting threat mitigation:
 [Threat "G"]: threats#g-compromise-package-repo
 [Threat "H"]: threats#h-use-compromised-package
 
-[processing-model]: https://github.com/in-toto/attestation/tree/main/spec#processing-model
+[validation-model]: https://github.com/in-toto/attestation/blob/main/docs/validation.md#validation-model
 
 ### Step 2: Check expectations
 

--- a/docs/spec/v1.1/verifying-artifacts.md
+++ b/docs/spec/v1.1/verifying-artifacts.md
@@ -94,9 +94,9 @@ Once, when bootstrapping the verifier:
 
 Given an artifact and its provenance:
 
-1.  [Verify][processing-model] the envelope's signature using the roots of
+1.  [Verify][validation-model] the envelope's signature using the roots of
     trust, resulting in a list of recognized public keys (or equivalent).
-2.  [Verify][processing-model] that statement's `subject` matches the digest of
+2.  [Verify][validation-model] that statement's `subject` matches the digest of
     the artifact in question.
 3.  Verify that the `predicateType` is `https://slsa.dev/provenance/v1`.
 4.  Look up the SLSA Build Level in the roots of trust, using the recognized
@@ -132,7 +132,7 @@ Resulting threat mitigation:
 [Threat "G"]: threats#g-compromise-package-repo
 [Threat "H"]: threats#h-use-compromised-package
 
-[processing-model]: https://github.com/in-toto/attestation/tree/main/spec#processing-model
+[validation-model]: https://github.com/in-toto/attestation/blob/main/docs/validation.md#validation-model
 
 ### Step 2: Check expectations
 


### PR DESCRIPTION
The "processing model" part of the in-toto attestation specification has
been renamed and  moved to a new "validation model" page. Update the
references to the processing model in our "verifying artifacts" page to
link to the validation model instead.