### PR TITLE
content: draft: Flesh out "Usage" threat

### DIFF
--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -662,7 +662,8 @@ cryptographic signature is no longer valid.
 ### (G) Distribution channel
 
 An adversary modifies the package on the package registry using an
-administrative interface or through a compromise of the infrastructure.
+administrative interface or through a compromise of the infrastructure
+including modification of the package in transit to the consumer.
 
 The distribution channel threats and mitigations look very similar to the
 Artifact Publication (F) threats and mitigations with the main difference

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -788,7 +788,16 @@ solutions.
 
 ### (I) Usage
 
-**TODO:** What should we put here?
+The consumer uses a package in an unsafe manner.
+
+<details><summary>Improper usage</summary>
+
+*Threat:* The software can be used in an insecure manner, allowing an
+adversary to compromise the consumer.
+
+*Mitigation:* This threat is not addressed by SLSA, but may be addressed by
+efforts like [Secure by Design][secure-by-design].
+</details>
 
 ## Dependency threats
 
@@ -1027,6 +1036,7 @@ collision resistance.
 [exists]: requirements.md#provenance-exists
 [isolated]: requirements.md#isolated
 [unforgeable]: requirements.md#provenance-unforgeable
+[secure-by-design]: https://www.cisa.gov/securebydesign
 [supply chain threats]: threats-overview
 [vsa]: verification_summary
 [vsa_verification]: verification_summary#how-to-verify

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -689,6 +689,19 @@ repository with the malicious package. Solution: Verifier rejects because
 builder is not as expected.
 
 </details>
+<details><summary>Issue VSA from untrusted intermediary <span>(expectations)</span></summary>
+
+*Threat:* Have an unofficial intermediary issue a VSA for a malicious package.
+
+*Mitigation*: Verifier requires VSAs to be issued by a trusted intermediary.
+
+*Example:* Verifier expects VSAs to be issued by TheRepository. Adversary
+builds a malicious package and then issues a VSA of their own for the malicious
+package. Solution: Verifier rejects because they only accept VSAs from
+TheRepository which the adversary cannot issue since they do not have the
+corresponding signing key.
+
+</details>
 <details><summary>Upload package without provenance or VSA <span>(Build L1)</span></summary>
 
 *Threat:* Replace the original package with a malicious one without provenance.
@@ -719,9 +732,9 @@ artifact does not match the `subject` found within the provenance.
 *Threat:* Perform a build that would not meet expectations, then modify the
 provenance or VSA to make the expectations checks pass.
 
-*Mitigation:* Verifier only accepts provenance with a valid [cryptographic
+*Mitigation:* Verifier only accepts provenance or VSA with a valid [cryptographic
 signature][authentic] or equivalent proving that the provenance came from an
-acceptable builder.
+acceptable builder or the VSA came from an expected verifier.
 
 *Example 1:* MyPackage is expected to be built by GitHub Actions from the
 `good/my-package` repo. Adversary builds with GitHub Actions from the
@@ -734,16 +747,9 @@ builds a malicious package and then modifies the original VSA's `subject`
 field to match the digest of the malicious package. Solution: Verifier rejects
 because the cryptographic signature is no longer valid.
 
-*Example 3:* Verifier expects VSAs to be issued by TheRepository. Adversary
-builds a malicious package and then issues a VSA of their own from
-EvilRepository for the malicious package. Solution: Verifier rejects because
-they only accept VSAs from TheRepository which the EvilRepository cannot
-issue since it does not have the corresponding signing key.
-
-*Example 4:* Verifier expects VSAs to be issued by TheRepository. Adversary
-uploads a malicious package to `repo/evil-package`, getting a valid VSA for
-`repo/evil-package` from TheRepository. Adversary then replaces
-`repo/my-pacakge` and its VSA with `repo/evil-package` and its VSA.
+*Example 3:* Adversary uploads a malicious package to `repo/evil-package`,
+getting a valid VSA for `repo/evil-package`. Adversary then replaces
+`repo/my-package` and its VSA with `repo/evil-package` and its VSA.
 Solution: Verifier rejects because the VSA `resourceUri` field lists
 `repo/evil-package` and not the expected `repo/my-package`.
 

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -797,6 +797,7 @@ adversary to compromise the consumer.
 
 *Mitigation:* This threat is not addressed by SLSA, but may be addressed by
 efforts like [Secure by Design][secure-by-design].
+
 </details>
 
 ## Dependency threats

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -670,7 +670,7 @@ being that these threats are mitigated by having the *consumer* perform
 verification.
 
 The consumer's actions may be simplified if (F) produces a [VSA][vsa].
-In this case the consumer may replace any provenance verification with
+In this case the consumer may replace provenance verification with
 [VSA verification][vsa_verification].
 
 <details><summary>Build with untrusted CI/CD <span>(expectations)</span></summary>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -666,7 +666,7 @@ administrative interface or through a compromise of the infrastructure.
 
 The distribution channel threats and mitigations look very similar to the
 Artifact Publication (F) threats and mitigations with the main difference
-being that these threats are mitigated by having the _consumer_ perform
+being that these threats are mitigated by having the *consumer* perform
 verification.
 
 The consumer's actions may be simplified if (F) produces a [VSA][vsa].

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -739,6 +739,14 @@ builds a malicious package and then issues a VSA of their own from
 EvilRepository for the malicious package. Solution: Verifier rejects because
 they only accept VSAs from TheRepository which the EvilRepository cannot
 issue since it does not have the corresponding signing key.
+
+*Example 4:* Verifier expects VSAs to be issued by TheRepository. Adversary
+uploads a malicious package to `repo/evil-package`, getting a valid VSA for
+`repo/evil-package` from TheRepository. Adversary then replaces
+`repo/my-pacakge` and its VSA with `repo/evil-package` and its VSA.
+Solution: Verifier rejects because the VSA `resourceUri` field lists
+`repo/evil-package` and not the expected `repo/my-package`.
+
 </details>
 
 ## Usage threats


### PR DESCRIPTION
There are two ways to look at the usage threat:

1. Can the attacker modify the software being delivered to a consumer.
2. Can the consumer use the software insecurly allowing an attacker
   to take advantage of that insecurity to exploit them.

IMO 1 has the same solutions as 'G' (PR https://github.com/slsa-framework/slsa/pull/1190).  I could repeat them
here under usage, but instead I've updated 'G' to include modification
in transit, and I've had 'Usage' address 2 above (albeit by just
deferring to CISA's work in this area).

fixes https://github.com/slsa-framework/slsa/issues/1182

NOTE: this PR is based on top of #1190 since the solution presented in 1190 obviates the need for addressing that here.