### PR TITLE
nonspec: Suggest people assign reviewers to PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,8 +168,9 @@ Review process:
     -   Feel free to ping the reviwers in the
     [slsa-specification Slack](https://openssf.slack.com/archives/C03NUSAPKC6)
     when the PR is ready for review.
-    -   You will need a different number of approvals for different [PR types](#pull-request-types). Your
-    reviewers may ask that you use a different PR type.
+    -   You will need a different number of approvals for different
+ [PR types](#pull-request-types). Your reviewers may ask that you use a
+ different PR type.
 
 3.  Wait an appropriate amount of time to allow for lazy consensus. Different
     types have different minimum waiting periods. The waiting period begins at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -160,16 +160,26 @@ Review process:
 
 1.  Ensure that the PR meets the [pull request conventions].
 
-2.  GitHub will automatically assign the maintainers as reviewers. You will need
-    a different number of approvals for different PR types. Your reviewers may
-    ask that you use a different PR type.
+2.  If there is a particular set of maintainers you've been working with, feel
+    free to assign the PR to them.  If they don't have time to review they
+    should feel free to assign to someone else, or provide feedback on when
+    they can get to it.  Otherwise, assign to
+    `@slsa-framework/specification-maintainers`.
+    -   Feel free to ping the reviwers in the
+    [slsa-specification Slack](https://openssf.slack.com/archives/C03NUSAPKC6)
+    when the PR is ready for review.
 
-3.  Wait an appropriate amount of time to allow for lazy consensus. Different
+3.  You will need a different number of approvals for different PR types. Your
+    reviewers may ask that you use a different PR type.
+
+4.  Wait an appropriate amount of time to allow for lazy consensus. Different
     types have different minimum waiting periods. The waiting period begins at
     the timestamp of either the final required approval or the latest non-author
     comment, whichever is later.
+    -   If a few days have passed without any feedback please feel free to ping
+    the PR and in Slack.
 
-4.  Once the waiting period has passed, a maintainer will merge your PR. Expect
+5.  Once the waiting period has passed, a maintainer will merge your PR. Expect
     your PR to be squashed+merged unless your reviewers advise you otherwise.
     If your PR has not been merged within 48h of the waiting period having
     passed, and a reason for that has not been added as a PR comment, use the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,8 +169,8 @@ Review process:
     [slsa-specification Slack](https://openssf.slack.com/archives/C03NUSAPKC6)
     when the PR is ready for review.
     -   You will need a different number of approvals for different
- [PR types](#pull-request-types). Your reviewers may ask that you use a
- different PR type.
+    [PR types](#pull-request-types). Your reviewers may ask that you use a
+    different PR type.
 
 3.  Wait an appropriate amount of time to allow for lazy consensus. Different
     types have different minimum waiting periods. The waiting period begins at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,18 +168,17 @@ Review process:
     -   Feel free to ping the reviwers in the
     [slsa-specification Slack](https://openssf.slack.com/archives/C03NUSAPKC6)
     when the PR is ready for review.
-
-3.  You will need a different number of approvals for different PR types. Your
+    -   You will need a different number of approvals for different PR types. Your
     reviewers may ask that you use a different PR type.
 
-4.  Wait an appropriate amount of time to allow for lazy consensus. Different
+3.  Wait an appropriate amount of time to allow for lazy consensus. Different
     types have different minimum waiting periods. The waiting period begins at
     the timestamp of either the final required approval or the latest non-author
     comment, whichever is later.
     -   If a few days have passed without any feedback please feel free to ping
     the PR and in Slack.
 
-5.  Once the waiting period has passed, a maintainer will merge your PR. Expect
+4.  Once the waiting period has passed, a maintainer will merge your PR. Expect
     your PR to be squashed+merged unless your reviewers advise you otherwise.
     If your PR has not been merged within 48h of the waiting period having
     passed, and a reason for that has not been added as a PR comment, use the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,7 +176,7 @@ Review process:
     the timestamp of either the final required approval or the latest non-author
     comment, whichever is later.
     -   If a few days have passed without any feedback please feel free to ping
-    the PR and in Slack.
+    the PR and [in Slack](https://openssf.slack.com/archives/C03NUSAPKC6).
 
 4.  Once the waiting period has passed, a maintainer will merge your PR. Expect
     your PR to be squashed+merged unless your reviewers advise you otherwise.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ Review process:
     -   Feel free to ping the reviwers in the
     [slsa-specification Slack](https://openssf.slack.com/archives/C03NUSAPKC6)
     when the PR is ready for review.
-    -   You will need a different number of approvals for different PR types. Your
+    -   You will need a different number of approvals for different [PR types](#pull-request-types). Your
     reviewers may ask that you use a different PR type.
 
 3.  Wait an appropriate amount of time to allow for lazy consensus. Different


### PR DESCRIPTION
Suggest PR authors assign specific reviewers and ping the Slack
channel if they want.

The goal is to make it more clear who is expected to take the next
action on PRs vs the current situation where the maintainers may
think someone else will take a look or that they may have missed
the initial PR request.

fixes #1149