### PR TITLE
impl: Create MAINTAINERS.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# Maintainers
-* @MarkLodato @mlieberman85 @joshuagl
-
-# Reviewers
-/docs/spec/**/distributing-provenance.md @di

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,6 @@
-## Maintainers of the SLSA Specification (in alphabetical order)
+# Maintainers of the SLSA Specification
+
+## Current maintainers (in alphabetical order)
 
 | Name | Email | OpenSSF Slack | GitHub | Affilitaion|
 | --- | --- | --- | --- | --- |
@@ -6,7 +8,7 @@
 | Joshua Lock | joshuagloe@gmail.com | @Joshua Lock |  [joshuagl](https://github.com/joshuagl) | Verizon |
 | Mark Lodato | lodato@google.com |  @Mark Lodato | [MarkLodato](https://github.com/MarkLodato) | Google |
 
-## Emeritus maintainers
+## Emeritus maintainers (in alphabetical order)
 
 Emeritus maintainers have maintained the SLSA specification in the past.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,8 +10,9 @@
 
 ### Adding a new maintainer
 
-We manage Maintainer permissions with the GitHub team "Specification
-Maintainers". We keep that group and this documentation in sync manually.
+We manage Maintainer permissions with the GitHub team,
+[Specification Maintainers](https://github.com/orgs/slsa-framework/teams/specification-maintainers).
+We keep that group and this documentation in sync manually.
 Whenever adding a new maintainer in this file, please add the user to the group.
 For instructions, see the [GitHub documentation](https://docs.github.com/en/organizations/organizing-members-into-teams/adding-organization-members-to-a-team).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,14 @@
+## Maintainers of the SLSA Specification (in alphabetical order)
+
+| Name | Email | OpenSSF Slack | GitHub | Affilitaion|
+| --- | --- | --- | --- | --- |
+| Michael Lieberman | mlieberman85@gmail.com | @Michael Lieberman | [mlieberman85](https://github.com/mlieberman85) | Kusari |
+| Joshua Lock | joshuagloe@gmail.com | @Joshua Lock |  [joshuagl](https://github.com/joshuagl) | Verizon |
+| Mark Lodato | lodato@google.com |  @Mark Lodato | [MarkLodato](https://github.com/MarkLodato) | Google |
+
+## Emeritus maintainers
+
+Emeritus maintainers have maintained the SLSA specification in the past.
+
+| Name | Email | OpenSSF Slack | GitHub | Affilitaion|
+| --- | --- | --- | --- | --- |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,15 +2,29 @@
 
 ## Current maintainers (in alphabetical order)
 
-| Name | Email | OpenSSF Slack | GitHub | Affilitaion|
+| Name | Email | OpenSSF Slack | GitHub | Affilitaion |
 | --- | --- | --- | --- | --- |
 | Michael Lieberman | mlieberman85@gmail.com | @Michael Lieberman | [mlieberman85](https://github.com/mlieberman85) | Kusari |
 | Joshua Lock | joshuagloe@gmail.com | @Joshua Lock |  [joshuagl](https://github.com/joshuagl) | Verizon |
 | Mark Lodato | lodato@google.com |  @Mark Lodato | [MarkLodato](https://github.com/MarkLodato) | Google |
 
+### Adding a new maintainer
+
+We manage Maintainer permissions with the GitHub team "Specification
+Maintainers". We keep that group and this documentation in sync manually.
+Whenever adding a new maintainer in this file, please add the user to the group.
+For instructions, see the [GitHub documentation](https://docs.github.com/en/organizations/organizing-members-into-teams/adding-organization-members-to-a-team).
+
 ## Emeritus maintainers (in alphabetical order)
 
 Emeritus maintainers have maintained the SLSA specification in the past.
 
-| Name | Email | OpenSSF Slack | GitHub | Affilitaion|
+| Name | Email | OpenSSF Slack | GitHub | Affilitaion |
 | --- | --- | --- | --- | --- |
+
+### Transitioning to emeritus
+
+We manage Maintainer permissions with the GitHub team "Specification
+Maintainers". We keep that group and this documentation in sync manually.
+Whenever transitioning a maintainer to emeritus status, please remove the user
+from that group. For instructions, see the [GitHub documentation](https://docs.github.com/en/organizations/organizing-members-into-teams/removing-organization-members-from-a-team).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -25,8 +25,6 @@ Emeritus maintainers have maintained the SLSA specification in the past.
 
 ### Transitioning to emeritus
 
-We manage Maintainer permissions with the GitHub team "Specification
-Maintainers". We keep that group and this documentation in sync manually.
 Whenever transitioning a maintainer to emeritus status, please remove the user
 from that group and move their row from the Current maintainers table to the
 Emeritus maintainers table. For instructions, see the [GitHub documentation](https://docs.github.com/en/organizations/organizing-members-into-teams/removing-organization-members-from-a-team).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -27,4 +27,5 @@ Emeritus maintainers have maintained the SLSA specification in the past.
 We manage Maintainer permissions with the GitHub team "Specification
 Maintainers". We keep that group and this documentation in sync manually.
 Whenever transitioning a maintainer to emeritus status, please remove the user
-from that group. For instructions, see the [GitHub documentation](https://docs.github.com/en/organizations/organizing-members-into-teams/removing-organization-members-from-a-team).
+from that group and move their row from the Current maintainers table to the
+Emeritus maintainers table. For instructions, see the [GitHub documentation](https://docs.github.com/en/organizations/organizing-members-into-teams/removing-organization-members-from-a-team).


### PR DESCRIPTION
This change publishes the current list of maintainers in MAINTAINERS.md. It also deletes .github/CODEOWNERS since we were using it to track maintainers previously.

#997 