### PR TITLE
resourceUri SHOULD match the download URI

### DIFF
--- a/docs/spec/draft/verification_summary.md
+++ b/docs/spec/draft/verification_summary.md
@@ -155,6 +155,13 @@ of the other top-level fields, such as `subject`, see [Statement]._
 `resourceUri` _string ([ResourceURI]), required_
 
 > URI that identifies the resource associated with the artifact being verified.
+>
+> The `resourceUri` SHOULD be set to the URI the producer expects the consumer
+> to fetch the artifact being verified from. This enables the consumer to easily
+> determine the expected value when [verifying](#how-to-verify). If the
+> `resourceUri` is set to some other value, the producer MUST communicate the
+> expected value, or how to determine the expected value, to consumers through
+> out-of-band channel.
 
 <a id="policy"></a>
 `policy` _object ([ResourceDescriptor]), required_


### PR DESCRIPTION
When verifying VSAs consumers are expected to match the resourceUri with the 'expected value' but the spec doesn't currently indicate how that expected value is to be determined.

In this change we suggest the resourceUri be set to the URI the consumer will fetch the artifact from. If it's set to something else the producer MUST tell the user how to determine the expected value.

fixes #1212