### PR TITLE
content: draft: Add 'principle' protecting anonymous contribution in SLSA

### DIFF
--- a/docs/spec/draft/principles.md
+++ b/docs/spec/draft/principles.md
@@ -107,10 +107,28 @@ In practice, though, these configurations are almost impossible to get right and
 keep right. There are often over-provisioning, confused deputy problems, or
 mistakes. Even if a platform is configured properly at one moment, it might not
 stay that way, and humans almost always end up getting in the access control
-lists.  
+lists.
 
 Access control is still important, but SLSA goes further to provide defense in depth: it **requires proof in
 the form of attestations that the package was built correctly**.
 
 **Benefits**: The attestation removes intermediate platforms from the trust base and ensures that
 individuals who are accidentally granted access do not have sufficient permission to tamper with the package.
+
+## Support anonymous and pseudonymous contribution
+
+SLSA supports anonymous and pseudonymous 'identities' within the software supply chain.
+While organizations that implement SLSA may chose otherwise, SLSA itself does not require,
+or encourage, participants to be mapped to their legal identities.
+
+**Nothing in this specification should be taken to mean that SLSA requires participants to
+to reveal their legal identity.**
+
+**Reasoning**: One of SLSA's other principles is to [trust code, not individuals](#trust-code-not-individuals).
+The legal identity of actor is largely not relevant from a supply chain security perspective.  Further,
+_requiring_ a legal identity would likely preclude the participation of many of open source software's most
+valued participants.
+
+**Benefits**: By _not_ requiring legal identities SLSA lowers the barriers to its adoption, enabling
+all of its other benefits and maintaining support for anonymous and pseudonymous contribution as has been
+practiced in the software industry for decades.

--- a/docs/spec/draft/principles.md
+++ b/docs/spec/draft/principles.md
@@ -126,8 +126,8 @@ to reveal their legal identity.**
 
 **Reasoning**: SLSA uses identities for multiple purposes: as a trust anchor for attestations
 (i.e. who or what is making this claim and do I trust it to do so) or for attributing actions
-to the actor which took them within the context of the system they're taking them in (e.g. a
-username, cryptographic signing key, etc.).
+to an actor. Choice of identification technology is left to the platform that provides the
+action (e.g. username, cryptographic signing key, etc.).
 
 When identities are strongly authenticated and used consistently they can be leveraged for both of
 these purposes without requiring them to be mapped to legal identities.  This reflects how

--- a/docs/spec/draft/principles.md
+++ b/docs/spec/draft/principles.md
@@ -124,11 +124,16 @@ or encourage, participants to be mapped to their legal identities.
 **Nothing in this specification should be taken to mean that SLSA requires participants to
 to reveal their legal identity.**
 
-**Reasoning**: One of SLSA's other principles is to [trust code, not individuals](#trust-code-not-individuals).
-The legal identity of actor is largely not relevant from a supply chain security perspective.  Further,
-_requiring_ a legal identity would likely preclude the participation of many of open source software's most
-valued participants.
+**Reasoning**: SLSA uses identities for multiple purposes: as a trust anchor for attestations
+(i.e. who or what is making this claim and do I trust it to do so) or for attributing actions
+to the actor which took them within the context of the system they're taking them in (e.g. a
+username, cryptographic signing key, etc...).
 
-**Benefits**: By _not_ requiring legal identities SLSA lowers the barriers to its adoption, enabling
-all of its other benefits and maintaining support for anonymous and pseudonymous contribution as has been
-practiced in the software industry for decades.
+When identities are strongly authenticated and used consistently they can be used for both of
+these purposes without requiring them to be mapped to legal identities.  This reflects how
+identities are often used in open source. A legal name means much less to projects than the
+history and behavior of a given handle over time does.
+
+**Benefits**: By _not_ requiring legal identities SLSA lowers the barriers to its adoption,
+enabling all of its other benefits and maintaining support for anonymous and pseudonymous
+contribution as has been practiced in the software industry for decades.

--- a/docs/spec/draft/principles.md
+++ b/docs/spec/draft/principles.md
@@ -126,8 +126,8 @@ to reveal their legal identity.**
 
 **Reasoning**: SLSA uses identities for multiple purposes: as a trust anchor for attestations
 (i.e. who or what is making this claim and do I trust it to do so) or for attributing actions
-to an actor. Choice of identification technology is left to the platform that provides the
-action (e.g. username, cryptographic signing key, etc.).
+to an actor. Choice of identification technology is left to the organization and technical
+stacks implementing the SLSA standards.
 
 When identities are strongly authenticated and used consistently they can often be leveraged
 for both of these purposes without requiring them to be mapped to legal identities.

--- a/docs/spec/draft/principles.md
+++ b/docs/spec/draft/principles.md
@@ -129,10 +129,12 @@ to reveal their legal identity.**
 to an actor. Choice of identification technology is left to the platform that provides the
 action (e.g. username, cryptographic signing key, etc.).
 
-When identities are strongly authenticated and used consistently they can be leveraged for both of
-these purposes without requiring them to be mapped to legal identities.  This reflects how
-identities are often used in open source. A legal name means much less to projects than the
-history and behavior of a given handle over time does.
+When identities are strongly authenticated and used consistently they can often be leveraged
+for both of these purposes without requiring them to be mapped to legal identities.
+This reflects how identities are often used in open source where legal name means much less
+to projects than the history and behavior of a given handle over time does. Meanwhile some
+organizations may choose to levy additional requirements on identities. They are free to do
+so, but SLSA itself does not require it.
 
 **Benefits**: By _not_ requiring legal identities SLSA lowers the barriers to its adoption,
 enabling all of its other benefits and maintaining support for anonymous and pseudonymous

--- a/docs/spec/draft/principles.md
+++ b/docs/spec/draft/principles.md
@@ -129,7 +129,7 @@ to reveal their legal identity.**
 to the actor which took them within the context of the system they're taking them in (e.g. a
 username, cryptographic signing key, etc...).
 
-When identities are strongly authenticated and used consistently they can be used for both of
+When identities are strongly authenticated and used consistently they can be leveraged for both of
 these purposes without requiring them to be mapped to legal identities.  This reflects how
 identities are often used in open source. A legal name means much less to projects than the
 history and behavior of a given handle over time does.

--- a/docs/spec/draft/principles.md
+++ b/docs/spec/draft/principles.md
@@ -127,7 +127,7 @@ to reveal their legal identity.**
 **Reasoning**: SLSA uses identities for multiple purposes: as a trust anchor for attestations
 (i.e. who or what is making this claim and do I trust it to do so) or for attributing actions
 to the actor which took them within the context of the system they're taking them in (e.g. a
-username, cryptographic signing key, etc...).
+username, cryptographic signing key, etc.).
 
 When identities are strongly authenticated and used consistently they can be leveraged for both of
 these purposes without requiring them to be mapped to legal identities.  This reflects how


### PR DESCRIPTION
As work on the source track progresses the topic of 'identity' comes up quite a bit. There has been some confusion about what this means, that it could be that SLSA intends to require legal identities for all contributors.  That isn't the case.

Many in the open source world prefer to contribute without revealing their 'real' identities as has been practiced for many years. SLSA does not intend to change that.

This PR tries to make it clear that SLSA does not require real identities.

refs #1133