### PR TITLE
content: draft: Clarify name of Source L3

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -100,7 +100,7 @@ All organizations of any size producing software of any kind.
 Benefits:
 Allows source consumers to track changes to the software over time and attribute those changes to the people that made them.
 
-### Level 3: Source Provenance Attestations
+### Level 3: Authenticatable and auditable attestations
 
 Summary:
 A consumer can ask the SCS for everything it knows about a specific revision of a repository.


### PR DESCRIPTION
Updating name of Source Level 3 to make it more clear by removing the somewhat ambiguous 'Source Provenance' and including the language from PR #1143 instead.

fixes #1112