### PR TITLE
impl: Create new project lifecycle process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,3 +210,46 @@ You can automatically append a sign-off to a commit by passing the `-s` /
 
 **Note**: this requires your `user.name` and `user.email` are set correctly
 in your git config.
+
+## Project lifecycle
+
+Major projects that require considerable effort, such as a new release, a new
+track, or a new level, should have a top-level GitHub issue and a shepherd to
+oversee the project and move it along. Without a shepherd, a project is likely
+to stagnate. If you would like to be a shepherd for a project, just nominate
+yourself in the issue.
+
+Responsibilities of the shepherd:
+
+-   Maintaining the top-level GitHub issue to track the overall project
+-   Breaking down the project into tasks
+-   Pinging open issues and pull requests when stale
+-   Getting consensus among Contributors and Maintainers
+-   Suggesting priorities
+-   Providing regular updates to the community
+-   Adding a project entry in [README.md](README.md)
+
+Template for GitHub issue:
+
+-   Title: `Project: <name>`
+-   Assignee: \<shepherd\>
+-   Labels: [`project`](https://github.com/slsa-framework/slsa/labels/project)
+-   Description:
+
+    ```markdown
+    This is a tracking issue for [SHORT DESCRIPTION].
+
+    [Project shepherd]: YOUR NAME (@GITHUB_USERNAME)
+
+    Sub-issues:
+
+    -   [ ] #1234
+    -   [ ] #4568
+
+    [Project shepherd]: https://github.com/slsa-framework/slsa/blob/main/CONTRIBUTING.md#project-lifecycle
+
+    ---
+
+    [any other text]
+
+    ```

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ See https://slsa.dev/community for ways to get involved in SLSA development.
 | Project | [Shepherd] |
 | ------- | ---------- |
 | [Build Level 4] | David A Wheeler (@david-a-wheeler) |
-| [Hardware Attested Builds] | Marcela Melara (@marcelamelara), Chad Kimes (@chkimes) |
+| [Hardware Attested Platforms] | Marcela Melara (@marcelamelara), Chad Kimes (@chkimes) |
 | [Source Track] | Kris K (@kpk47) |
 | [Version 1.1 release] | Joshua Lock (@joshuagl) |
 
 [Shepherd]: CONTRIBUTING.md#project-lifecycle
 [Build Level 4]: https://github.com/slsa-framework/slsa/issues/977
-[Hardware Attested Builds]: https://github.com/slsa-framework/slsa/issues/975
+[Hardware Attested Platforms]: https://github.com/slsa-framework/slsa/issues/975
 [Source Track]: https://github.com/slsa-framework/slsa/issues/956
 [Version 1.1 release]: https://github.com/slsa-framework/slsa/issues/900
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ See https://slsa.dev/community for ways to get involved in SLSA development.
 | Project | [Shepherd] |
 | ------- | ---------- |
 | [Build Level 4] | David A Wheeler (@david-a-wheeler) |
-| [Build Platform Operations Track] | Marcela Melera (@marcelamelera), Chad Kimes (@chkimes) |
+| [Build Platform Operations Track] | Marcela Melara (@marcelamelara), Chad Kimes (@chkimes) |
 | [Source Track] | Kris K (@kpk47) |
 | [Version 1.1 release] | Joshua Lock (@joshuagl) |
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,25 @@ specification, and overall project management. Other git repositories within the
 [slsa-framework](https://github.com/slsa-framework) organization have
 repo-specific issue trackers.
 
+## How to get involved
+
+See https://slsa.dev/community for ways to get involved in SLSA development.
+
+## Active projects
+
+| Project | [Shepherd] |
+| ------- | ---------- |
+| [Build Level 4] | David A Wheeler (@david-a-wheeler) |
+| [Build Platform Operations Track] | Marcela Melera (@marcelamelera), Chad Kimes (@chkimes) |
+| [Source Track] | Kris K (@kpk47) |
+| [Version 1.1 release] | Joshua Lock (@joshuagl) |
+
+[Shepherd]: CONTRIBUTING.md#project-lifecycle
+[Build Level 4]: https://github.com/slsa-framework/slsa/issues/977
+[Build Platform Operations Track]: https://github.com/slsa-framework/slsa/issues/975
+[Source Track]: https://github.com/slsa-framework/slsa/issues/956
+[Version 1.1 release]: https://github.com/slsa-framework/slsa/issues/900
+
 ## URL Aliases
 
 We have several [redirect](docs/_redirects) configured on slsa.dev for
@@ -34,10 +53,6 @@ convenience of the team:
     -   https://slsa.dev/notes/specification
         (or [.../spec](https://slsa.dev/notes/spec))
     -   https://slsa.dev/notes/tooling
-
-## How to get involved
-
-See https://slsa.dev/community for ways to get involved in SLSA development.
 
 ## Governance
 

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ See https://slsa.dev/community for ways to get involved in SLSA development.
 | Project | [Shepherd] |
 | ------- | ---------- |
 | [Build Level 4] | David A Wheeler (@david-a-wheeler) |
-| [Build Platform Operations Track] | Marcela Melara (@marcelamelara), Chad Kimes (@chkimes) |
+| [Hardware Attested Builds] | Marcela Melara (@marcelamelara), Chad Kimes (@chkimes) |
 | [Source Track] | Kris K (@kpk47) |
 | [Version 1.1 release] | Joshua Lock (@joshuagl) |
 
 [Shepherd]: CONTRIBUTING.md#project-lifecycle
 [Build Level 4]: https://github.com/slsa-framework/slsa/issues/977
-[Build Platform Operations Track]: https://github.com/slsa-framework/slsa/issues/975
+[Hardware Attested Builds]: https://github.com/slsa-framework/slsa/issues/975
 [Source Track]: https://github.com/slsa-framework/slsa/issues/956
 [Version 1.1 release]: https://github.com/slsa-framework/slsa/issues/900
 


### PR DESCRIPTION
As discussed in the 2023-10-09 specification meeting, create a new
"Project lifecycle" for major projects (new version, new track, etc).
The main idea is to assign a "project shepherd" to oversee the project.
This person is responsible for moving the project along. The reason for
creating this is that many projects seem to stagnate without a single
responsible person.

This commit populates the initial list of projects as per our discussion
at the meeting.
