### PR TITLE
Move v1.1 to Candidate Release (CR)

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -37,8 +37,8 @@ spec:
       name: Version 1.0
       status: Approved
     v1.1:
-      name: Version 1.1 (DRAFT)
-      status: Draft
+      name: Version 1.1 RC
+      status: Candidate
       draft: true
     draft:
       name: Working Draft

--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -81,7 +81,7 @@
             {%- else %}
               {%- assign new_url = "/" + spec_id + "/" + spec.current %}
             {%- endif %}
-            <p>{{ current_version.name }} is available! See <a href="{{ new_url }}">the newest documentation</a>.</p>
+            <p>{{ current_version.name }} is the current version. See <a href="{{ new_url }}">the {{ current_version.name }} documentation</a>.</p>
           {%- endif %}
         {%- endif %}
       </div>

--- a/docs/spec/v1.1/whats-new.md
+++ b/docs/spec/v1.1/whats-new.md
@@ -5,7 +5,7 @@ description: SLSA v1.1 is a minor release of SLSA. That is, all changes are inte
 
 SLSA v1.1 is a minor release of SLSA v1 which brings clarifications and
 additional content without changing the meaning of the specification. This
-document describes the major changes in v1.1 relative to the prior release,
+document describes the main changes in v1.1 relative to the prior release,
 [v1.0].
 
 ## Summary of changes


### PR DESCRIPTION
This PR proposes to change the status of v1.1 to Candidate Release in preparation for final publication.

I ought to point out that there is a bunch of VSA related issues that had been targeted for this release and that have not been addressed. See Issue #900. However, until someone works on any of these issues there is no hope of making progress and waiting for these to close will delay getting 1.1 out indefinitely. Although not ideal I therefore propose to defer these and publish what we have.
