### PR TITLE
editorial: Separate producer from platform requirements in Levels

### DIFF
--- a/docs/spec/v1.1/levels.md
+++ b/docs/spec/v1.1/levels.md
@@ -97,6 +97,7 @@ SLSA---other than tamper protection---without changing their build workflows.
 
 <dt>Requirements<dd>
 
+-   Software Producer:
     -   Follow a consistent build process so that others can form
         expectations about what a "correct" build looks like.
     -   Run builds on a build platform that meets Build L1 requirements.

--- a/docs/spec/v1.1/levels.md
+++ b/docs/spec/v1.1/levels.md
@@ -103,7 +103,6 @@ SLSA---other than tamper protection---without changing their build workflows.
     -   Run builds on a build platform that meets Build L1 requirements.
     -   Distribute provenance to consumers, preferably using a convention
         determined by the package ecosystem.
-
 -   Build platform:
     -   Automatically generate [provenance] describing how the artifact was
         built, including: what entity built the package, what build process
@@ -159,7 +158,7 @@ All of [Build L1], plus:
 -   Build platform:
     -   Generate and sign[^sign] the provenance itself. This may be done
         during the original build, an after-the-fact reproducible build, or
-        some equivalent platform that ensures the trustworthiness of the
+        some equivalent system that ensures the trustworthiness of the
         provenance.
 -   Consumer:
     -   Validate the authenticity of the provenance.

--- a/docs/spec/v1.1/levels.md
+++ b/docs/spec/v1.1/levels.md
@@ -95,19 +95,17 @@ but is trivial to bypass or forge.
 Projects and organizations wanting to easily and quickly gain some benefits of
 SLSA---other than tamper protection---without changing their build workflows.
 
-<dt>Software Producer Requirements<dd>
+<dt>Requirements<dd>
 
--   Follow a consistent build process so that others can form expectations
-    about what a "correct" build looks like.
-
--   Distribute provenance to consumers, preferably using a convention
-    determined by the package ecosystem.
-
-<dt>Build Platform Requirements<dd>
-
--   Automatically generate [provenance] describing how the artifact was
-    built, including: what entity built the package, what build process they
-    used, and what the top-level input to the build were.
+-   Software producer:
+    -   Follow a consistent build process so that others can form
+        expectations about what a "correct" build looks like.
+    -   Distribute provenance to consumers, preferably using a convention
+        determined by the package ecosystem.
+-   Build platform:
+    -   Automatically generate [provenance] describing how the artifact was
+        built, including: what entity built the package, what build process
+        they used, and what the top-level input to the build were.
 
 <dt>Benefits<dd>
 
@@ -149,22 +147,20 @@ Projects and organizations wanting to gain moderate security benefits of SLSA by
 switching to a hosted build platform, while waiting for changes to the build
 platform itself required by [Build L3].
 
-<dt>Software Producer Requirements<dd>
+<dt>Requirements<dd>
 
 All of [Build L1], plus:
 
--   Run builds on a hosted build platform that meets Build L2 requirements.
-
--   Enable downstream verifiers of provenance to validate the authenticity
-    of the provenance.
-
-<dt>Build Platform Requirements<dd>
-
-All of [Build L1], plus:
-
--   Generate and sign[^sign] the provenance itself. This may be done during
-    the original build, an after-the-fact reproducible build, or some
-    equivalent platform that ensures the trustworthiness of the provenance.
+-   Software producer:
+    -   Run builds on a hosted build platform that meets Build L2
+        requirements.
+-   Build platform:
+    -   Generate and sign[^sign] the provenance itself. This may be done
+        during the original build, an after-the-fact reproducible build, or
+        some equivalent platform that ensures the trustworthiness of the
+        provenance.
+-   Consumer:
+    -   Validate the authenticity of the provenance.
 
 <dt>Benefits<dd>
 
@@ -204,21 +200,19 @@ strong tamper protection.
 Most software releases. Build L3 usually requires significant changes to
 existing build platforms.
 
-<dt>Software Producer Requirements<dd>
+<dt>Requirements<dd>
 
 All of [Build L2], plus:
 
--   Run builds on a hosted build platform that meets Build L3 requirements.
-
-<dt>Build Platform Requirements<dd>
-
-All of [Build L2], plus:
-
--   Implement strong controls to:
-
-    -   prevent runs from influencing one another, even within the same project.
-    -   prevent secret material used to sign the provenance from being
-        accessible to the user-defined build steps.
+-   Software producer:
+    -   Run builds on a hosted build platform that meets Build L3
+        requirements.
+-   Build platform:
+    -   Implement strong controls to:
+        -   prevent runs from influencing one another, even within the same
+            project.
+        -   prevent secret material used to sign the provenance from being
+            accessible to the user-defined build steps.
 
 <dt>Benefits<dd>
 

