### PR TITLE
content: Add mitigation for malicious source platform admin.

### DIFF
--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -323,7 +323,9 @@ has no solution on GitHub.
 *Threat:* Platform administrator abuses their privileges to bypass controls or
 to push a malicious version of the software.
 
-*Mitigation:* TODO
+*Mitigation:* The source platform must have controls in place to prevent and
+detect abusive behavior from administrators (e.g. two-person approvals, audit
+logging).
 
 *Example 1:* GitHostingService employee uses an internal tool to push changes to
 the MyPackage source repo.


### PR DESCRIPTION
Add mitigation for malicious source platform admin.

We didn't have any guidance for this threat.  There are a number of ways we may be able to address this in the future via the SLSA Source Track and/or tools like gittuf.  However, SLSA doesn't currently address them.  This entire section is already labeled as not being handled by SLSA but does still include other mitigations.

I'm using the same language we have for "Compromise build platform admin", which seems like the same sort of threat, and should work 'fine' until we have something better.

Filed #1187 to track

Fixes #1179.