### PR TITLE
impl: use consistent Markdown sytnax for tables

### DIFF
--- a/docs/spec/v0.1/terminology.md
+++ b/docs/spec/v0.1/terminology.md
@@ -39,31 +39,31 @@ one or more artifacts.
 
 <p align="center"><img src="../../images/build-model.svg" alt="Model Build"></p>
 
-| Term | Description
-| --- | ---
-| Platform | System that allows tenants to run build. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build.
-| Service | A platform that is hosted, not a developer's machine. (Term used in [requirements](requirements.md).)
-| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single environment.
-| Steps | The set of actions that comprise a build, defined by the tenant.
-| Environment | Machine, container, VM, or similar in which the build runs, initialized by the platform. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps.
-| Trigger | External event or request causing the platform to run the build.
-| Source | Top-level input artifact required by the build.
-| Dependencies | Additional input artifacts required by the build.
-| Outputs | Collection of artifacts produced by the build.
-| Admin | Person with administrative access to the platform, potentially allowing them to tamper with the build process or access secret material.
+| Term | Description |
+| --- | --- |
+| Platform | System that allows tenants to run build. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. |
+| Service | A platform that is hosted, not a developer's machine. (Term used in [requirements](requirements.md).) |
+| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single environment. |
+| Steps | The set of actions that comprise a build, defined by the tenant. |
+| Environment | Machine, container, VM, or similar in which the build runs, initialized by the platform. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps. |
+| Trigger | External event or request causing the platform to run the build. |
+| Source | Top-level input artifact required by the build. |
+| Dependencies | Additional input artifacts required by the build. |
+| Outputs | Collection of artifacts produced by the build. |
+| Admin | Person with administrative access to the platform, potentially allowing them to tamper with the build process or access secret material. |
 
 <details><summary>Example: GitHub Actions</summary>
 
-| Term         | Example
-| ------------ | -------
-| Platform     | [GitHub Actions] + runner + runner's dependent services
-| Build        | Workflow or job (either would be OK)
-| Steps        | [`steps`]
-| Environment  | [`runs-on`]
-| Trigger      | [workflow trigger]
-| Source       | git commit defining the workflow
-| Dependencies | any other artifacts fetched during execution
-| Admin        | GitHub personnel
+| Term         | Example |
+| ------------ | ------- |
+| Platform     | [GitHub Actions] + runner + runner's dependent services |
+| Build        | Workflow or job (either would be OK) |
+| Steps        | [`steps`] |
+| Environment  | [`runs-on`] |
+| Trigger      | [workflow trigger] |
+| Source       | git commit defining the workflow |
+| Dependencies | any other artifacts fetched during execution |
+| Admin        | GitHub personnel |
 
 [GitHub Actions]: https://docs.github.com/en/actions
 [`runs-on`]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on
@@ -91,13 +91,13 @@ runner environment plus the remote execution environment.
 The model can still work for the case of a developer building on their local
 workstation, though this does not meet SLSA 2+.
 
-| Term         | Example
-| ------------ | -------
-| Platform     | developer's workstation
-| Build        | whatever they ran
-| Steps        | whatever they ran
-| Environment  | developer's workstation
-| Trigger      | commands that the developer ran
-| Admin        | developer
+| Term         | Example |
+| ------------ | ------- |
+| Platform     | developer's workstation |
+| Build        | whatever they ran |
+| Steps        | whatever they ran |
+| Environment  | developer's workstation |
+| Trigger      | commands that the developer ran |
+| Admin        | developer |
 
 </details>

--- a/docs/spec/v1.0-rc1/terminology.md
+++ b/docs/spec/v1.0-rc1/terminology.md
@@ -50,16 +50,16 @@ describing this whole process.
 
 <p align="center"><img src="build-model.svg" alt="Model Build"></p>
 
