### PR TITLE
nonspec: Remove outdated link to old meeting videos

### DIFF
--- a/docs/community.md
+++ b/docs/community.md
@@ -107,10 +107,6 @@ Google has been using an internal version of SLSA since 2013 and requires it for
                 <img class="mx-auto w-full" src="https://img.youtube.com/vi/DNCrK22uE4U/0.jpg" alt="operation slsa episode 2 image">
                 <p class="text-green-darker font-bold h5 mt-4">Operation SLSA: Episode 2</p>
             </a>
-            <a href="https://youtube.com/playlist?list=PLVl2hFL_zAh9sw-wib4W6A14i6DnBTod7" class="w-full lg:w-1/2 md:pl-5">
-                <img class="mx-auto w-full" src="https://img.youtube.com/vi/DxAyP1QVYXc/0.jpg" alt="slsa code image">
-                <p class="text-green-darker font-bold h5 mt-4">SLSA Biweekly Meetings (Playlist)</p>
-            </a>
             <a href="https://youtu.be/aS_FKrCLh8o" class="w-full lg:w-1/2 md:pl-5">
                 <img class="mx-auto w-full" src="https://img.youtube.com/vi/aS_FKrCLh8o/0.jpg" alt="supply chain media image">
                 <p class="text-green-darker font-bold h5 mt-4">Getting Started with Supply Chain Security is Easier Than You... Michael Lieberman & Timothy Miller</p>


### PR DESCRIPTION
Discussion ref: https://openssf.slack.com/archives/C029E4N3DPF/p1733962123447219