### PR TITLE
nonspec: Remove Kris from MAINTAINERS

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,7 +18,6 @@ permissions in this repository.
 | Andrew McNamara | arewm@redhat.com |  @arewm | [arewm](https://github.com/arewm) | Red Hat
 | Arnaud Le Hors | lehors@us.ibm.com | @Arnaud Le Hors | [lehors](https://github.com/lehors) | IBM
 | Joshua Lock | joshuagloe@gmail.com | @Joshua Lock |  [joshuagl](https://github.com/joshuagl) | Verizon
-| Kris K | kkris@google.com | @Kris K | [kpk47](https://github.com/kpk47) | Google
 | Marcela Melara | marcela.melara@intel.com | @Marcela Melara | [marcelamelara](https://github.com/marcelamelara) | Intel
 | Mark Lodato | lodato@google.com |  @Mark Lodato | [MarkLodato](https://github.com/MarkLodato) | Google
 | Michael Lieberman | mlieberman85@gmail.com | @Michael Lieberman | [mlieberman85](https://github.com/mlieberman85) | Kusari
@@ -51,6 +50,7 @@ candidate to the [Specification Maintainers] GitHub team.
 
 | Name | Email | OpenSSF Slack | GitHub | Affiliation
 | --- | --- | --- | --- | ---
+| Kris K | kkris@google.com | @Kris K | [kpk47](https://github.com/kpk47) | Google
 
 ### Removing a Maintainer
 


### PR DESCRIPTION
@kpk47 has been inactive for some time so I figured I'd send this to clean things up since we've had some new maintainers added recently.

However if Kris would still be interested in contributing we could drop this.

[According to our governance this PR requires majority approval](https://github.com/slsa-framework/governance/blob/main/5._Governance.md#:~:text=A%20proposed%20removal%20also%20requires%20a%20majority%20approval)