### PR TITLE
content: draft: Harden 'safe-expunging-process'

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -61,7 +61,7 @@ If a branch has been identified as consumable branch, force pushes to that branc
 
 Different organizations and tech stacks may have different approaches to the problem.
 
-Safe Expunging Scenarios:
+Safe Expunging Scenarios (non-exhaustive):
 
 ### Legal Takedowns
 
@@ -78,13 +78,13 @@ A team may decide that all reachable commits in the history of a revision need t
 In git VCS, compliance with this new policy will require history to be rewritten (commit metadata is included in the computation of the revision id).
 Policies in this category include things like commit signatures, author / committer formatting restrictions, closed-issue-linkage, etc.
 
-SCSs SHOULD make the fact of these changes public when they occur (e.g. an issue, announcement, or other mechanism).
+Organizations MUST make the fact of these changes public when they occur (e.g. an issue, announcement, or other mechanism).
 
 ### Repository renames
 
 When a repo is transferred to a new organization ("donated"), or if a repo must be renamed or otherwise have its url changed within the same org, attestations for previous revisions of this repo will no longer be matched because the combination of the repository id and the revision id will have changed.
 
-SCSs SHOULD make the fact of these changes public when they occur (e.g. an issue, announcement, or other mechanism).
+Organizations MUST make the fact of these changes public when they occur (e.g. an issue, announcement, or other mechanism).
 
 ## Levels
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -46,7 +46,7 @@ Consumers can examine the various source provenance attestations to determine if
 
 ## Safe Expunging Process
 
-SCSs MAY allow _administrators_ to expunge (remove) content from a repository and its change history without leaving a public record of the removed content.
+SCSs MAY allow the organization to expunge (remove) content from a repository and its change history without leaving a public record of the removed content.
 This includes changing files, history, or changing references in git and is used to accommodate legal/privacy compliance requirements as well as administrative
 changes within a repository (see below for more information on the various scenarios).
 When used as an attack, this is called “repo hijacking” (or “repo-jacking”) and is one of the primary threats source provenance attestations protect against.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -49,8 +49,8 @@ Consumers can examine the various source provenance attestations to determine if
 SCSs MAY allow the organization to expunge (remove) content from a repository and its change history without leaving a public record of the removed content.
 This includes changing files, history, or changing references in git and is used to accommodate legal/privacy compliance requirements.
 
-Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact. 
-In version control systems like git, removal of a revision changes the object id of all subsequent revisions that were built on top of it. 
+Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact.
+In version control systems like git, removal of a revision changes the object id of all subsequent revisions that were built on top of it.
 Although there is no "safe" way to do it, it sometimes necessary and there are steps you can take to mitigate the damage.
 
 When used as an attack, this is called “repo hijacking” (or “repo-jacking”) and is one of the primary threats source provenance attestations protect against.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -50,7 +50,7 @@ SCSs MAY allow the organization to expunge (remove) content from a repository an
 This includes changing files, history, or changing references in git and is used to accommodate legal/privacy compliance requirements.
 
 Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact.
-In version control systems like git, removal of a revision changes the object id of all subsequent revisions that were built on top of it.
+In version control systems like Git, removal of a revision changes the object IDs of all subsequent revisions that were built on top of it.
 Although there is no "safe" way to do it, it sometimes necessary and there are steps you can take to mitigate the damage.
 
 When used as an attack, this is called “repo hijacking” (or “repo-jacking”) and is one of the primary threats source provenance attestations protect against.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -46,26 +46,31 @@ Consumers can examine the various source provenance attestations to determine if
 
 ## Safe Expunging Process
 
-Administrators have the ability to expunge (remove) content from a repository and its change history without leaving a record of the removed content.
-This includes changing files, history, or changing references in git and is used to accommodate legal or privacy compliance requirements.
+SCSs MAY allow _administrators_ to expunge (remove) content from a repository and its change history without leaving a public record of the removed content.
+This includes changing files, history, or changing references in git and is used to accommodate legal/privacy compliance requirements as well as administrative
+changes within a repository (see below for more information on the various scenarios).
 When used as an attack, this is called “repo hijacking” (or “repo-jacking”) and is one of the primary threats source provenance attestations protect against.
+As such great care must be taken by SCSs when implementing these changes for legitimate purposes.
+
+SCSs SHOULD require multi-party approval for any changes made under this process.
+
+The Safe Expunging Process MUST be documented and describe how requests and actions are tracked and SHOULD log the fact that content was removed.
 
 On the git VCS, force pushes allow you to remove data from a branch.
 If a branch has been identified as consumable branch, force pushes to that branch must follow the safe expunging process.
 
-TODO: Determine how organizations can provide transparency around this process.
-At a minimum the organization would need to declare why data was removed from the branch.
-
-The goal of this sections is to document that this process is allowed.
 Different organizations and tech stacks may have different approaches to the problem.
 
