### PR TITLE
impl: rename "project" to "workstream"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,42 +211,42 @@ You can automatically append a sign-off to a commit by passing the `-s` /
 **Note**: this requires your `user.name` and `user.email` are set correctly
 in your git config.
 
-## Project lifecycle
+## Workstream lifecycle
 
-Major projects that require considerable effort, such as a new release, a new
+Major workstreams that require considerable effort, such as a new release, a new
 track, or a new level, should have a top-level GitHub issue and a shepherd to
-oversee the project and move it along. Without a shepherd, a project is likely
-to stagnate. If you would like to be a shepherd for a project, just nominate
-yourself in the issue.
+oversee the workstream and move it along. Without a shepherd, a workstream is
+likely to stagnate. If you would like to be a shepherd for a workstream, just
+nominate yourself in the issue.
 
 Responsibilities of the shepherd:
 
--   Maintaining the top-level GitHub issue to track the overall project
--   Breaking down the project into tasks
+-   Maintaining the top-level GitHub issue to track the overall workstream
+-   Breaking down the workstream into tasks
 -   Pinging open issues and pull requests when stale
 -   Getting consensus among Contributors and Maintainers
 -   Suggesting priorities
 -   Providing regular updates to the community
--   Adding a project entry in [README.md](README.md)
+-   Adding a workstream entry in [README.md](README.md)
 
 Template for GitHub issue:
 
--   Title: `Project: <name>`
+-   Title: `Workstream: <name>`
 -   Assignee: \<shepherd\>
--   Labels: [`project`](https://github.com/slsa-framework/slsa/labels/project)
+-   Labels: [`workstream`](https://github.com/slsa-framework/slsa/labels/workstream)
 -   Description:
 
     ```markdown
     This is a tracking issue for [SHORT DESCRIPTION].
 
-    [Project shepherd]: YOUR NAME (@GITHUB_USERNAME)
+    [Workstream shepherd]: YOUR NAME (@GITHUB_USERNAME)
 
     Sub-issues:
 
     -   [ ] #1234
     -   [ ] #4568
 
-    [Project shepherd]: https://github.com/slsa-framework/slsa/blob/main/CONTRIBUTING.md#project-lifecycle
+    [Workstream shepherd]: https://github.com/slsa-framework/slsa/blob/main/CONTRIBUTING.md#workstream-lifecycle
 
     ---
 

--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ repo-specific issue trackers.
 
 See https://slsa.dev/community for ways to get involved in SLSA development.
 
-## Active projects
+## Active workstreams
 
-| Project | [Shepherd] |
-| ------- | ---------- |
+| Workstream | [Shepherd] |
+| ---------- | ---------- |
 | [Build Level 4] | David A Wheeler (@david-a-wheeler) |
 | [Hardware Attested Platforms] | Marcela Melara (@marcelamelara), Chad Kimes (@chkimes) |
 | [Source Track] | Kris K (@kpk47) |
 | [Version 1.1 release] | Joshua Lock (@joshuagl) |
 
-[Shepherd]: CONTRIBUTING.md#project-lifecycle
+[Shepherd]: CONTRIBUTING.md#workstream-lifecycle
 [Build Level 4]: https://github.com/slsa-framework/slsa/issues/977
 [Hardware Attested Platforms]: https://github.com/slsa-framework/slsa/issues/975
 [Source Track]: https://github.com/slsa-framework/slsa/issues/956


### PR DESCRIPTION
As pointed out in #981, the term "project" is used for SLSA overall. For
example, see the top of CONTRIBUTING.md. To avoid overloading that term,
rename to "workstream". This seems to imply the same concept.

Signed-off-by: Mark Lodato <lodato@google.com>