-| Primary Term | Description
-| --- | ---
-| Platform | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build.
-| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single environment on a platform.
-| Steps | The set of actions that comprise a build, defined by the tenant.
-| Environment | Machine, container, VM, or similar in which the build runs, initialized by the platform. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps.
-| External parameters | The set of top-level, independent inputs to the build, specified by a tenant and used by the platform to initialize the build.
-| Dependencies | Artifacts fetched during initialization or execution of the build process, such as configuration files, source artifacts, or build tools.
-| Outputs | Collection of artifacts produced by the build.
-| Provenance | Attestation (metadata) describing how the outputs were produced, including identification of the platform and external parameters.
+| Primary Term | Description |
+| --- | --- |
+| Platform | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. |
+| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single environment on a platform. |
+| Steps | The set of actions that comprise a build, defined by the tenant. |
+| Environment | Machine, container, VM, or similar in which the build runs, initialized by the platform. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps. |
+| External parameters | The set of top-level, independent inputs to the build, specified by a tenant and used by the platform to initialize the build. |
+| Dependencies | Artifacts fetched during initialization or execution of the build process, such as configuration files, source artifacts, or build tools. |
+| Outputs | Collection of artifacts produced by the build. |
+| Provenance | Attestation (metadata) describing how the outputs were produced, including identification of the platform and external parameters. |
 
 Notably, there is no formal notion of "source" in the build model, just
 parameters and dependencies. Most build platforms have an explicit "source"

--- a/docs/spec/v1.0-rc2/index.md
+++ b/docs/spec/v1.0-rc2/index.md
@@ -17,11 +17,14 @@ levels and recommended attestation formats, including provenance.
 
 {{ section.description }}
 
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable MD055 MD056 -->
 | Page | Description |
 | ---- | ----------- |
 {%- for child in section.children %}
 | [{{child.title}}]({{child.url | relative_url}}) | {{child.description}} |
 {%- endfor %}
+<!-- markdownlint-restore -->
 
 {%- endif %}
 {%- endfor %}

--- a/docs/spec/v1.0-rc2/terminology.md
+++ b/docs/spec/v1.0-rc2/terminology.md
@@ -49,12 +49,12 @@ be filled by more than one person or an organization. Similarly, a person or
 organization may act as more than one role in a particular software supply
 chain.
 
-| Role | Description | Examples
-| --- | --- | ---
-| Producer | A party who creates software and provides it to others. Producers are often also consumers. | An open source project's maintainers. A software vendor.
-| Verifier | A party who inspect an artifact's provenance to determine the artifact's authenticity. | A business's software ingestion system. A programming language ecosystem's package registry.
-| Consumer | A party who uses software provided by a producer. The consumer may verify provenance for software they consume or delegate that responsibility to a separate verifier. | A developer who uses open source software distributions. A business that uses a point of sale system.
-| Infrastructure provider | A party who provides software or services to other roles. | A package registry's maintainers. A build system's maintainers.
+| Role | Description | Examples |
+| --- | --- | --- |
+| Producer | A party who creates software and provides it to others. Producers are often also consumers. | An open source project's maintainers. A software vendor. |
+| Verifier | A party who inspect an artifact's provenance to determine the artifact's authenticity. | A business's software ingestion system. A programming language ecosystem's package registry. |
+| Consumer | A party who uses software provided by a producer. The consumer may verify provenance for software they consume or delegate that responsibility to a separate verifier. | A developer who uses open source software distributions. A business that uses a point of sale system. |
+| Infrastructure provider | A party who provides software or services to other roles. | A package registry's maintainers. A build system's maintainers. |
 
 ### Build model
 
@@ -70,19 +70,19 @@ describing this whole process.
 
 <p align="center"><img src="build-model.svg" alt="Model Build"></p>
 
