### PR TITLE
impl: fix comparison instructions

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -97,15 +97,18 @@ $ mv _site _site.A
 # Prepare version B
 $ JEKYLL_BUILD_REVISION=COMMIT bundle exec jekyll build
 $ mv _site _site.B
-$ sed -i -e 's@<updated>[^<]\+</updated>@<updated>DATE</updated>@' _site.{A,B}/feed.xml
+$ sed -i.bak -r -e '1s@<updated>[^<]+</updated>@<updated>DATE</updated>@' _site.{A,B}/feed.xml
+$ rm _site.{A,B}/feed.xml.bak
 $ git diff --no-index --no-prefix _site.A _site.B
 ```
 
 Alternatively, if you already built without `JEKYLL_BUILD_REVISION`, you can
-scrub the commit like this, though it is less accurate:
+scrub the commit like this, though it is less accurate. On MacOS or BSD, use
+`-i ''` instead of just `-i`.
 
 ```bash
-sed -i -e 's@/slsa/blob/[0-9a-f]\+/docs/@/slsa/blob/COMMIT/docs/@g' _site/**/*
+shopt -s globstar
+sed -i -r -e 's@/slsa/blob/[0-9a-f]+/docs/@/slsa/blob/COMMIT/docs/@g' _site/**/*
 ```
 
 ## Production


### PR DESCRIPTION
Commit 74452a8 added instructions to compare builds, but it had a few
bugs:

- Did not work on MacOS due to differences between BSD `sed` (Mac) and
  GNU `sed` (Linux)
  - To edit in-place without a backup file, GNU sed uses `-i` (no
    parameter) and BSD sed uses `-i ''`. There is no cross-platform way
    to do this. So instead, just use a backup file (`-i.bak`) then
    delete it afterward.
  - `\+` is a GNU extension to basic regexp. Switch to extended regexp
    (`-r`) which works on GNU sed and modern BSD sed.
- Incorrectly edited all dates instead of just the first. Only the first
  is the build timestamp (`site.time` in Jekyll). The rest are
  deterministic and should not be scrubbed. Use the `1` sed range to
  fix.
- Did not note that the bash `**/*` syntax requires `shopt -s globstar`.

Signed-off-by: Mark Lodato <lodato@google.com>
