### PR TITLE
editorial: update mapping of Nix terminology to the SLSA Package model

### DIFF
--- a/docs/spec/v1.0-rc2/terminology.md
+++ b/docs/spec/v1.0-rc2/terminology.md
@@ -219,10 +219,10 @@ additions are welcome!
     <td>Package name
     <td>Package
   <tr>
-    <td><a href="https://nixos.org/guides/how-nix-works.html">nix</a> (e.g. <a href="https://nixos.org/">NixOS</a>)
-    <td><em>?</em>
-    <td><a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-store-object">Store Object</a>?
-    <td>Package or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-derivation">Derivation</a>
+    <td><a href="https://nixos.org/manual/nix">Nix</a> (e.g. <a href="https://nixos.org/">NixOS</a>)
+    <td>Repository (e.g. <a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a>) or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-binary-cache">binary cache</a>
+    <td><a href="https://nixos.org/manual/nix/stable/language/derivations.html">Derivation name</a>
+    <td><a href="https://nixos.org/manual/nix/stable/language/derivations.html">Derivation</a> or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-store-object">store object</a>
   <tr>
     <td colspan=4><em>Storage systems</em>
   <tr>

--- a/docs/spec/v1.0/terminology.md
+++ b/docs/spec/v1.0/terminology.md
@@ -253,10 +253,10 @@ additions are welcome!
     <td>Package name
     <td>Package
   <tr>
-    <td><a href="https://nixos.org/guides/how-nix-works.html">nix</a> (e.g. <a href="https://nixos.org/">NixOS</a>)
-    <td><em>?</em>
-    <td><a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-store-object">Store Object</a>?
-    <td>Package or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-derivation">Derivation</a>
+    <td><a href="https://nixos.org/manual/nix">Nix</a> (e.g. <a href="https://nixos.org/">NixOS</a>)
+    <td>Repository (e.g. <a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a>) or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-binary-cache">binary cache</a>
+    <td><a href="https://nixos.org/manual/nix/stable/language/derivations.html">Derivation name</a>
+    <td><a href="https://nixos.org/manual/nix/stable/language/derivations.html">Derivation</a> or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-store-object">store object</a>
   <tr>
     <td colspan=4><em>Storage systems</em>
   <tr>

--- a/docs/spec/v1.1/terminology.md
+++ b/docs/spec/v1.1/terminology.md
@@ -253,10 +253,10 @@ additions are welcome!
     <td>Package name
     <td>Package
   <tr>
-    <td><a href="https://nixos.org/guides/how-nix-works.html">nix</a> (e.g. <a href="https://nixos.org/">NixOS</a>)
-    <td><em>?</em>
-    <td><a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-store-object">Store Object</a>?
-    <td>Package or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-derivation">Derivation</a>
+    <td><a href="https://nixos.org/manual/nix">Nix</a> (e.g. <a href="https://nixos.org/">NixOS</a>)
+    <td>Repository (e.g. <a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a>) or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-binary-cache">binary cache</a>
+    <td><a href="https://nixos.org/manual/nix/stable/language/derivations.html">Derivation name</a>
+    <td><a href="https://nixos.org/manual/nix/stable/language/derivations.html">Derivation</a> or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-store-object">store object</a>
   <tr>
     <td colspan=4><em>Storage systems</em>
   <tr>


### PR DESCRIPTION
Change Nix package ecosystem terminology to match definitions of SLSA Package model terminology. Capitalize Nix to match proper name of package ecosystem. Map SLSA Package registry to Nixpkgs (the largest repository of Nix packages [and also a Nix Flake]) and Flakes (distributed repositories of Nix packages). Map SLSA Package name to attributes of Nixpkgs and Flake outputs. Map SLSA Package artifact to Nix Store Path.