### PR TITLE
content: add principle for defining levels/tracks

### DIFF
--- a/docs/spec/v1.1/principles.md
+++ b/docs/spec/v1.1/principles.md
@@ -8,8 +8,9 @@ decisions.
 
 ## Simple levels with clear outcomes
 
-Use levels to communicate security state and to encourage a large population to
-improve its security stance over time.
+Use [levels](levels) to communicate security state and to encourage a large
+population to improve its security stance over time. When necessary, split
+levels into separate tracks to recognize progress in unrelated security areas.
 
 **Reasoning:** Levels simplify how to think about security by boiling a complex
 topic into an easy-to-understand number. It is clear that level N is better than
@@ -21,19 +22,20 @@ Guidelines:
 -   **Define levels in terms of concrete security outcomes.** Each level should
     have clear and meaningful security value, such as stopping a particular
     class of threats. Levels should represent security milestones, not just
-    incremental progress.
+    incremental progress. Give each level an easy-to-remember mnemonic, such as
+    "Provenance exists".
 
 -   **Balance level granularity.** Too many levels makes SLSA hard to understand
     and remember, while too few makes each level hard to achieve. Try to bundle
     requirements into levels such that an implementer is likely implement all at
     the same time.
 
--   **Use tracks sparingly.** SLSA has independent sets of levels called
-    *tracks* that measure progress along independent axes. Strive for no more
-    than 3-5 tracks, lest SLSA be too complex to understand. Furthermore, avoid
-    creating overlapping or confusingly similar tracks. When a track is
-    warranted, define a crisp objective of the track, such as "trustworthy
-    provenance" for the [Build track](levels#build-track).
+-   **Use tracks sparingly.** Additional tracks add extra complexity to SLSA, so
+    a new track should be seen as a last resort. Each track should have a clear,
+    distinct purpose with a crisply defined objective, such as trustworthy
+    provenance for the [Build track](levels#build-track). As a rule of thumb, a
+    new track may be warranted the threats it addresses are unrelated to those
+    of other tracks. Try to avoid tracks that sound confusingly similar.
 
 ## Trust platforms, verify artifacts
 

--- a/docs/spec/v1.1/principles.md
+++ b/docs/spec/v1.1/principles.md
@@ -28,7 +28,9 @@ Guidelines:
 -   **Balance level granularity.** Too many levels makes SLSA hard to understand
     and remember; too few makes each level hard to achieve. Collapse levels
     until each step requires a non-trivial but manageable amount of work to
-    implement.
+    implement. Separate levels if they require significant work from multiple
+    distinct parties, such as infrastructure work plus user behavior changes, so
+    long as the intermediate level still has some security value (prior bullet).
 
 -   **Use tracks sparingly.** Additional tracks add extra complexity to SLSA, so
     a new track should be seen as a last resort. Each track should have a clear,

--- a/docs/spec/v1.1/principles.md
+++ b/docs/spec/v1.1/principles.md
@@ -34,9 +34,9 @@ Guidelines:
     a new track should be seen as a last resort. Each track should have a clear,
     distinct purpose with a crisply defined objective, such as trustworthy
     provenance for the [Build track](levels#build-track). As a rule of thumb, a
-    new track may be warranted if the threats it addresses are unrelated to
-    those of other tracks. Try to avoid tracks that sound confusingly similar in
-    either name or objective.
+    new track may be warranted if it addresses threats unrelated to another
+    track. Try to avoid tracks that sound confusingly similar in either name or
+    objective.
 
 ## Trust platforms, verify artifacts
 

--- a/docs/spec/v1.1/principles.md
+++ b/docs/spec/v1.1/principles.md
@@ -26,9 +26,9 @@ Guidelines:
     "Provenance exists".
 
 -   **Balance level granularity.** Too many levels makes SLSA hard to understand
-    and remember; too few makes each level hard to achieve. Try to bundle
-    requirements into levels such that an implementer is likely to implement all
-    at the same time.
+    and remember; too few makes each level hard to achieve. Collapse levels
+    until each step requires a non-trivial but manageable amount of work to
+    implement.
 
 -   **Use tracks sparingly.** Additional tracks add extra complexity to SLSA, so
     a new track should be seen as a last resort. Each track should have a clear,

--- a/docs/spec/v1.1/principles.md
+++ b/docs/spec/v1.1/principles.md
@@ -6,6 +6,35 @@ description: An introduction to the guiding principles behind SLSA's design deci
 This page is an introduction to the guiding principles behind SLSA's design
 decisions.
 
+## Simple levels with clear outcomes
+
+Use levels to communicate security state and to encourage a large population to
+improve its security stance over time.
+
+**Reasoning:** Levels simplify how to think about security by boiling a complex
+topic into an easy-to-understand number. It is clear that level N is better than
+level N-1, even to someone with passing familiarity. This provides a convenient
+way to describe current security state as well as a natural path to improvement.
+
+Guidelines:
+
+-   **Define levels in terms of concrete security outcomes.** Each level should
+    have clear and meaningful security value, such as stopping a particular
+    class of threats. Levels should represent security milestones, not just
+    incremental progress.
+
+-   **Balance level granularity.** Too many levels makes SLSA hard to understand
+    and remember, while too few makes each level hard to achieve. Try to bundle
+    requirements into levels such that an implementer is likely implement all at
+    the same time.
+
+-   **Use tracks sparingly.** SLSA has independent sets of levels called
+    *tracks* that measure progress along independent axes. Strive for no more
+    than 3-5 tracks, lest SLSA be too complex to understand. Furthermore, avoid
+    creating overlapping or confusingly similar tracks. When a track is
+    warranted, define a crisp objective of the track, such as "trustworthy
+    provenance" for the [Build track](levels#build-track).
+
 ## Trust platforms, verify artifacts
 
 Establish trust in a small number of platforms and systems---such as change management, build,

--- a/docs/spec/v1.1/principles.md
+++ b/docs/spec/v1.1/principles.md
@@ -27,8 +27,8 @@ Guidelines:
 
 -   **Balance level granularity.** Too many levels makes SLSA hard to understand
     and remember; too few makes each level hard to achieve. Try to bundle
-    requirements into levels such that an implementer is likely implement all at
-    the same time.
+    requirements into levels such that an implementer is likely to implement all
+    at the same time.
 
 -   **Use tracks sparingly.** Additional tracks add extra complexity to SLSA, so
     a new track should be seen as a last resort. Each track should have a clear,

--- a/docs/spec/v1.1/principles.md
+++ b/docs/spec/v1.1/principles.md
@@ -26,7 +26,7 @@ Guidelines:
     "Provenance exists".
 
 -   **Balance level granularity.** Too many levels makes SLSA hard to understand
-    and remember, while too few makes each level hard to achieve. Try to bundle
+    and remember; too few makes each level hard to achieve. Try to bundle
     requirements into levels such that an implementer is likely implement all at
     the same time.
 
@@ -34,8 +34,9 @@ Guidelines:
     a new track should be seen as a last resort. Each track should have a clear,
     distinct purpose with a crisply defined objective, such as trustworthy
     provenance for the [Build track](levels#build-track). As a rule of thumb, a
-    new track may be warranted the threats it addresses are unrelated to those
-    of other tracks. Try to avoid tracks that sound confusingly similar.
+    new track may be warranted if the threats it addresses are unrelated to
+    those of other tracks. Try to avoid tracks that sound confusingly similar in
+    either name or objective.
 
 ## Trust platforms, verify artifacts
 


### PR DESCRIPTION
Document the principles around defining new levels and tracks. As we
expand SLSA, we need to ensure that SLSA remains focused and
understandable. A large part of that is having a consistent and simple
philosophy.