-Scenarios that need to be addressed:
+Safe Expunging Scenarios:
 
 ### Legal Takedowns
 
-A DMCA takedown request will be addressed by following an agreed-upon process.
+A legal takedown request will be addressed by following an agreed-upon process.
 That process should be documented itself and followed.
 It may be the case that the specific set of commits targeted by the takedown can be expunged in ways that do not impact revisions.
+
+This process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
+and regulations which may require the change to be kept private to the extent possible.
 
 ### Commit metadata rewrites
 
@@ -73,9 +78,13 @@ A team may decide that all reachable commits in the history of a revision need t
 In git VCS, compliance with this new policy will require history to be rewritten (commit metadata is included in the computation of the revision id).
 Policies in this category include things like commit signatures, author / committer formatting restrictions, closed-issue-linkage, etc.
 
+SCSs SHOULD make the fact of these changes public when they occur (e.g. an issue, announcement, or other mechanism).
+
 ### Repository renames
 
 When a repo is transferred to a new organization ("donated"), or if a repo must be renamed or otherwise have its url changed within the same org, attestations for previous revisions of this repo will no longer be matched because the combination of the repository id and the revision id will have changed.
+
+SCSs SHOULD make the fact of these changes public when they occur (e.g. an issue, announcement, or other mechanism).
 
 ## Levels
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -75,7 +75,7 @@ The takedown request MUST be addressed by following an agreed-upon process.
 
 It may be the case that the specific set of commits targeted by the takedown can be expunged in ways that do not impact revisions.
 
-This process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
+The application of the safe expunging process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
 and regulations which may require the change to be kept private to the extent possible.
 
 ## Levels

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -46,37 +46,31 @@ Consumers can examine the various source provenance attestations to determine if
 
 ## Safe Expunging Process
 
-SCSs MAY allow the organization to expunge (remove) content from a repository and its change history without leaving a public record of the removed content.
-This includes changing files, history, or changing references in git and is used to accommodate legal/privacy compliance requirements.
+SCSs MAY allow the organization to expunge (remove) content from a repository and its change history without leaving a public record of the removed content,
+but MUST only allow these changes in order to meet legal or privacy compliance requirements.
+Content changed under this process includes changing files, history, references, or any other metadata stored by the SCS.
+
+### Warning
 
 Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact.
-In version control systems like Git, removal of a revision changes the object IDs of all subsequent revisions that were built on top of it.
-Although there is no "safe" way to do it, it sometimes necessary and there are steps you can take to mitigate the damage.
+For example, in VCSs like Git, removal of a revision changes the object IDs of all subsequent revisions that were built on top of it,
+this can break downstream consumers ability to refer to source they've already integrated into their products.
 
-When used as an attack, this is called “repo hijacking” (or “repo-jacking”) and is one of the primary threats source provenance attestations protect against.
-As such great care must be taken by SCSs when implementing these changes for legitimate purposes.
+It may be the case that the specific set of commits targeted by the takedown can be expunged in ways that do not impact revisions which can mitigate these problems.
+
+It is also the case that removing content from a repository won't necessarily remove it everywhere.
+The content may still exist in other copies of the repository, either in backups or on developer machines.
+
+### Process
+
+An SCS MUST document the Safe Expunging Process and describe how requests and actions are tracked and SHOULD log the fact that content was removed.
+Different organizations and tech stacks may have different approaches to the problem.
 
 SCSs SHOULD require multi-party approval for any changes made under this process.
 
-The Safe Expunging Process MUST be documented and describe how requests and actions are tracked and SHOULD log the fact that content was removed.
-
-On the git VCS, force pushes allow you to remove data from a branch.
-If a branch has been identified as consumable branch, force pushes to that branch must follow the safe expunging process.
-
-Different organizations and tech stacks may have different approaches to the problem.
-
-Safe Expunging Scenarios:
-
-### Legal Takedowns
-
-The only currently acceptable scenario to expunge data is in response to some legal or compliance request.
-
-The takedown request MUST be addressed by following an agreed-upon process.
-
-It may be the case that the specific set of commits targeted by the takedown can be expunged in ways that do not impact revisions.
-
 The application of the safe expunging process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
 and regulations which may require the change to be kept private to the extent possible.
+Organizations SHOULD prefer to make logs public if possible.
 
 ## Levels
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -56,7 +56,7 @@ Removing a revision from a repository is similar to deleting a package version f
 For example, in VCSs like Git, removal of a revision changes the object IDs of all subsequent revisions that were built on top of it,
 , breaking downstream consumers' ability to refer to source they've already integrated into their products.
 
