### PR TITLE
editorial: tweak presentation of VSA pages

### DIFF
--- a/docs/_data/nav/v0.1.yml
+++ b/docs/_data/nav/v0.1.yml
@@ -39,7 +39,7 @@
       - title: Provenance
         url: /spec/v0.1/provenance
 
-      - title: VSA
+      - title: Verification Summary
         url: /spec/v0.1/verification_summary
 
     - title: Stages

--- a/docs/_data/nav/v0.2.yml
+++ b/docs/_data/nav/v0.2.yml
@@ -39,7 +39,7 @@
       - title: Provenance
         url: /spec/v0.2/provenance
 
-      - title: VSA
+      - title: Verification Summary
         url: /spec/v0.2/verification_summary
 
     - title: Stages

--- a/docs/_data/nav/v1.0-rc1.yml
+++ b/docs/_data/nav/v1.0-rc1.yml
@@ -51,7 +51,7 @@
       - title: Provenance
         url: /spec/v1.0-rc1/provenance
 
-      - title: VSA
+      - title: Verification Summary
         # There was no v1.0-rc VSA. This confuses the version selector.
         url: /spec/v0.2/verification_summary
 

--- a/docs/_data/nav/v1.0-rc2.yml
+++ b/docs/_data/nav/v1.0-rc2.yml
@@ -89,7 +89,7 @@
     url: /spec/v1.0-rc2/provenance
     description: Suggested provenance format and explanation
 
-  - title: VSA
+  - title: Verification Summary
     url: /spec/v1.0-rc2/verification_summary
     description: Suggested VSA format and explanation
 

--- a/docs/_data/nav/v1.0.yml
+++ b/docs/_data/nav/v1.0.yml
@@ -89,7 +89,7 @@
     url: /spec/v1.0/provenance
     description: Suggested provenance format and explanation
 
-  - title: VSA
+  - title: Verification Summary
     url: /spec/v1.0/verification_summary
     description: Suggested VSA format and explanation
 

--- a/docs/_data/nav/v1.1.yml
+++ b/docs/_data/nav/v1.1.yml
@@ -89,7 +89,7 @@
     url: /spec/v1.1/provenance
     description: Suggested provenance format and explanation
 
-  - title: VSA
+  - title: Verification Summary
     url: /spec/v1.1/verification_summary
     description: Suggested VSA format and explanation
 

--- a/docs/spec/v0.1/verification_summary.md
+++ b/docs/spec/v0.1/verification_summary.md
@@ -1,6 +1,6 @@
 ---
-title: SLSA Verification Summary Attestation (VSA)
-description: SLSA v0.1 specification for a verification summary of artifacts by a trusted verifier entity.
+title: Verification Summary Attestation (VSA)
+description: Specification for a verification summary of artifacts by a trusted verifier entity.
 layout: standard
 ---
 

--- a/docs/spec/v0.2/verification_summary.md
+++ b/docs/spec/v0.2/verification_summary.md
@@ -1,6 +1,6 @@
 ---
-title: SLSA Verification Summary Attestation (VSA)
-description: SLSA v0.2 specification for a verification summary of artifacts by a trusted verifier entity.
+title: Verification Summary Attestation (VSA)
+description: Specification for a verification summary of artifacts by a trusted verifier entity.
 layout: standard
 ---
 

--- a/docs/spec/v1.0-rc2/verification_summary.md
+++ b/docs/spec/v1.0-rc2/verification_summary.md
@@ -1,6 +1,6 @@
 ---
-title: SLSA Verification Summary Attestation (VSA)
-description: SLSA v1.0 RC2 specification for a verification summary of artifacts by a trusted verifier entity.
+title: Verification Summary Attestation (VSA)
+description: Specification for a verification summary of artifacts by a trusted verifier entity.
 layout: standard
 ---
 

--- a/docs/spec/v1.0/verification_summary.md
+++ b/docs/spec/v1.0/verification_summary.md
@@ -1,6 +1,6 @@
 ---
-title: SLSA Verification Summary Attestation (VSA)
-description: SLSA v1.0 specification for a verification summary of artifacts by a trusted verifier entity.
+title: Verification Summary Attestation (VSA)
+description: Specification for a verification summary of artifacts by a trusted verifier entity.
 layout: standard
 ---
 

--- a/docs/spec/v1.1/verification_summary.md
+++ b/docs/spec/v1.1/verification_summary.md
@@ -1,6 +1,6 @@
 ---
-title: SLSA Verification Summary Attestation (VSA)
-description: SLSA v1.0 specification for a verification summary of artifacts by a trusted verifier entity.
+title: Verification Summary Attestation (VSA)
+description: Specification for a verification summary of artifacts by a trusted verifier entity.
 layout: standard
 ---
 


### PR DESCRIPTION
- Expand VSA --> Verification Summary in the left-hand nav menu. The VSA acronym only makes sense to readers familiar with the VSA.
- Remove redundant "SLSA" prefix from VSA page titles
- Remove specification version from VSA page descriptions