### PR TITLE
nonspec: Add Marcela as new SLSA spec maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,6 +19,7 @@ permissions in this repository.
 | Arnaud Le Hors | lehors@us.ibm.com | @Arnaud Le Hors | [lehors](https://github.com/lehors) | IBM
 | Joshua Lock | joshuagloe@gmail.com | @Joshua Lock |  [joshuagl](https://github.com/joshuagl) | Verizon
 | Kris K | kkris@google.com | @Kris K | [kpk47](https://github.com/kpk47) | Google
+| Marcela Melara | marcela.melara@intel.com | @Marcela Melara | [marcelamelara](https://github.com/marcelamelara) | Intel
 | Mark Lodato | lodato@google.com |  @Mark Lodato | [MarkLodato](https://github.com/MarkLodato) | Google
 | Michael Lieberman | mlieberman85@gmail.com | @Michael Lieberman | [mlieberman85](https://github.com/mlieberman85) | Kusari
 | Tom Hennen | tomhennen@google.com | @Tom Hennen | [TomHennen](https://github.com/TomHennen) | Google


### PR DESCRIPTION
I'd like to self-nominate for maintainer status of the SLSA spec. I believe I meet the [criteria](https://github.com/slsa-framework/slsa/blob/main/MAINTAINERS.md#becoming-a-maintainer) for maintainer status. Thanks!