### PR TITLE
nonspec: Update meeting schedule on the community page.

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -46,7 +46,7 @@ developing tooling, we welcome your contributions.
                     <a target="_blank" href="https://groups.google.com/g/slsa-discussion" class="cta-link mt-6 font-semibold h5">Mailing list</a>
                 </div>
             </div>
-	    <div class="w-full md:w-1/2 getting_started_card md:pl-5 lg:mb-0 mb-8">
+     <div class="w-full md:w-1/2 getting_started_card md:pl-5 lg:mb-0 mb-8">
                 <div class="bg-pastel-green h-full rounded-lg p-10">
                     <p class="h4 font-semibold mb-6">Archived meeting notes</p>
                     <p>The SLSA community no longer holds these meetings regularly. Their meeting notes are archived here for posterity.</p>

--- a/docs/community.md
+++ b/docs/community.md
@@ -40,10 +40,18 @@ developing tooling, we welcome your contributions.
                     <p class="h4 font-semibold mb-6">General contributions</p>
                     <p>For questions, suggestions, or status updates, please use one of the following channels.</p>
                     <a target="_blank" href="https://github.com/slsa-framework/slsa/blob/main/CONTRIBUTING.md" class="cta-link mt-6 font-semibold h5">Contribution guidelines</a>
-                    <a target="_blank" href="notes/specification" class="cta-link mt-6 font-semibold h5">Community meeting (weekly)</a>
+                    <a target="_blank" href="notes/specification" class="cta-link mt-6 font-semibold h5">Specification meeting (weekly)</a>
                     <a target="_blank" href="https://github.com/slsa-framework/slsa/issues" class="cta-link mt-6 font-semibold h5">GitHub issues (tracks all work)</a>
                     <a target="_blank" href="https://slack.openssf.org/" class="cta-link mt-6 font-semibold h5" title="#slsa">Slack (#slsa)</a>
                     <a target="_blank" href="https://groups.google.com/g/slsa-discussion" class="cta-link mt-6 font-semibold h5">Mailing list</a>
+                </div>
+            </div>
+	    <div class="w-full md:w-1/2 getting_started_card md:pl-5 lg:mb-0 mb-8">
+                <div class="bg-pastel-green h-full rounded-lg p-10">
+                    <p class="h4 font-semibold mb-6">Archived meeting notes</p>
+                    <p>The SLSA community no longer holds these meetings regularly. Their meeting notes are archived here for posterity.</p>
+                    <a href="notes/community" class="cta-link mt-6 font-semibold h5">Community meeting (monthly)</a>
+                    <a href="notes/tooling" class="cta-link mt-6 font-semibold h5">Tooling Special Interest Group</a>
                 </div>
             </div>
         </div>

--- a/docs/community.md
+++ b/docs/community.md
@@ -38,20 +38,12 @@ developing tooling, we welcome your contributions.
             <div class="w-full md:w-1/2 getting_started_card md:pl-5 lg:mb-0 mb-8">
                 <div class="bg-pastel-green h-full rounded-lg p-10">
                     <p class="h4 font-semibold mb-6">General contributions</p>
-                    <p>For general questions, suggestions, or status updates, please use one of the following channels.</p>
+                    <p>For questions, suggestions, or status updates, please use one of the following channels.</p>
                     <a target="_blank" href="https://github.com/slsa-framework/slsa/blob/main/CONTRIBUTING.md" class="cta-link mt-6 font-semibold h5">Contribution guidelines</a>
-                    <a target="_blank" href="notes/community" class="cta-link mt-6 font-semibold h5">Community meeting (monthly)</a>
+                    <a target="_blank" href="notes/specification" class="cta-link mt-6 font-semibold h5">Community meeting (weekly)</a>
                     <a target="_blank" href="https://github.com/slsa-framework/slsa/issues" class="cta-link mt-6 font-semibold h5">GitHub issues (tracks all work)</a>
                     <a target="_blank" href="https://slack.openssf.org/" class="cta-link mt-6 font-semibold h5" title="#slsa">Slack (#slsa)</a>
                     <a target="_blank" href="https://groups.google.com/g/slsa-discussion" class="cta-link mt-6 font-semibold h5">Mailing list</a>
-                </div>
-            </div>
-            <div class="w-full md:w-1/2 getting_started_card md:pl-5 lg:mb-0 mb-8">
-                <div class="bg-pastel-green h-full rounded-lg p-10">
-                    <p class="h4 font-semibold mb-6">Special Interest Groups (SIGs)</p>
-                    <p>To get more deeply involved in SLSA, we welcome your participation in the following special interest groups (SIGs). See linked meeting notes for more info, including meeting times and Slack channel.</p>
-                    <a href="notes/specification" class="cta-link mt-6 font-semibold h5">Specification SIG</a>
-                    <a href="notes/tooling" class="cta-link mt-6 font-semibold h5">Tooling SIG</a>
                 </div>
             </div>
         </div>

--- a/docs/community.md
+++ b/docs/community.md
@@ -50,7 +50,7 @@ developing tooling, we welcome your contributions.
                 <div class="bg-pastel-green h-full rounded-lg p-10">
                     <p class="h4 font-semibold mb-6">Archived meeting notes</p>
                     <p>The SLSA community no longer holds these meetings regularly. Their meeting notes are archived here for posterity.</p>
-                    <a href="notes/community" class="cta-link mt-6 font-semibold h5">Community meeting (monthly)</a>
+                    <a href="notes/community" class="cta-link mt-6 font-semibold h5">Community meeting</a>
                     <a href="notes/tooling" class="cta-link mt-6 font-semibold h5">Tooling Special Interest Group</a>
                 </div>
             </div>

--- a/docs/community.md
+++ b/docs/community.md
@@ -37,7 +37,7 @@ developing tooling, we welcome your contributions.
         <div class="flex flex-wrap w-6/7 mt-8 mx-auto md:-ml-5 clear-both">
             <div class="w-full md:w-1/2 getting_started_card md:pl-5 lg:mb-0 mb-8">
                 <div class="bg-pastel-green h-full rounded-lg p-10">
-                    <p class="h4 font-semibold mb-6">General contributions</p>
+                    <p class="h4 font-semibold mb-6">How to contribute</p>
                     <p>For questions, suggestions, or status updates, please use one of the following channels.</p>
                     <a target="_blank" href="https://github.com/slsa-framework/slsa/blob/main/CONTRIBUTING.md" class="cta-link mt-6 font-semibold h5">Contribution guidelines</a>
                     <a target="_blank" href="notes/specification" class="cta-link mt-6 font-semibold h5">Specification meeting (weekly)</a>


### PR DESCRIPTION
We've agreed to cancel the monthly community meeting and roll it into the weekly specification SIG meeting. Additionally, the tooling SIG has not met regularly for some time. This PR makes the following changes to the community page to reflect our new schedule:
- Archive the meeting notes for both the community meeting and the tooling SIG meeting.
- Direct contributors to the weekly specification meeting.

#1036 