-| Primary Term | Description
-| --- | ---
-| Platform | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. It includes software, hardware, people, and organizations.
-| Admin | A privileged user with administrative access to the platform, potentially allowing them to tamper with builds or the control plane.
-| Tenant | An untrusted user that builds an artifact on the platform. The tenant defines the build steps and external parameters.
-| Control plane | Build system component that orchestrates each independent build execution and produces provenance. The control plane is managed by an admin and trusted to be outside the tenant's control.
-| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single build environment on a platform.
-| Steps | The set of actions that comprise a build, defined by the tenant.
-| Build environment | The independent execution context in which the build runs, initialized by the control plane. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps.
-| External parameters | The set of top-level, independent inputs to the build, specified by a tenant and used by the control plane to initialize the build.
-| Dependencies | Artifacts fetched during initialization or execution of the build process, such as configuration files, source artifacts, or build tools.
-| Outputs | Collection of artifacts produced by the build.
-| Provenance | Attestation (metadata) describing how the outputs were produced, including identification of the platform and external parameters.
+| Primary Term | Description |
+| --- | --- |
+| Platform | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. It includes software, hardware, people, and organizations. |
+| Admin | A privileged user with administrative access to the platform, potentially allowing them to tamper with builds or the control plane. |
+| Tenant | An untrusted user that builds an artifact on the platform. The tenant defines the build steps and external parameters. |
+| Control plane | Build system component that orchestrates each independent build execution and produces provenance. The control plane is managed by an admin and trusted to be outside the tenant's control. |
+| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single build environment on a platform. |
+| Steps | The set of actions that comprise a build, defined by the tenant. |
+| Build environment | The independent execution context in which the build runs, initialized by the control plane. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps. |
+| External parameters | The set of top-level, independent inputs to the build, specified by a tenant and used by the control plane to initialize the build. |
+| Dependencies | Artifacts fetched during initialization or execution of the build process, such as configuration files, source artifacts, or build tools. |
+| Outputs | Collection of artifacts produced by the build. |
+| Provenance | Attestation (metadata) describing how the outputs were produced, including identification of the platform and external parameters. |
 
 Notably, there is no formal notion of "source" in the build model, just
 parameters and dependencies. Most build platforms have an explicit "source"

--- a/docs/spec/v1.0/index.md
+++ b/docs/spec/v1.0/index.md
@@ -17,11 +17,14 @@ levels and recommended attestation formats, including provenance.
 
 {{ section.description }}
 
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable MD055 MD056 -->
 | Page | Description |
 | ---- | ----------- |
 {%- for child in section.children %}
 | [{{child.title}}]({{child.url | relative_url}}) | {{child.description}} |
 {%- endfor %}
+<!-- markdownlint-restore -->
 
 {%- endif %}
 {%- endfor %}

--- a/docs/spec/v1.0/terminology.md
+++ b/docs/spec/v1.0/terminology.md
@@ -57,12 +57,12 @@ be filled by more than one person or an organization. Similarly, a person or
 organization may act as more than one role in a particular software supply
 chain.
 
-| Role | Description | Examples
-| --- | --- | ---
-| Producer | A party who creates software and provides it to others. Producers are often also consumers. | An open source project's maintainers. A software vendor.
-| Verifier | A party who inspect an artifact's provenance to determine the artifact's authenticity. | A business's software ingestion system. A programming language ecosystem's package registry.
-| Consumer | A party who uses software provided by a producer. The consumer may verify provenance for software they consume or delegate that responsibility to a separate verifier. | A developer who uses open source software distributions. A business that uses a point of sale system.
-| Infrastructure provider | A party who provides software or services to other roles. | A package registry's maintainers. A build platform's maintainers.
+| Role | Description | Examples |
+| --- | --- | --- |
+| Producer | A party who creates software and provides it to others. Producers are often also consumers. | An open source project's maintainers. A software vendor. |
+| Verifier | A party who inspect an artifact's provenance to determine the artifact's authenticity. | A business's software ingestion system. A programming language ecosystem's package registry. |
+| Consumer | A party who uses software provided by a producer. The consumer may verify provenance for software they consume or delegate that responsibility to a separate verifier. | A developer who uses open source software distributions. A business that uses a point of sale system. |
+| Infrastructure provider | A party who provides software or services to other roles. | A package registry's maintainers. A build platform's maintainers. |
 
 ### Build model
 
