### PR TITLE
fix: address new markdown-lint warnings triggered on new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SLSA ("salsa") is Supply-chain Levels for Software Artifacts
 
-<img align="right" src="https://github.com/slsa-framework/slsa/blob/main/docs/images/slsa-dancing-goose-logo.svg">
+<img align="right" src="https://github.com/slsa-framework/slsa/blob/main/docs/images/slsa-dancing-goose-logo.svg" alt="The OpenSSF mascot, a goose in armor, strikes a pose wearing a red salsa dress">
 
 SLSA (pronounced ["salsa"](https://www.google.com/search?q=how+to+pronounce+salsa)) is a security framework from source to service, giving anyone working with software a common language for increasing levels of software security and supply chain integrity. It’s how you get from safe enough to being as resilient as possible, at any link in the chain.
 

--- a/controls/policy.md
+++ b/controls/policy.md
@@ -13,6 +13,7 @@ policy based on [software attestations](attestations.md).
 
 *TODO: Define what an attestation-based admission control policy is.*
 
+<!-- markdownlint-disable MD045 -->
 <p align="center"><img width="50%" src="images/policy_model.svg"></p>
 
 To make the decision, a policy engine combines the following:

--- a/docs/_posts/2022-05-02-slsa-sbom.md
+++ b/docs/_posts/2022-05-02-slsa-sbom.md
@@ -7,7 +7,9 @@ is_guest_post: true
 <!-- markdownlint-disable-next-line MD033 -->
 <center>
 <img src="https://user-images.githubusercontent.com/3060102/165816019-184fdd3d-1fa6-4d33-933f-49c1642006c0.png"
-width="300" /></center>
+width="300"
+alt="The OpenSSF mascot, a goose in armor, in a red salsa dress holds a sheaf of paper
+the topmost of which is titled SBOM"/></center>
 
 If you’re trying to build and run secure software today, you’ve probably heard
 of an [SBOM, or a Software Bill of Materials](https://ntia.gov/SBOM). Acting as

--- a/docs/spec/v1.0/terminology.md
+++ b/docs/spec/v1.0/terminology.md
@@ -3,22 +3,23 @@ title: Terminology
 description: Before diving into the SLSA specification levels, we need to establish a core set of terminology and models to describe what we're protecting.
 ---
 <!--- Note on updating docs:
-* Using terms such as "developer," "maintainer," "producer," "author," and
-  "publisher" interchangeably can cause confusion.
-  *  For consistency: Whenever possible, default to "producer," in line with the
-     model of producer--consumer--infrastructure provider. "Maintainer" is reserved
-     for sections specifying the act of continuing to maintain a project after its
-     creation, or when used in a less technical context where it is unlikely to cause
-     confusion. Author is reserved for the act of making source code commits or
-     reviews. Individual is used when the context's focus is specifying a single
-     person (i.e., "an individual's workstation" or "compromised individual").
-* Using terms such as "platform," "system," and "service" interchangeably can cause
-  confusion.
-  * For consistency: Whenever possible, default to "platform." Instead of using "service,"
-    a reference to a "hosted platform" should be used. A reference to some specific
-    software or tools internal to a platform can be made with "platform component" unless
-    there is a more appropriate definition to use directly like "control plane." External
-    self-described services and systems can continue to be called by these terms.
+*   Using terms such as "developer," "maintainer," "producer," "author," and
+    "publisher" interchangeably can cause confusion.
+  *   For consistency: Whenever possible, default to "producer," in line with the
+      model of producer--consumer--infrastructure provider. "Maintainer" is reserved
+      for sections specifying the act of continuing to maintain a project after its
+      creation, or when used in a less technical context where it is unlikely to cause
+      confusion. Author is reserved for the act of making source code commits or
+      reviews. Individual is used when the context's focus is specifying a single
+      person (i.e., "an individual's workstation" or "compromised individual").
+*   Using terms such as "platform," "system," and "service" interchangeably can cause
+    confusion.
+  *   For consistency: Whenever possible, default to "platform." Instead of using
+      "service,"a reference to a "hosted platform" should be used. A reference to some
+      specific software or tools internal to a platform can be made with "platform
+      component" unless there is a more appropriate definition to use directly like
+      "control plane." External self-described services and systems can continue to
+      be called by these terms.
 --->
 
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set

--- a/docs/spec/v1.0/terminology.md
+++ b/docs/spec/v1.0/terminology.md
@@ -2,25 +2,24 @@
 title: Terminology
 description: Before diving into the SLSA specification levels, we need to establish a core set of terminology and models to describe what we're protecting.
 ---
-<!--- Note on updating docs:
-*   Using terms such as "developer," "maintainer," "producer," "author," and
-    "publisher" interchangeably can cause confusion.
-  *   For consistency: Whenever possible, default to "producer," in line with the
-      model of producer--consumer--infrastructure provider. "Maintainer" is reserved
-      for sections specifying the act of continuing to maintain a project after its
-      creation, or when used in a less technical context where it is unlikely to cause
-      confusion. Author is reserved for the act of making source code commits or
-      reviews. Individual is used when the context's focus is specifying a single
-      person (i.e., "an individual's workstation" or "compromised individual").
-*   Using terms such as "platform," "system," and "service" interchangeably can cause
-    confusion.
-  *   For consistency: Whenever possible, default to "platform." Instead of using
-      "service,"a reference to a "hosted platform" should be used. A reference to some
-      specific software or tools internal to a platform can be made with "platform
-      component" unless there is a more appropriate definition to use directly like
-      "control plane." External self-described services and systems can continue to
-      be called by these terms.
---->
+<!-- Note on updating docs:
+* Using terms such as "developer," "maintainer," "producer," "author," and
+  "publisher" interchangeably can cause confusion.
+  *  For consistency: Whenever possible, default to "producer," in line with the
+     model of producer--consumer--infrastructure provider. "Maintainer" is reserved
+     for sections specifying the act of continuing to maintain a project after its
+     creation, or when used in a less technical context where it is unlikely to cause
+     confusion. Author is reserved for the act of making source code commits or
+     reviews. Individual is used when the context's focus is specifying a single
+     person (i.e., "an individual's workstation" or "compromised individual").
+* Using terms such as "platform," "system," and "service" interchangeably can cause
+  confusion.
+  * For consistency: Whenever possible, default to "platform." Instead of using "service,"
+    a reference to a "hosted platform" should be used. A reference to some specific
+    software or tools internal to a platform can be made with "platform component" unless
+    there is a more appropriate definition to use directly like "control plane." External
+    self-described services and systems can continue to be called by these terms.
+-->
 
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set
 of terminology and models to describe what we're protecting.

--- a/docs/spec/v1.1/terminology.md
+++ b/docs/spec/v1.1/terminology.md
@@ -3,22 +3,23 @@ title: Terminology
 description: Before diving into the SLSA specification levels, we need to establish a core set of terminology and models to describe what we're protecting.
 ---
 <!--- Note on updating docs:
-* Using terms such as "developer," "maintainer," "producer," "author," and
-  "publisher" interchangeably can cause confusion.
-  *  For consistency: Whenever possible, default to "producer," in line with the
-     model of producer--consumer--infrastructure provider. "Maintainer" is reserved
-     for sections specifying the act of continuing to maintain a project after its
-     creation, or when used in a less technical context where it is unlikely to cause
-     confusion. Author is reserved for the act of making source code commits or
-     reviews. Individual is used when the context's focus is specifying a single
-     person (i.e., "an individual's workstation" or "compromised individual").
-* Using terms such as "platform," "system," and "service" interchangeably can cause
-  confusion.
-  * For consistency: Whenever possible, default to "platform." Instead of using "service,"
-    a reference to a "hosted platform" should be used. A reference to some specific
-    software or tools internal to a platform can be made with "platform component" unless
-    there is a more appropriate definition to use directly like "control plane." External
-    self-described services and systems can continue to be called by these terms.
+*   Using terms such as "developer," "maintainer," "producer," "author," and
+    "publisher" interchangeably can cause confusion.
+  *   For consistency: Whenever possible, default to "producer," in line with the
+      model of producer--consumer--infrastructure provider. "Maintainer" is reserved
+      for sections specifying the act of continuing to maintain a project after its
+      creation, or when used in a less technical context where it is unlikely to cause
+      confusion. Author is reserved for the act of making source code commits or
+      reviews. Individual is used when the context's focus is specifying a single
+      person (i.e., "an individual's workstation" or "compromised individual").
+*   Using terms such as "platform," "system," and "service" interchangeably can cause
+    confusion.
+  *   For consistency: Whenever possible, default to "platform." Instead of using
+      "service,"a reference to a "hosted platform" should be used. A reference to some
+      specific software or tools internal to a platform can be made with "platform
+      component" unless there is a more appropriate definition to use directly like
+      "control plane." External self-described services and systems can continue to
+      be called by these terms.
 --->
 
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set

--- a/docs/spec/v1.1/terminology.md
+++ b/docs/spec/v1.1/terminology.md
@@ -2,25 +2,24 @@
 title: Terminology
 description: Before diving into the SLSA specification levels, we need to establish a core set of terminology and models to describe what we're protecting.
 ---
-<!--- Note on updating docs:
-*   Using terms such as "developer," "maintainer," "producer," "author," and
-    "publisher" interchangeably can cause confusion.
-  *   For consistency: Whenever possible, default to "producer," in line with the
-      model of producer--consumer--infrastructure provider. "Maintainer" is reserved
-      for sections specifying the act of continuing to maintain a project after its
-      creation, or when used in a less technical context where it is unlikely to cause
-      confusion. Author is reserved for the act of making source code commits or
-      reviews. Individual is used when the context's focus is specifying a single
-      person (i.e., "an individual's workstation" or "compromised individual").
-*   Using terms such as "platform," "system," and "service" interchangeably can cause
-    confusion.
-  *   For consistency: Whenever possible, default to "platform." Instead of using
-      "service,"a reference to a "hosted platform" should be used. A reference to some
-      specific software or tools internal to a platform can be made with "platform
-      component" unless there is a more appropriate definition to use directly like
-      "control plane." External self-described services and systems can continue to
-      be called by these terms.
---->
+<!-- Note on updating docs:
+* Using terms such as "developer," "maintainer," "producer," "author," and
+  "publisher" interchangeably can cause confusion.
+  *  For consistency: Whenever possible, default to "producer," in line with the
+     model of producer--consumer--infrastructure provider. "Maintainer" is reserved
+     for sections specifying the act of continuing to maintain a project after its
+     creation, or when used in a less technical context where it is unlikely to cause
+     confusion. Author is reserved for the act of making source code commits or
+     reviews. Individual is used when the context's focus is specifying a single
+     person (i.e., "an individual's workstation" or "compromised individual").
+* Using terms such as "platform," "system," and "service" interchangeably can cause
+  confusion.
+  * For consistency: Whenever possible, default to "platform." Instead of using "service,"
+    a reference to a "hosted platform" should be used. A reference to some specific
+    software or tools internal to a platform can be made with "platform component" unless
+    there is a more appropriate definition to use directly like "control plane." External
+    self-described services and systems can continue to be called by these terms.
+-->
 
 Before diving into the [SLSA Levels](levels.md), we need to establish a core set
 of terminology and models to describe what we're protecting.


### PR DESCRIPTION
Markdown lint v0.38.0 has some changes which result in new warnings for MD0030 and MD0045 that weren't triggered prior to the update.

- MD030/list-marker-space: is now being triggered for Markdown inside a comment block
- MD045/no-alt-text: is now being triggered for HTML <img> tags

Signed-off-by: Joshua Lock <joshua.lock@uk.verizon.com>