### PR TITLE
nonspec: clean up meeting notes page

### DIFF
--- a/docs/notes/index.md
+++ b/docs/notes/index.md
@@ -1,16 +1,24 @@
 ---
 title: Meeting notes
 description: Links for SLSA community meeting notes.
+layout: standard
 ---
 
-This directory contains simple aliases for the SLSA community meeting notes
-docs. This way you can type, for example, `https://slsa.dev/notes/community`
+This directory contains URL aliases for the SLSA community meeting notes in
+Google Docs. This way you can type, for example, `https://slsa.dev/notes/spec`
 instead of finding the Google docs URL. Each notes document also has the time,
 meeting link, etc. at the top.
+
+## Current meetings
+
+| URL                            | Alias        | Meeting
+| ------------------------------ | ------------ | ---------------------------
+| [specification](specification) | [spec](spec) | Weekly Monday meeting (formerly "Specification SIG")
+
+## Retired meetings
 
 | URL                            | Alias        | Meeting
 | ------------------------------ | ------------ | ---------------------------
 | [community](community)         |              | General community meeting
 | [positioning](positioning)     |              | Positioning SIG
-| [specification](specification) | [spec](spec) | Specification SIG
 | [tooling](tooling)             |              | Tooling SIG


### PR DESCRIPTION
Make the meeting notes easier to find by moving all of the old meeting
notes to a "retired" section and renaming the single remaining meeting
to "weekly Monday meeting".

Also clean up the wording in the intro and use a proper Jekyll layout to
fix the styling.

Signed-off-by: Mark Lodato <lodato@google.com>
