### PR TITLE
nonspec: add instructions for checking markdown formatting

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,24 +57,26 @@ style, as encoded in our [markdownlint configuration](.markdownlint.yaml). In
 addition we prefer to keep our Markdown documents wrapped at 80 columns (though
 this is not currently enforced).
 
-To check (and fix) style problems before sending a PR you can install
-and run [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2).
+To check (and fix) style problems before sending a PR you can run linting
+locally with `npm run lint && ./lint.sh` or `npm run format && ./lint.sh`.
 
 ```shell
-$ markdownlint-cli2 CONTRIBUTING.md
-markdownlint-cli2 v0.13.0 (markdownlint v0.34.0)
-Finding: CONTRIBUTING.md
-Linting: 1 file(s)
-Summary: 2 error(s)
-CONTRIBUTING.md:70 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
-CONTRIBUTING.md:71 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Above] [Context: "### Pull request conventions"]
-$ markdownlint-cli2 CONTRIBUTING.md --fix
-markdownlint-cli2 v0.13.0 (markdownlint v0.34.0)
-Finding: CONTRIBUTING.md
-Linting: 1 file(s)
-Summary: 0 error(s)
+$ npm run lint && ./lint.sh
+
+> lint
+> markdownlint .
+
+CONTRIBUTING.md:77 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Above] [Context: "### Pull request conventions"]
+$ npm run format && ./lint.sh
+
+> format
+> markdownlint . --fix
+
 $
 ```
+
+If you haven't already you'll need to install npm (e.g. `sudo apt install npm`)
+and package dependencies (`npm install`).
 
 ### Pull request conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,25 @@ style, as encoded in our [markdownlint configuration](.markdownlint.yaml). In
 addition we prefer to keep our Markdown documents wrapped at 80 columns (though
 this is not currently enforced).
 
+To check (and fix) style problems before sending a PR you can install
+and run [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2).
+
+```shell
+$ markdownlint-cli2 CONTRIBUTING.md
+markdownlint-cli2 v0.13.0 (markdownlint v0.34.0)
+Finding: CONTRIBUTING.md
+Linting: 1 file(s)
+Summary: 2 error(s)
+CONTRIBUTING.md:70 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
+CONTRIBUTING.md:71 MD022/blanks-around-headings Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Above] [Context: "### Pull request conventions"]
+$ markdownlint-cli2 CONTRIBUTING.md --fix
+markdownlint-cli2 v0.13.0 (markdownlint v0.34.0)
+Finding: CONTRIBUTING.md
+Linting: 1 file(s)
+Summary: 0 error(s)
+$
+```
+
 ### Pull request conventions
 
 [pull request conventions]: #pull-request-conventions


### PR DESCRIPTION
Add instructions for checking markdown formatting using markdownlint-cli2.

I got tired of getting errors after sending and updating PRs but didn't know how to run the style checker locally. Once I figured it out I suspected other folks might have a similar problem.