### PR TITLE
nonspec: Create dedicated current activities page

### DIFF
--- a/docs/_data/nav/draft.yml
+++ b/docs/_data/nav/draft.yml
@@ -6,7 +6,7 @@
 
 - title: Current activities
   url: /current-activities
-  description: Additions and updates actively being developed
+  description: What the SLSA community is currently working on
 
 - title: Understanding SLSA
   description: >

--- a/docs/_data/nav/draft.yml
+++ b/docs/_data/nav/draft.yml
@@ -4,6 +4,10 @@
 - title: Overview
   url: /spec/draft/
 
+- title: Current activities
+  url: /current-activities
+  description: Additions and updates actively being developed
+
 - title: Understanding SLSA
   description: >
     These pages provide an overview of SLSA, how it helps protect against common

--- a/docs/_data/nav/v1.0.yml
+++ b/docs/_data/nav/v1.0.yml
@@ -6,6 +6,7 @@
 
 - title: Current activities
   url: /current-activities
+  description: Additions and updates actively being developed
 
 - title: Understanding SLSA
   description: >

--- a/docs/_data/nav/v1.0.yml
+++ b/docs/_data/nav/v1.0.yml
@@ -4,6 +4,9 @@
 - title: Overview
   url: /spec/v1.0/
 
+- title: Current activities
+  url: /current-activities
+
 - title: Understanding SLSA
   description: >
     These pages provide an overview of SLSA, how it helps protect against common

--- a/docs/_data/nav/v1.0.yml
+++ b/docs/_data/nav/v1.0.yml
@@ -6,7 +6,7 @@
 
 - title: Current activities
   url: /current-activities
-  description: Additions and updates actively being developed
+  description: What the SLSA community is currently working on
 
 - title: Understanding SLSA
   description: >

--- a/docs/_data/nav/v1.1.yml
+++ b/docs/_data/nav/v1.1.yml
@@ -6,6 +6,7 @@
 
 - title: Current activities
   url: /current-activities
+  description: Additions and updates actively being developed
 
 - title: Understanding SLSA
   description: >

--- a/docs/_data/nav/v1.1.yml
+++ b/docs/_data/nav/v1.1.yml
@@ -4,6 +4,9 @@
 - title: Overview
   url: /spec/v1.1/
 
+- title: Current activities
+  url: /current-activities
+
 - title: Understanding SLSA
   description: >
     These pages provide an overview of SLSA, how it helps protect against common

--- a/docs/_data/nav/v1.1.yml
+++ b/docs/_data/nav/v1.1.yml
@@ -6,7 +6,7 @@
 
 - title: Current activities
   url: /current-activities
-  description: Additions and updates actively being developed
+  description: What the SLSA community is currently working on
 
 - title: Understanding SLSA
   description: >

--- a/docs/community.md
+++ b/docs/community.md
@@ -78,12 +78,12 @@ developing tooling, we welcome your contributions.
 </div>
             </div>
             <div class="w-full md:w-1/2">
-			<div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is available now!</div>
+                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is available now!</div>
                 <p>
                 The community has been hard at work since the release of
-				<a href="spec/v1.0/">SLSA v1.0</a> in 2023 to expand the breadth
-				and depth of the specification with updates and new tracks.
-				For more information, see our <a href="/spec/current-activities">current activities</a> page!
+                <a href="spec/v1.0/">SLSA v1.0</a> in 2023 to expand the breadth
+                and depth of the specification with updates and new tracks.
+                For more information, see our <a href="/spec/current-activities">current activities</a> page!
                 <br><br>
 Google has been using an internal version of SLSA since 2013 and requires it for all of their production workloads.</p>
             </div>

--- a/docs/community.md
+++ b/docs/community.md
@@ -78,11 +78,12 @@ developing tooling, we welcome your contributions.
 </div>
             </div>
             <div class="w-full md:w-1/2">
-                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is available now!</div>
+			<div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is available now!</div>
                 <p>
