### PR TITLE
fix: Correct sidebar links on provenance page

### DIFF
--- a/docs/spec/draft/provenance.md
+++ b/docs/spec/draft/provenance.md
@@ -320,7 +320,7 @@ have correctly performed the operation and populated this provenance.
 
 Metadata about this particular execution of the build.
 
-<tr id="runDetailByproducts"><td><code>byproducts</code>
+<tr id="runDetailsByproducts"><td><code>byproducts</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/7aefca35a0f74a6e0cb397a8c4a76558f54de571/spec/v1/resource_descriptor.md">ResourceDescriptor</a>)<td>
 
 Additional artifacts generated during the build that are not considered

--- a/docs/spec/draft/provenance.md
+++ b/docs/spec/draft/provenance.md
@@ -309,18 +309,18 @@ REQUIRED for SLSA Build L1: `builder`
 <table>
 <tr><th>Field<th>Type<th>Description
 
-<tr id="builder"><td><code>builder</code>
+<tr id="runDetailsBuilder"><td><code>builder</code>
 <td><a href="#builder">Builder</a><td>
 
 Identifies the build platform that executed the invocation, which is trusted to
 have correctly performed the operation and populated this provenance.
 
-<tr id="metadata"><td><code>metadata</code>
+<tr id="runDetailsMetadata"><td><code>metadata</code>
 <td><a href="#buildmetadata">BuildMetadata</a><td>
 
 Metadata about this particular execution of the build.
 
-<tr id="byproducts"><td><code>byproducts</code>
+<tr id="runDetailByproducts"><td><code>byproducts</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/7aefca35a0f74a6e0cb397a8c4a76558f54de571/spec/v1/resource_descriptor.md">ResourceDescriptor</a>)<td>
 
 Additional artifacts generated during the build that are not considered

--- a/docs/spec/v1.0/provenance.md
+++ b/docs/spec/v1.0/provenance.md
@@ -307,7 +307,7 @@ have correctly performed the operation and populated this provenance.
 
 Metadata about this particular execution of the build.
 
-<tr id="runDetailByproducts"><td><code>byproducts</code>
+<tr id="runDetailsByproducts"><td><code>byproducts</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/main/spec/v1/resource_descriptor.md">ResourceDescriptor</a>)<td>
 
 Additional artifacts generated during the build that are not considered

--- a/docs/spec/v1.0/provenance.md
+++ b/docs/spec/v1.0/provenance.md
@@ -296,18 +296,18 @@ REQUIRED for SLSA Build L1: `builder`
 <table>
 <tr><th>Field<th>Type<th>Description
 
-<tr id="builder"><td><code>builder</code>
+<tr id="runDetailsBuilder"><td><code>builder</code>
 <td><a href="#builder">Builder</a><td>
 
 Identifies the build platform that executed the invocation, which is trusted to
 have correctly performed the operation and populated this provenance.
 
-<tr id="metadata"><td><code>metadata</code>
+<tr id="runDetailsMetadata"><td><code>metadata</code>
 <td><a href="#buildmetadata">BuildMetadata</a><td>
 
 Metadata about this particular execution of the build.
 
-<tr id="byproducts"><td><code>byproducts</code>
+<tr id="runDetailByproducts"><td><code>byproducts</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/main/spec/v1/resource_descriptor.md">ResourceDescriptor</a>)<td>
 
 Additional artifacts generated during the build that are not considered

--- a/docs/spec/v1.1/provenance.md
+++ b/docs/spec/v1.1/provenance.md
@@ -320,7 +320,7 @@ have correctly performed the operation and populated this provenance.
 
 Metadata about this particular execution of the build.
 
-<tr id="runDetailByproducts"><td><code>byproducts</code>
+<tr id="runDetailsByproducts"><td><code>byproducts</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/7aefca35a0f74a6e0cb397a8c4a76558f54de571/spec/v1/resource_descriptor.md">ResourceDescriptor</a>)<td>
 
 Additional artifacts generated during the build that are not considered

--- a/docs/spec/v1.1/provenance.md
+++ b/docs/spec/v1.1/provenance.md
@@ -309,18 +309,18 @@ REQUIRED for SLSA Build L1: `builder`
 <table>
 <tr><th>Field<th>Type<th>Description
 
-<tr id="builder"><td><code>builder</code>
+<tr id="runDetailsBuilder"><td><code>builder</code>
 <td><a href="#builder">Builder</a><td>
 
 Identifies the build platform that executed the invocation, which is trusted to
 have correctly performed the operation and populated this provenance.
 
-<tr id="metadata"><td><code>metadata</code>
+<tr id="runDetailsMetadata"><td><code>metadata</code>
 <td><a href="#buildmetadata">BuildMetadata</a><td>
 
 Metadata about this particular execution of the build.
 
-<tr id="byproducts"><td><code>byproducts</code>
+<tr id="runDetailByproducts"><td><code>byproducts</code>
 <td>array (<a href="https://github.com/in-toto/attestation/blob/7aefca35a0f74a6e0cb397a8c4a76558f54de571/spec/v1/resource_descriptor.md">ResourceDescriptor</a>)<td>
 
 Additional artifacts generated during the build that are not considered


### PR DESCRIPTION
When clicking on Schema.Builder, the anchor would go to the table row with the builder ID instead of the builder heading. This should deconflict the anchor points to make the sidebar correctly point to the right place on the page.

The change also makes the tr ids consistent for the RunDetails section.