### PR TITLE
impl: Fix Jekyll front matter

### DIFF
--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -1,8 +1,9 @@
 ---
 title: Verifying source
-description: SLSA uses attestations to indicate security claims associated with a repository revision, but attestations don't do anything unless somebody inspects them.
-SLSA calls that inspection verification, and this page describes how to verify properties of source revisions using their SLSA source provenance attestations.
-The intended audience is platform implementers, security engineers, and software consumers.
+description: |
+  SLSA uses attestations to indicate security claims associated with a repository revision, but attestations don't do anything unless somebody inspects them.
+  SLSA calls that inspection verification, and this page describes how to verify properties of source revisions using their SLSA source provenance attestations.
+  The intended audience is platform implementers, security engineers, and software consumers.
 ---
 
 SLSA uses attestations to indicate security claims associated with a repository revision, but attestations don't do anything unless somebody inspects them.


### PR DESCRIPTION
I noticed that the jekyll build was producing an error because the `description` variable in the front matter of the `verifying-source.md` file contained multiple lines. This fixes the format so that there is no longer any error and as a consequence the page title is now displayed correctly.

However, I must admit that although every page contains a description I cannot find whether it is actually used anywhere...