@@ -95,20 +95,20 @@ a dependency.
 For examples of how this model applies to real-world build platforms, see [index
 of build types](/provenance/v1#index-of-build-types).
 
-| Primary Term | Description
-| --- | ---
-| Platform | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. It includes software, hardware, people, and organizations.
-| Admin | A privileged user with administrative access to the platform, potentially allowing them to tamper with builds or the control plane.
-| Tenant | An untrusted user that builds an artifact on the platform. The tenant defines the build steps and external parameters.
-| Control plane | Build platform component that orchestrates each independent build execution and produces provenance. The control plane is managed by an admin and trusted to be outside the tenant's control.
-| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single build environment on a platform.
-| Steps | The set of actions that comprise a build, defined by the tenant.
-| Build environment | The independent execution context in which the build runs, initialized by the control plane. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps.
-| Build caches | An intermediate artifact storage managed by the platform that maps intermediate artifacts to their explicit inputs. A build may share build caches with any subsequent build running on the platform.
-| External parameters | The set of top-level, independent inputs to the build, specified by a tenant and used by the control plane to initialize the build.
-| Dependencies | Artifacts fetched during initialization or execution of the build process, such as configuration files, source artifacts, or build tools.
-| Outputs | Collection of artifacts produced by the build.
-| Provenance | Attestation (metadata) describing how the outputs were produced, including identification of the platform and external parameters.
+| Primary Term | Description |
+| --- | --- |
+| Platform | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. It includes software, hardware, people, and organizations. |
+| Admin | A privileged user with administrative access to the platform, potentially allowing them to tamper with builds or the control plane. |
+| Tenant | An untrusted user that builds an artifact on the platform. The tenant defines the build steps and external parameters. |
+| Control plane | Build platform component that orchestrates each independent build execution and produces provenance. The control plane is managed by an admin and trusted to be outside the tenant's control. |
+| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single build environment on a platform. |
+| Steps | The set of actions that comprise a build, defined by the tenant. |
+| Build environment | The independent execution context in which the build runs, initialized by the control plane. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps. |
+| Build caches | An intermediate artifact storage managed by the platform that maps intermediate artifacts to their explicit inputs. A build may share build caches with any subsequent build running on the platform. |
+| External parameters | The set of top-level, independent inputs to the build, specified by a tenant and used by the control plane to initialize the build. |
+| Dependencies | Artifacts fetched during initialization or execution of the build process, such as configuration files, source artifacts, or build tools. |
+| Outputs | Collection of artifacts produced by the build. |
+| Provenance | Attestation (metadata) describing how the outputs were produced, including identification of the platform and external parameters. |
 
 <details><summary>Ambiguous terms to avoid</summary>
 

--- a/docs/spec/v1.1/index.md
+++ b/docs/spec/v1.1/index.md
@@ -17,11 +17,14 @@ levels and recommended attestation formats, including provenance.
 
 {{ section.description }}
 
+<!-- markdownlint-capture -->
+<!-- markdownlint-disable MD055 MD056 -->
 | Page | Description |
 | ---- | ----------- |
 {%- for child in section.children %}
 | [{{child.title}}]({{child.url | relative_url}}) | {{child.description}} |
 {%- endfor %}
+<!-- markdownlint-restore -->
 
 {%- endif %}
 {%- endfor %}

--- a/docs/spec/v1.1/terminology.md
+++ b/docs/spec/v1.1/terminology.md
@@ -57,12 +57,12 @@ be filled by more than one person or an organization. Similarly, a person or
 organization may act as more than one role in a particular software supply
 chain.
 
-| Role | Description | Examples
-| --- | --- | ---
-| Producer | A party who creates software and provides it to others. Producers are often also consumers. | An open source project's maintainers. A software vendor.
-| Verifier | A party who inspect an artifact's provenance to determine the artifact's authenticity. | A business's software ingestion system. A programming language ecosystem's package registry.
-| Consumer | A party who uses software provided by a producer. The consumer may verify provenance for software they consume or delegate that responsibility to a separate verifier. | A developer who uses open source software distributions. A business that uses a point of sale system.
-| Infrastructure provider | A party who provides software or services to other roles. | A package registry's maintainers. A build platform's maintainers.
+| Role | Description | Examples |
+| --- | --- | --- |
+| Producer | A party who creates software and provides it to others. Producers are often also consumers. | An open source project's maintainers. A software vendor. |
+| Verifier | A party who inspect an artifact's provenance to determine the artifact's authenticity. | A business's software ingestion system. A programming language ecosystem's package registry. |
+| Consumer | A party who uses software provided by a producer. The consumer may verify provenance for software they consume or delegate that responsibility to a separate verifier. | A developer who uses open source software distributions. A business that uses a point of sale system. |
+| Infrastructure provider | A party who provides software or services to other roles. | A package registry's maintainers. A build platform's maintainers. |
 
 ### Build model
 
@@ -95,20 +95,20 @@ a dependency.
 For examples of how this model applies to real-world build platforms, see [index
 of build types](/provenance/v1#index-of-build-types).
 
-| Primary Term | Description
-| --- | ---
-| Platform | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. It includes software, hardware, people, and organizations.
-| Admin | A privileged user with administrative access to the platform, potentially allowing them to tamper with builds or the control plane.
-| Tenant | An untrusted user that builds an artifact on the platform. The tenant defines the build steps and external parameters.
-| Control plane | Build platform component that orchestrates each independent build execution and produces provenance. The control plane is managed by an admin and trusted to be outside the tenant's control.
-| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single build environment on a platform.
-| Steps | The set of actions that comprise a build, defined by the tenant.
-| Build environment | The independent execution context in which the build runs, initialized by the control plane. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps.
-| Build caches | An intermediate artifact storage managed by the platform that maps intermediate artifacts to their explicit inputs. A build may share build caches with any subsequent build running on the platform.
-| External parameters | The set of top-level, independent inputs to the build, specified by a tenant and used by the control plane to initialize the build.
-| Dependencies | Artifacts fetched during initialization or execution of the build process, such as configuration files, source artifacts, or build tools.
-| Outputs | Collection of artifacts produced by the build.
-| Provenance | Attestation (metadata) describing how the outputs were produced, including identification of the platform and external parameters.
+| Primary Term | Description |
+| --- | --- |
+| Platform | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. It includes software, hardware, people, and organizations. |
+| Admin | A privileged user with administrative access to the platform, potentially allowing them to tamper with builds or the control plane. |
+| Tenant | An untrusted user that builds an artifact on the platform. The tenant defines the build steps and external parameters. |
+| Control plane | Build platform component that orchestrates each independent build execution and produces provenance. The control plane is managed by an admin and trusted to be outside the tenant's control. |
+| Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single build environment on a platform. |
+| Steps | The set of actions that comprise a build, defined by the tenant. |
+| Build environment | The independent execution context in which the build runs, initialized by the control plane. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps. |
+| Build caches | An intermediate artifact storage managed by the platform that maps intermediate artifacts to their explicit inputs. A build may share build caches with any subsequent build running on the platform. |
+| External parameters | The set of top-level, independent inputs to the build, specified by a tenant and used by the control plane to initialize the build. |
+| Dependencies | Artifacts fetched during initialization or execution of the build process, such as configuration files, source artifacts, or build tools. |
+| Outputs | Collection of artifacts produced by the build. |
+| Provenance | Attestation (metadata) describing how the outputs were produced, including identification of the platform and external parameters. |
 
 <details><summary>Ambiguous terms to avoid</summary>
 


### PR DESCRIPTION
Address markdownlint warning about inconsistent markdown syntax for
tables. We almost always use a trailing `|`, so add that to the few
places where it's missing. Also disable the lint warning on Liquid
templates that markdownlint fails to parse properly.

This unblocks upgrading to markdownlint-cli v0.39 (#1021).

A future PR might switch to leading-only syntax (#1023), but that is
outside the scope of this PR.

