### PR TITLE
content: draft: Add mitigation for compromised build tooling

### DIFF
--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -866,14 +866,19 @@ libDep, resulting in MyPackage also having the security vulnerability.
 process, which alters the build process and injects unintended behavior into the
 output artifact.
 
+*Mitigation:* Treat build tooling, including OS images, as any other software
+to be verified prior to use (as described in (G)). This will allow the build
+platform to detect any modified binaries.
+
 *Example:* MyPackage is a tarball containing an ELF executable, created by
 running `/usr/bin/tar` during its build process. An adversary compromises the
 `tar` OS package such that `/usr/bin/tar` injects a backdoor into every ELF
 executable it writes. The next time MyPackage is built, the build picks up the
 vulnerable `tar` package, which injects the backdoor into the resulting
-MyPackage artifact.
-
-*Mitigation:* **TODO**
+MyPackage artifact.  Solution: The build platform verifies the disk image,
+or the individual components on the disk image, against the associated
+provenance or VSAs prior to running a build. The modified `/usr/bin/tar`
+will fail this verification.
 
 </details>
 


### PR DESCRIPTION
This threat can be mitigated in a number of ways, here I address it in the simplest one, verifying the tooling prior to use.  You can also imagine resolving it by recording the digests in the provenance, and propagating VSAs so that downstream verifiers can verify recursively, but that's pretty complicated.

You can also resolve this with the attested build environments track, but I don't think we should mention that here until it's finalized? Or maybe we can point to it now as 'coming soon'?

fixes #1184