### PR TITLE
content: draft: Update threat-overview table to use new threat diagram

### DIFF
--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -53,7 +53,7 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <td>A
 <td>Producer
 <td><a href="https://en.wikipedia.org/wiki/XZ_Utils_backdoor">XZ Utils Backdoor</a>: A maintainer intentionally inserted malicious behavior into a legitimate package.
-<td>SLSA does not directly address this threat, but in open source software it could make it easier to discover by forcing malicious behavior into the publicly available source code.
+<td>SLSA does not directly address this threat but could make it easier to discover malicious behavior in open source software, by forcing it into the publicly available source code.
 <tr>
 <td>B
 <td>Authoring & reviewing

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -110,7 +110,7 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <th>How SLSA could help
 <tbody>
 <tr>
-<td>D
+<td>N/A
 <td>Dependency becomes unavailable
 <td><a href="https://www.techradar.com/news/this-popular-code-library-is-causing-problems-for-hundreds-of-thousands-of-devs">Mimemagic</a>: Producer intentionally removes package or version of package from repository with no warning. Network errors or service outages may also make packages unavailable temporarily.
 <td>SLSA does not directly address this threat.

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -87,8 +87,8 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <tr>
 <td>I
 <td>Usage
-<td>TODO: Add example?
-<td>SLSA address this threat.
+<td><a href="https://www.horizon3.ai/attack-research/disclosures/cve-2023-27524-insecure-default-configuration-in-apache-superset-leads-to-remote-code-execution/">Default credentials</a>: Attacker could leverage default credentials to access sensitive data.
+<td>SLSA does not address this threat.
 <tr>
 <td>N/A
 <td>Dependency threats (i.e. A-H, recursively)

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -45,10 +45,15 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <thead>
 <tr>
 <th>
-<th>Threats to
+<th>Threats from
 <th>Known example
 <th>How SLSA could help
 <tbody>
+<tr>
+<td>A
+<td>Producer
+<td><a href="https://en.wikipedia.org/wiki/SpySheriff">SpySheriff</a>: Software vendor purports to offer anti-spyware software, but that software is actually malicious.
+<td>SLSA does not address this threat.
 <tr>
 <td>B
 <td>Authoring & reviewing

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -68,7 +68,7 @@ For close source software SLSA does not provide any solutions for malicious prod
 <tr>
 <td>D
 <td>External build parameters
-<td><a href="https://www.webmin.com/exploit.html">Webmin</a>: Attacker modified the build infrastructure to use source files not matching source control.
+<td><a href="https://www.reddit.com/r/HobbyDrama/comments/jouwq7/open_source_development_the_great_suspender_saga/">The Great Suspender</a>: Attacker published software that was not built from the purported sources.
 <td>A SLSA-compliant build server would have produced provenance identifying the actual sources used, allowing consumers to detect such tampering.
 <tr>
 <td>E

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -45,50 +45,55 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <thead>
 <tr>
 <th>
-<th>Integrity threat
+<th>Threats to
 <th>Known example
 <th>How SLSA could help
 <tbody>
 <tr>
-<td>A
-<td>Submit unauthorized change (to source repo)
+<td>B
+<td>Authoring & reviewing
 <td><a href="https://arstechnica.com/information-technology/2021/09/cryptocurrency-launchpad-hit-by-3-million-supply-chain-attack/">SushiSwap</a>: Contractor with repository access pushed a malicious commit redirecting cryptocurrency to themself.
 <td>Two-person review could have caught the unauthorized change.
 <tr>
-<td>B
-<td>Compromise source repo
+<td>C
+<td>Source code management
 <td><a href="https://news-web.php.net/php.internals/113838">PHP</a>: Attacker compromised PHP's self-hosted git server and injected two malicious commits.
 <td>A better-protected source code platform would have been a much harder target for the attackers.
 <tr>
-<td>C
-<td>Build from modified source (not matching source repo)
+<td>D
+<td>External build parameters
 <td><a href="https://www.webmin.com/exploit.html">Webmin</a>: Attacker modified the build infrastructure to use source files not matching source control.
 <td>A SLSA-compliant build server would have produced provenance identifying the actual sources used, allowing consumers to detect such tampering.
 <tr>
-<td>D
-<td>Use compromised dependency (i.e. A-H, recursively)
-<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior. The update did not match the code submitted to GitHub (i.e. attack F).
-<td>Applying SLSA recursively to all dependencies would have prevented this particular vector, because the provenance would have indicated that it either wasn't built from a proper builder or that the source did not come from GitHub.
-<tr>
 <td>E
-<td>Compromise build process
+<td>Build process
 <td><a href="https://www.crowdstrike.com/blog/sunspot-malware-technical-analysis/">SolarWinds</a>: Attacker compromised the build platform and installed an implant that injected malicious behavior during each build.
 <td>Higher SLSA levels require <a href="requirements#build-requirements">stronger security controls for the build platform</a>, making it more difficult to compromise and gain persistence.
 <tr>
 <td>F
