### PR TITLE
impl: Add rules for moving maintainers to emeritus status.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,12 +18,22 @@ For instructions, see the [GitHub documentation](https://docs.github.com/en/orga
 
 ## Emeritus maintainers (in alphabetical order)
 
-Emeritus maintainers have maintained the SLSA specification in the past.
+Emeritus maintainers have maintained the SLSA specification in the past but are
+not currently doing so.
 
 | Name | Email | OpenSSF Slack | GitHub | Affilitaion |
 | --- | --- | --- | --- | --- |
 
 ### Transitioning to emeritus
+
+Maintainers may transition to emeritus status by request. They may also
+transition to emeritus status automatically if they are not active in the SLSA
+community for six (6) months. "Active" is loosely defined to mean attending
+meetings, sending or reviewing PRs, or posting on the Slack or mailing lists.
+Any ambiguity in whether or not a maintainer is considered active will be
+resolved by the other maintainers. There should always be at least three active
+maintainers, so automatic transitions to emeritus status will pause if there
+are three or fewer active maintainers.
 
 Whenever transitioning a maintainer to emeritus status, please remove the user
 from that group and move their row from the Current maintainers table to the

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,6 +8,9 @@
 | Joshua Lock | joshuagloe@gmail.com | @Joshua Lock |  [joshuagl](https://github.com/joshuagl) | Verizon |
 | Mark Lodato | lodato@google.com |  @Mark Lodato | [MarkLodato](https://github.com/MarkLodato) | Google |
 
+Proposals to change the list of maintainers should be made in the form of a PR
+against this file.
+
 ### Adding a new maintainer
 
 We manage Maintainer permissions with the GitHub team,
@@ -28,8 +31,8 @@ not currently doing so.
 
 Maintainers may transition to emeritus status by request. They may also
 transition to emeritus status automatically if they are not active in the SLSA
-community for six (6) months. "Active" is loosely defined to mean attending
-meetings, sending or reviewing PRs, or posting on the Slack or mailing lists.
+community for six (6) months. "Active" is loosely defined to mean performing the
+duties defined in the [SLSA Governance](https://github.com/slsa-framework/governance/blob/main/5._Governance.md) documentation.
 Any ambiguity in whether or not a maintainer is considered active will be
 resolved by the other maintainers. There should always be at least three active
 maintainers, so automatic transitions to emeritus status will pause if there

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -32,7 +32,7 @@ not currently doing so.
 Maintainers may transition to emeritus status by request. They may also
 transition to emeritus status automatically if they are not active in the SLSA
 community for six (6) months. "Active" is loosely defined to mean performing the
-duties defined in the [SLSA Governance](https://github.com/slsa-framework/governance/blob/main/5._Governance.md) documentation.
+Maintainer duties defined in the [SLSA Governance](https://github.com/slsa-framework/governance/blob/main/5._Governance.md) documentation.
 Any ambiguity in whether or not a maintainer is considered active will be
 resolved by the other maintainers. There should always be at least three active
 maintainers, so automatic transitions to emeritus status will pause if there


### PR DESCRIPTION
Adds details about maintainers moving to emeritus status
- Automatically become emeritus after some months without being active
- Defines what it means to be active
- Puts a lower bound on the number of maintainers