-                <a href="spec/v1.0/">SLSA v1.0</a> is now available, released in April 2023.
-                We expect the specification to remain stable, with future versions expanding its breadth and depth.
-                For more information about this release, see <a href="/spec/v1.0/whats-new">What's new in v1.0</a>.
+                The community has been hard at work since the release of
+				<a href="spec/v1.0/">SLSA v1.0</a> in 2023 to expand the breadth
+				and depth of the specification with updates and new tracks.
+				For more information, see our <a href="/spec/current-activities">current activities</a> page!
                 <br><br>
 Google has been using an internal version of SLSA since 2013 and requires it for all of their production workloads.</p>
             </div>

--- a/docs/community.md
+++ b/docs/community.md
@@ -67,29 +67,6 @@ developing tooling, we welcome your contributions.
         </div>
     </div>
 </section>
-<section class="section bg-green-dark flex justify-center items-center">
-    <div class="wrapper inner w-full">
-        <div class="md:flex justify-between items-start text-white">
-            <div class="text w-full md:w-1/3">
-<div class="h2 p-0 -mt-16 mb-8 md:mb-0">
-
-## Project status
-
-</div>
-            </div>
-            <div class="w-full md:w-1/2">
-                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is available now!</div>
-                <p>
-                The community has been hard at work since the release of
-                <a href="spec/v1.0/">SLSA v1.0</a> in 2023 to expand the breadth
-                and depth of the specification with updates and new tracks.
-                For more information, see our <a href="/spec/current-activities">current activities</a> page!
-                <br><br>
-Google has been using an internal version of SLSA since 2013 and requires it for all of their production workloads.</p>
-            </div>
-        </div>
-    </div>
-</section>
 <section class="section bg-pastel-green">
     <div class="wrapper inner w-full">
         <div class="flex flex-col justify-center items-center mb-8 w-2/3 mx-auto md:pl-5">

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -18,7 +18,7 @@ Learn how you can [get involved](https://slsa.dev/community#get-involved)!
 A Source track will provide protection against tampering of the source code
 prior to the build.
 
-The current [draft version (v1.1)](source-requirements.md) describes levels
+The current [draft version)](/spec/draft/source-requirements.md) describes levels
 of increasing tamper resistance and ways consumers might verify properties
 of source revisions using SLSA source provenance attestations.
 
@@ -27,7 +27,7 @@ of source revisions using SLSA source provenance attestations.
 The goal of a Build Environment track is to enable the detection of tampering
 with core components of the compute environment executing builds.
 
-The current [draft version](../draft/attested-build-env-levels.md)
+The current [draft version](/spec/draft/attested-build-env-levels.md)
 of the Build Environment track includes the following requirements:
 
 -   Generation and verification of SLSA Build Provenance for build images.

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -1,11 +1,8 @@
 ---
 title: Current activities
-description: There's an active community of members, contributors and collaborators working to enhance the SLSA specification with updates to existing and new
-tracks. This page provides a summary of current ongoing activities.
-layout: specifications
+description: There's an active community of members, contributors and collaborators working to enhance the SLSA specification with updates to existing and new tracks. This page provides a summary of current ongoing activities.
+layout: standard
 ---
