### PR TITLE
impl: add instructions on how to diff builds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -85,6 +85,29 @@ after creating a PR, Netlify will add a comment with a link to a preview. The
 URL is of the form `https://deploy-preview-#--slsa.netlify.app` where `#` is the
 pull request number. This preview is updated on every push.
 
+### Comparing built versions
+
+To compute a diff of two different build results, you need to scrub commit IDs
+and timestamps:
+
+```bash
+# Prepare version A
+$ JEKYLL_BUILD_REVISION=COMMIT bundle exec jekyll build
+$ mv _site _site.A
+# Prepare version B
+$ JEKYLL_BUILD_REVISION=COMMIT bundle exec jekyll build
+$ mv _site _site.B
+$ sed -i -e 's@<updated>[^<]\+</updated>@<updated>DATE</updated>@' _site.{A,B}/feed.xml
+$ git diff --no-index --no-prefix _site.A _site.B
+```
+
+Alternatively, if you already built without `JEKYLL_BUILD_REVISION`, you can
+scrub the commit like this, though it is less accurate:
+
+```bash
+sed -i -e 's@/slsa/blob/[0-9a-f]\+/docs/@/slsa/blob/COMMIT/docs/@g' _site/**/*
+```
+
 ## Production
 
 ### Netlify configuration


### PR DESCRIPTION
It's not completely straightforward to compare two versions of the built
site (`_site`) since you need to scrub commit IDs and timestamps. This
commit adds a new section to docs/README.md explaining how to do this.

This is useful to do when upgrading to new versions of dependencies
(e.g. #1028) or changing templates, where you want to make sure there
are no unexpected changes.

Ideally this could be done automatically as part of our CI/CD (GitHub
Actions or Netlify), but this is a simple first step.