-It may be the case that the specific set of changes targeted by the takedown can be expunged in ways that do not impact consumed revisions, which can mitigate these problems.
+It may be the case that the specific set of changes targeted by a legal takedown can be expunged in ways that do not impact consumed revisions, which can mitigate these problems.
 
 It is also the case that removing content from a repository won't necessarily remove it everywhere.
 The content may still exist in other copies of the repository, either in backups or on developer machines.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -66,7 +66,7 @@ The content may still exist in other copies of the repository, either in backups
 An SCS MUST document the Safe Expunging Process and describe how requests and actions are tracked and SHOULD log the fact that content was removed.
 Different organizations and tech stacks may have different approaches to the problem.
 
-SCSs SHOULD have technical mechanisms in place which require multiple Trusted Persons to trigger any expunging (removals) made under this process.
+SCSs SHOULD have technical mechanisms in place which require an Administrator plus, at least, one additional 'trusted person' to trigger any expunging (removals) made under this process.
 
 The application of the safe expunging process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
 and regulations which may require the change to be kept private to the extent possible.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -47,8 +47,12 @@ Consumers can examine the various source provenance attestations to determine if
 ## Safe Expunging Process
 
 SCSs MAY allow the organization to expunge (remove) content from a repository and its change history without leaving a public record of the removed content.
-This includes changing files, history, or changing references in git and is used to accommodate legal/privacy compliance requirements as well as administrative
-changes within a repository (see below for more information on the various scenarios).
+This includes changing files, history, or changing references in git and is used to accommodate legal/privacy compliance requirements.
+
+Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact. 
+In version control systems like git, removal of a revision changes the object id of all subsequent revisions that were built on top of it. 
+Although there is no "safe" way to do it, it sometimes necessary and there are steps you can take to mitigate the damage.
+
 When used as an attack, this is called “repo hijacking” (or “repo-jacking”) and is one of the primary threats source provenance attestations protect against.
 As such great care must be taken by SCSs when implementing these changes for legitimate purposes.
 
@@ -61,31 +65,18 @@ If a branch has been identified as consumable branch, force pushes to that branc
 
 Different organizations and tech stacks may have different approaches to the problem.
 
-Safe Expunging Scenarios (non-exhaustive):
+Safe Expunging Scenarios:
 
 ### Legal Takedowns
 
-A legal takedown request will be addressed by following an agreed-upon process.
-That process should be documented itself and followed.
+The only currently acceptable scenario to expunge data is in response to some legal or compliance request.
+
+The takedown request MUST be addressed by following an agreed-upon process.
+
 It may be the case that the specific set of commits targeted by the takedown can be expunged in ways that do not impact revisions.
 
 This process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
 and regulations which may require the change to be kept private to the extent possible.
-
-### Commit metadata rewrites
-
-A team may decide that all reachable commits in the history of a revision need to follow a new metadata convention.
-In git VCS, compliance with this new policy will require history to be rewritten (commit metadata is included in the computation of the revision id).
-Policies in this category include things like commit signatures, author / committer formatting restrictions, closed-issue-linkage, etc.
-
-Organizations MUST make the fact of these changes public when they occur (e.g. an issue, announcement, or other mechanism).
-
-### Repository renames
-
-When a repo is transferred to a new organization ("donated"), or if a repo must be renamed or otherwise have its url changed within the same org, attestations for previous revisions of this repo will no longer be matched because the combination of the repository id and the revision id will have changed.
-
-Organizations MUST inform all consumers of a repo of these changes when they occur.
-Organizations SHOULD provide a means to resolve previous revision IDs to the new revision IDs.
 
 ## Levels
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -66,7 +66,7 @@ The content may still exist in other copies of the repository, either in backups
 An SCS MUST document the Safe Expunging Process and describe how requests and actions are tracked and SHOULD log the fact that content was removed.
 Different organizations and tech stacks may have different approaches to the problem.
 
-SCSs SHOULD require multi-party approval for any changes made under this process.
+SCSs SHOULD have technical mechanisms in place which require multiple Trusted Persons to trigger any expunging (removals) made under this process.
 
 The application of the safe expunging process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
 and regulations which may require the change to be kept private to the extent possible.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -84,7 +84,8 @@ Organizations MUST make the fact of these changes public when they occur (e.g. a
 
 When a repo is transferred to a new organization ("donated"), or if a repo must be renamed or otherwise have its url changed within the same org, attestations for previous revisions of this repo will no longer be matched because the combination of the repository id and the revision id will have changed.
 
-Organizations MUST make the fact of these changes public when they occur (e.g. an issue, announcement, or other mechanism).
+Organizations MUST inform all consumers of a repo of these changes when they occur.
+Organizations SHOULD provide a means to resolve previous revision IDs to the new revision IDs.
 
 ## Levels
 


### PR DESCRIPTION
fixes #1135

Hardens the 'safe-expunging-process' by:

1. Suggesting that SCSs should document and log changes when possible.
2. SCSs should use multi-party approval when possible

Also clarifies that some of these changes may need to be kept private to comply with local laws.