--- a/docs/spec/v1.1/levels.md
+++ b/docs/spec/v1.1/levels.md
@@ -95,17 +95,19 @@ but is trivial to bypass or forge.
 Projects and organizations wanting to easily and quickly gain some benefits of
 SLSA---other than tamper protection---without changing their build workflows.
 
-<dt>Requirements<dd>
+<dt>Software Producer Requirements<dd>
 
--   Software producer follows a consistent build process so that others can form
-    expectations about what a "correct" build looks like.
+-   Follow a consistent build process so that others can form expectations
+    about what a "correct" build looks like.
 
--   Build platform automatically generates [provenance] describing how the
-    artifact was built, including: what entity built the package, what build
-    process they used, and what the top-level input to the build were.
+-   Distribute provenance to consumers, preferably using a convention
+    determined by the package ecosystem.
 
--   Software producer distributes provenance to consumers, preferably using a
-    convention determined by the package ecosystem.
+<dt>Build Platform Requirements<dd>
+
+-   Automatically generate [provenance] describing how the artifact was
+    built, including: what entity built the package, what build process they
+    used, and what the top-level input to the build were.
 
 <dt>Benefits<dd>
 
@@ -147,17 +149,22 @@ Projects and organizations wanting to gain moderate security benefits of SLSA by
 switching to a hosted build platform, while waiting for changes to the build
 platform itself required by [Build L3].
 
-<dt>Requirements<dd>
+<dt>Software Producer Requirements<dd>
 
 All of [Build L1], plus:
 
--   The build runs on a hosted build platform that generates and signs[^sign] the
-    provenance itself. This may be the original build, an after-the-fact
-    reproducible build, or some equivalent platform that ensures the
-    trustworthiness of the provenance.
+-   Run builds on a hosted build platform that meets Build L2 requirements.
 
--   Downstream verification of provenance includes validating the authenticity
+-   Enable downstream verifiers of provenance to validate the authenticity
     of the provenance.
+
+<dt>Build Platform Requirements<dd>
+
+All of [Build L1], plus:
+
+-   Generate and sign[^sign] the provenance itself. This may be done during
+    the original build, an after-the-fact reproducible build, or some
+    equivalent platform that ensures the trustworthiness of the provenance.
 
 <dt>Benefits<dd>
 
@@ -197,11 +204,17 @@ strong tamper protection.
 Most software releases. Build L3 usually requires significant changes to
 existing build platforms.
 
-<dt>Requirements<dd>
+<dt>Software Producer Requirements<dd>
 
 All of [Build L2], plus:
 
--   Build platform implements strong controls to:
+-   Run builds on a hosted build platform that meets Build L3 requirements.
+
+<dt>Build Platform Requirements<dd>
+
+All of [Build L2], plus:
+
+-   Implement strong controls to:
 
     -   prevent runs from influencing one another, even within the same project.
     -   prevent secret material used to sign the provenance from being

--- a/docs/spec/v1.1/levels.md
+++ b/docs/spec/v1.1/levels.md
@@ -97,11 +97,12 @@ SLSA---other than tamper protection---without changing their build workflows.
 
 <dt>Requirements<dd>
 
--   Software producer:
     -   Follow a consistent build process so that others can form
         expectations about what a "correct" build looks like.
+    -   Run builds on a build platform that meets Build L1 requirements.
     -   Distribute provenance to consumers, preferably using a convention
         determined by the package ecosystem.
+
 -   Build platform:
     -   Automatically generate [provenance] describing how the artifact was
         built, including: what entity built the package, what build process
@@ -152,7 +153,7 @@ platform itself required by [Build L3].
 All of [Build L1], plus:
 
 -   Software producer:
-    -   Run builds on a hosted build platform that meets Build L2
+    -   Run builds on a [hosted] build platform that meets Build L2
         requirements.
 -   Build platform:
     -   Generate and sign[^sign] the provenance itself. This may be done
@@ -237,6 +238,7 @@ All of [Build L2], plus:
 [build l2]: #build-l2
 [build l3]: #build-l3
 [future versions]: future-directions.md
+[hosted]: requirements.md#isolation-strength
 [previous version]: ../v0.1/levels.md
 [provenance]: terminology.md
 [verification]: verifying-artifacts.md


### PR DESCRIPTION
This PR adds a separate "Build Platform Requirements" row in each table of levels.md, more clearly defining what SW producers vs. build platform are responsible for at each level. To be clear, the requirements themselves have not changed, but rather the row in which they appear.

This change more closely matches the current separation in requirements.md, and also facilitates adding requirements for each role in higher/newer Build Track levels.