-
-## What are we currently working on?
 
 Since the release of <a href="spec/v1.0/">SLSA v1.0</a> in 2023,
 the SLSA community has been hard at work to expand the breadth

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -1,0 +1,55 @@
+---
+title: Current activities
+description: There's an active community of members, contributors and collaborators working to enhance the SLSA specification with updates to existing and new
+tracks. This page provides a summary of current ongoing activities.
+layout: standard
+---
+
+Since the release of <a href="spec/v1.0/">SLSA v1.0</a> in 2023,
+the SLSA community has been hard at work to expand the breadth
+and depth of the specification with updates and new tracks.
+Learn how you can [get involved](https://slsa.dev/community#get-involved)!
+
+<section id="source-track">
+
+## Source track
+
+A Source track will provide protection against tampering of the source code
+prior to the build.
+
+The current [draft version (v1.1)](source-requirements.md) describes levels
+of increasing tamper resistance and ways consumers might verify properties
+of source revisions using SLSA source provenance attestations.
+
+</section>
+
+<section id="buildenv-track">
+
+## Build Environment track
+
+The goal of a Build Environment track is to enable the detection of tampering
+with core components of the compute environment executing builds.
+
+The current [draft version](../draft/attested-build-env-levels.md)
+of the Build Environment track includes the following requirements:
+
+-   Generation and verification of SLSA Build Provenance for build images.
+-   Validation of initial build environment system state against known good
+    reference values.
+-   Deployment of the hosted build platform on a compute system that supports
+    system state measurement and attestation capabilities at the hardware level.
+
+These requirements are **subject to significant change** while this track
+is in draft.
+
+</section>
+
+<section id="dependency-track">
+## Dependency track
+
+Building upon the foundation laid by S2C2F, the depedency track defines
+requirements for consuming dependencies.
+
+**TODO**: Expand this section
+
+</section>

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -10,7 +10,7 @@ Since the release of <a href="spec/v1.0/">SLSA v1.0</a> in 2023,
 the SLSA community has been hard at work to expand the breadth
 and depth of the specification with updates and new tracks.
 
-Learn how you can [get involved](https://slsa.dev/community#get-involved)!
+Learn how you can [get involved](/community#get-involved)!
 
 ### Source track
 

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -15,7 +15,7 @@ Learn how you can [get involved](/community#get-involved)!
 A Source track will provide protection against tampering of the source code
 prior to the build.
 
-The current [draft version)](/spec/draft/source-requirements.md) describes levels
+The current [draft version](/spec/draft/source-requirements.md) describes levels
 of increasing tamper resistance and ways consumers might verify properties
 of source revisions using SLSA source provenance attestations.
 

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -2,6 +2,7 @@
 title: Current activities
 description: There's an active community of members, contributors and collaborators working to enhance the SLSA specification with updates to existing and new
 tracks. This page provides a summary of current ongoing activities.
+layout: specifications
 ---
 
 ## What are we currently working on?
@@ -42,5 +43,3 @@ is in draft.
 
 Building upon the foundation laid by S2C2F, the depedency track defines
 requirements for consuming dependencies.
-
-**TODO**: Expand this section

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -2,10 +2,9 @@
 title: Current activities
 description: There's an active community of members, contributors and collaborators working to enhance the SLSA specification with updates to existing and new
 tracks. This page provides a summary of current ongoing activities.
-layout: standard
 ---
 
-## Current Activities
+## What are we currently working on?
 
 Since the release of <a href="spec/v1.0/">SLSA v1.0</a> in 2023,
 the SLSA community has been hard at work to expand the breadth

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -38,5 +38,5 @@ is in draft.
 
 ### Dependency track
 
-Building upon the foundation laid by S2C2F, the depedency track defines
+Building upon the foundation laid by [S2C2F](https://openssf.org/projects/s2c2f/), the depedency track defines
 requirements for consuming dependencies.

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -5,14 +5,15 @@ tracks. This page provides a summary of current ongoing activities.
 layout: standard
 ---
 
+## Current Activities
+
 Since the release of <a href="spec/v1.0/">SLSA v1.0</a> in 2023,
 the SLSA community has been hard at work to expand the breadth
 and depth of the specification with updates and new tracks.
+
 Learn how you can [get involved](https://slsa.dev/community#get-involved)!
 
-<section id="source-track">
-
-## Source track
+### Source track
 
 A Source track will provide protection against tampering of the source code
 prior to the build.
@@ -21,11 +22,7 @@ The current [draft version (v1.1)](source-requirements.md) describes levels
 of increasing tamper resistance and ways consumers might verify properties
 of source revisions using SLSA source provenance attestations.
 
-</section>
-
-<section id="buildenv-track">
-
-## Build Environment track
+### Build Environment track
 
 The goal of a Build Environment track is to enable the detection of tampering
 with core components of the compute environment executing builds.
@@ -42,14 +39,9 @@ of the Build Environment track includes the following requirements:
 These requirements are **subject to significant change** while this track
 is in draft.
 
-</section>
-
-<section id="dependency-track">
-## Dependency track
+### Dependency track
 
 Building upon the foundation laid by S2C2F, the depedency track defines
 requirements for consuming dependencies.
 
 **TODO**: Expand this section
-
-</section>

--- a/docs/index.md
+++ b/docs/index.md
@@ -205,16 +205,21 @@ testimonials:
 </section>
 <section class="section bg-green-dark flex justify-center items-center">
     <div class="wrapper inner w-full">
-        <div class="flex flex-wrap justify-between items-start text-white">
+        <div class="md:flex justify-between items-start text-white">
             <div class="text w-full md:w-1/3">
-                <p class="h2 p-0">Project status</p>
+<div class="h2 p-0 -mt-16 mb-8 md:mb-0">
+
+## Project status
+
+</div>
             </div>
             <div class="w-full md:w-1/2">
-                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mt-8 md:mt-0 mb-8 h4 font-semibold">SLSA v1.0 is available now!</div>
+                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is available now!</div>
                 <p>
-                <a href="spec/v1.0/">SLSA v1.0</a> is now available, released in April 2023.
-                We expect the specification to remain stable, with future versions expanding its breadth and depth.
-                For more information about this release, see <a href="/spec/v1.0/whats-new">What's new in v1.0</a>.
+                The community has been hard at work since the release of
+                <a href="spec/v1.0/">SLSA v1.0</a> in 2023 to expand the breadth
+                and depth of the specification with updates and new tracks.
+                For more information, see our <a href="/spec/current-activities">current activities</a> page!
                 <br><br>
 Google has been using an internal version of SLSA since 2013 and requires it for all of their production workloads.</p>
             </div>

--- a/docs/spec/draft/future-directions.md
+++ b/docs/spec/draft/future-directions.md
@@ -32,40 +32,6 @@ following requirements, which **may or may not** be part of a future Build L4:
 
 </section>
 
-<section id="source-track">
-
-## Source track
-
-A Source track will provide protection against tampering of the source code
-prior to the build.
-
-The current [draft version (v1.1)](source-requirements.md) describes levels
-of increasing tamper resistance and ways consumers might verify properties
-of source revisions using SLSA source provenance attestations.
-
-</section>
-
-<section id="buildenv-track">
-
-## Build Environment track
-
-The goal of a Build Environment track is to enable the detection of tampering
-with core components of the compute environment executing builds.
-
-The current [draft version](../draft/attested-build-env-levels.md)
-of the Build Environment track includes the following requirements:
-
--   Generation and verification of SLSA Build Provenance for build images.
--   Validation of initial build environment system state against known good
-    reference values.
--   Deployment of the hosted build platform on a compute system that supports
-    system state measurement and attestation capabilities at the hardware level.
-
-These requirements are **subject to significant change** while this track
-is in draft.
-
-</section>
-
 <section id="build-platform-operations-track">
 
 ## Build Platform Operations track

--- a/docs/spec/draft/onepage.md
+++ b/docs/spec/draft/onepage.md
@@ -8,6 +8,6 @@ A single page containing all the following files as different sections
 {%- endcomment -%}
 
 {% assign dir = "/spec/draft/" %}
-{% assign filenames = "whats-new,about,threats-overview,use-cases,principles,faq,future-directions,terminology,levels,requirements,distributing-provenance,verifying-systems,verifying-artifacts,threats,source-requirements,provenance,verification_summary" %}
+{% assign filenames = "whats-new,about,current-activities,threats-overview,use-cases,principles,faq,future-directions,terminology,levels,requirements,distributing-provenance,verifying-systems,verifying-artifacts,threats,source-requirements,provenance,verification_summary" %}
 
 {% include onepage.liquid dir=dir filenames=filenames %}

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -57,7 +57,7 @@ This includes the threat of an authorized individual introducing an unauthorized
 change---in other words, an insider threat.
 
 SLSA v1.0 does not address source threats, but we anticipate doing so in a
-[future version](future-directions.md#source-track). In the meantime, the
+[future version](current-activities.md#source-track). In the meantime, the
 threats and potential mitigations listed here show how SLSA v1.0 can fit into a
 broader supply chain security program.
 
@@ -886,7 +886,7 @@ output artifact.
 including OS images, as any other artifact to be verified prior to use.
 The threats described in this document apply recursively to build tooling
 as do the mitigations and examples.  A future
-[Build Environment track](future-directions#build-environment-track) may
+[Build Environment track](current-activities#build-environment-track) may
 provide more comprehensive guidance on how to address more specfiic
 aspects of this threat.
 

--- a/docs/spec/v1.0/onepage.md
+++ b/docs/spec/v1.0/onepage.md
@@ -8,6 +8,6 @@ A single page containing all the following files as different sections
 {%- endcomment -%}
 
 {% assign dir = "/spec/v1.0/" %}
-{% assign filenames = "whats-new,about,threats-overview,use-cases,principles,faq,future-directions,terminology,levels,requirements,distributing-provenance,verifying-systems,verifying-artifacts,threats,provenance,verification_summary" %}
+{% assign filenames = "whats-new,about,current-activities,threats-overview,use-cases,principles,faq,future-directions,terminology,levels,requirements,distributing-provenance,verifying-systems,verifying-artifacts,threats,provenance,verification_summary" %}
 
 {% include onepage.liquid dir=dir filenames=filenames %}

--- a/docs/spec/v1.1/future-directions.md
+++ b/docs/spec/v1.1/future-directions.md
@@ -32,27 +32,6 @@ following requirements, which **may or may not** be part of a future Build L4:
 
 </section>
 
-<section id="source-track">
-
-## Source track
-
-A Source track could provide protection against tampering of the source code
-prior to the build.
-
-The initial [draft version (v0.1)](../v0.1/requirements.md#source-requirements)
-of SLSA included the following source requirements, which **may or may not**
-form the basis for a future Source track:
-
--   Strong authentication of author and reviewer identities, such as 2-factor
-    authentication using a hardware security key, to resist account and
-    credential compromise.
--   Retention of the source code to allow for after-the-fact inspection and
-    future rebuilds.
--   Mandatory two-person review of all changes to the source to prevent a single
-    compromised actor or account from introducing malicious changes.
-
-</section>
-
 <section id="build-platform-operations-track">
 
 ## Build Platform Operations track

--- a/docs/spec/v1.1/onepage.md
+++ b/docs/spec/v1.1/onepage.md
@@ -8,6 +8,6 @@ A single page containing all the following files as different sections
 {%- endcomment -%}
 
 {% assign dir = "/spec/v1.1/" %}
-{% assign filenames = "whats-new,about,threats-overview,use-cases,principles,faq,future-directions,terminology,levels,requirements,distributing-provenance,verifying-systems,verifying-artifacts,threats,provenance,verification_summary" %}
+{% assign filenames = "whats-new,about,current-activities,threats-overview,use-cases,principles,faq,future-directions,terminology,levels,requirements,distributing-provenance,verifying-systems,verifying-artifacts,threats,provenance,verification_summary" %}
 
 {% include onepage.liquid dir=dir filenames=filenames %}

--- a/docs/spec/v1.1/threats.md
+++ b/docs/spec/v1.1/threats.md
@@ -64,7 +64,7 @@ This includes the threat of an authorized individual introducing an unauthorized
 change---in other words, an insider threat.
 
 SLSA v1.0 does not address source threats, but we anticipate doing so in a
-[future version](future-directions.md#source-track). In the meantime, the
+[future version](current-activities.md#source-track). In the meantime, the
 threats and potential mitigations listed here show how SLSA v1.0 can fit into a
 broader supply chain security program.
 


### PR DESCRIPTION
Following our ongoing discussions about questions of SLSA's current status, I quickly put together a new page for the website that outlines our current activities. This is mostly meant to be a starting point that we can improve upon as we figure out the best way to communicate our ongoing activities.