-<td>Upload modified package (not matching build process)
+<td>Artifact publication
 <td><a href="https://about.codecov.io/apr-2021-post-mortem/">CodeCov</a>: Attacker used leaked credentials to upload a malicious artifact to a GCS bucket, from which users download directly.
 <td>Provenance of the artifact in the GCS bucket would have shown that the artifact was not built in the expected manner from the expected source repo.
 <tr>
 <td>G
-<td>Compromise package registry
+<td>Distribution channel
 <td><a href="https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf">Attacks on Package Mirrors</a>: Researcher ran mirrors for several popular package registries, which could have been used to serve malicious packages.
 <td>Similar to above (F), provenance of the malicious artifacts would have shown that they were not built as expected or from the expected source repo.
 <tr>
 <td>H
-<td>Use compromised package
+<td>Package selection
 <td><a href="https://blog.sonatype.com/damaging-linux-mac-malware-bundled-within-browserify-npm-brandjack-attempt">Browserify typosquatting</a>: Attacker uploaded a malicious package with a similar name as the original.
 <td>SLSA does not directly address this threat, but provenance linking back to source control can enable and enhance other solutions.
+<tr>
+<td>I
+<td>Usage
+<td>TODO: Add example?
+<td>SLSA address this threat.
+<tr>
+<td>N/A
+<td>Dependency threats (i.e. A-H, recursively)
+<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior. The update did not match the code submitted to GitHub (i.e. attack F).
+<td>Applying SLSA recursively to all dependencies would have prevented this particular vector, because the provenance would have indicated that it either wasn't built from a proper builder or that the source did not come from GitHub.
 </table>
 
 <table>

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -52,8 +52,9 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <tr>
 <td>A
 <td>Producer
-<td><a href="https://en.wikipedia.org/wiki/XZ_Utils_backdoor">XZ Utils Backdoor</a>: A maintainer intentionally inserted malicious behavior into a legitimate package.
+<td><a href="https://en.wikipedia.org/wiki/SpySheriff">SpySheriff</a>: Software producer purports to offer anti-spyware software, but that software is actually malicious.
 <td>SLSA does not directly address this threat but could make it easier to discover malicious behavior in open source software, by forcing it into the publicly available source code.
+For close source software SLSA does not provide any solutions for malicious producers.
 <tr>
 <td>B
 <td>Authoring & reviewing

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -63,7 +63,7 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <td>C
 <td>Source code management
 <td><a href="https://news-web.php.net/php.internals/113838">PHP</a>: Attacker compromised PHP's self-hosted git server and injected two malicious commits.
-<td>A better-protected source code platform would have been a much harder target for the attackers.
+<td>A better-protected source code system would have been a much harder target for the attackers.
 <tr>
 <td>D
 <td>External build parameters

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -98,7 +98,7 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <td>N/A
 <td>Dependency threats (i.e. A-H, recursively)
 <td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior. The update did not match the code submitted to GitHub (i.e. attack F).
-<td>Applying SLSA recursively to all dependencies would have prevented this particular vector, because the provenance would have indicated that it either wasn't built from a proper builder or that the source did not come from GitHub.
+<td>Applying SLSA recursively to all dependencies would prevent this particular vector, because the provenance would indicate that it either wasn't built from a proper builder or that the source did not come from GitHub.
 </table>
 
 <table>

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -52,7 +52,7 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <tr>
 <td>A
 <td>Producer
-<td><a href="https://en.wikipedia.org/wiki/SpySheriff">SpySheriff</a>: Software vendor purports to offer anti-spyware software, but that software is actually malicious.
+<td><a href="https://en.wikipedia.org/wiki/XZ_Utils_backdoor">XZ Utils Backdoor</a>: A maintainer intentionally inserted malicious behavior into a legitimate package.
 <td>SLSA does not address this threat.
 <tr>
 <td>B

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -53,7 +53,7 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <td>A
 <td>Producer
 <td><a href="https://en.wikipedia.org/wiki/XZ_Utils_backdoor">XZ Utils Backdoor</a>: A maintainer intentionally inserted malicious behavior into a legitimate package.
-<td>SLSA does not address this threat.
+<td>SLSA does not directly address this threat, but in open source software it could make it easier to discover by forcing malicious behavior into the publicly available source code.
 <tr>
 <td>B
 <td>Authoring & reviewing


### PR DESCRIPTION
The existing threats-overview page uses the old SLSA threats diagram, so the lettering was off and some threats were not addressed.

This update fixes the lettering, updates the language to use the terms used on the diagram, and adds missing threats.

fixes #1208