### PR TITLE
content: recommend a VSA include the policy's digest

### DIFF
--- a/docs/spec/v1.1/verification_summary.md
+++ b/docs/spec/v1.1/verification_summary.md
@@ -83,7 +83,7 @@ to establish minimum requirements on dependencies SLSA levels may use
   "resourceUri": <artifact-URI-in-request>,
   "policy": {
     "uri": "<URI>",
-    "digest": { /* DigestSet */ }
+    "digest": { <digest-of-policy-data> }
   }
   "inputAttestations": [
     {
@@ -162,7 +162,7 @@ of the other top-level fields, such as `subject`, see [Statement]._
 > Describes the policy that the `subject` was verified against.
 >
 > The entry MUST contain a `uri` identifying which policy was applied and
-> SHOULD contain a digest to indicate the exact version of that policy.
+> SHOULD contain a `digest` to indicate the exact version of that policy.
 
 <a id="inputAttestations"></a>
 `inputAttestations` _array ([ResourceDescriptor]), optional_

--- a/docs/spec/v1.1/verification_summary.md
+++ b/docs/spec/v1.1/verification_summary.md
@@ -161,7 +161,8 @@ of the other top-level fields, such as `subject`, see [Statement]._
 
 > Describes the policy that the `subject` was verified against.
 >
-> The entry MUST contain a `uri`.
+> The entry MUST contain a `uri` identifying which policy was applied and
+> SHOULD contain a digest to indicate the exact version of that policy.
 
 <a id="inputAttestations"></a>
 `inputAttestations` _array ([ResourceDescriptor]), optional_
@@ -380,6 +381,8 @@ Users MAY use custom values here but MUST NOT use custom values starting with
 ## Change history
 
 -   1.1:
+    -   Changed the `policy` object to recommend that the `digest` field of
+        the `ResourceDescriptor` is set.
     -   Added optional `verifier.version` field to record verification tools.
     -   Added Verification section with examples.
     -   Made `timeVerified` optional.

--- a/docs/spec/v1.1/whats-new.md
+++ b/docs/spec/v1.1/whats-new.md
@@ -14,6 +14,8 @@ changes in v1.1 relative to the prior release, [v1.0].
     source of definitions.
 -   Add procedure for verifying VSAs.
 -   Add verifier metadata to VSA format.
+-   It is now recommended that the `digest` field of `ResourceDescriptor` is
+    set in a Verification Summary Attestation's (VSA) `policy` object.
 
 <!-- Footnotes and link definitions -->
 


### PR DESCRIPTION
Recommended that the `digest` field of `ResourceDescriptor` is set in a Verification Summary Attestation's (VSA) `policy` object.

Fixes: #803 