### PR TITLE
editorial: Expand SLSA acronym in docs

### DIFF
--- a/docs/spec/v1.1/about.md
+++ b/docs/spec/v1.1/about.md
@@ -8,7 +8,7 @@ to SLSA, start here!
 
 ## What is SLSA?
 
-SLSA is a set of incrementally adoptable guidelines for supply chain security,
+Supply-chain Levels for Software Artifacts, or SLSA ("salsa"), is a set of incrementally adoptable guidelines for supply chain security,
 established by industry consensus. The specification set by SLSA is useful for
 both software producers and consumers: producers can follow SLSA's guidelines to
 make their software supply chain more secure, and consumers can use SLSA to make


### PR DESCRIPTION
When visiting slsa.dev/spec/$version/about, I didn't see any mention of what the SLSA acronym actually stands for.
This change simply expands the acronym in the docs.