### PR TITLE
content: simplify description of event-stream threat

### DIFF
--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -98,7 +98,7 @@ For close source software SLSA does not provide any solutions for malicious prod
 <tr>
 <td>N/A
 <td>Dependency threats (i.e. A-H, recursively)
-<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior.
+<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the binary version of the dependency to add malicious behavior without updating the corresponding source code.
 <td>Applying SLSA recursively to all dependencies would prevent this particular vector, because the provenance would indicate that it either wasn't built from a proper builder or that the source did not come from GitHub.
 </table>
 

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -98,8 +98,8 @@ For close source software SLSA does not provide any solutions for malicious prod
 <tr>
 <td>N/A
 <td>Dependency threats (i.e. A-H, recursively)
-<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the binary version of the dependency to add malicious behavior without updating the corresponding source code.
-<td>Applying SLSA recursively to all dependencies would prevent this particular vector, because the provenance would indicate that it either wasn't built from a proper builder or that the source did not come from GitHub.
+<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker controls an innocuous dependency and publishes a malicious binary version without a corresponding update to the source code.
+<td>Applying SLSA recursively to all dependencies would prevent this particular vector, because the provenance would indicate that it either wasn't built from a proper builder or that the binary did not match the source.
 </table>
 
 <table>

--- a/docs/spec/draft/threats-overview.md
+++ b/docs/spec/draft/threats-overview.md
@@ -98,7 +98,7 @@ For close source software SLSA does not provide any solutions for malicious prod
 <tr>
 <td>N/A
 <td>Dependency threats (i.e. A-H, recursively)
-<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior. The update did not match the code submitted to GitHub (i.e. attack F).
+<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior.
 <td>Applying SLSA recursively to all dependencies would prevent this particular vector, because the provenance would indicate that it either wasn't built from a proper builder or that the source did not come from GitHub.
 </table>
 

--- a/docs/spec/v1.1/threats-overview.md
+++ b/docs/spec/v1.1/threats-overview.md
@@ -67,8 +67,8 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <tr>
 <td>D
 <td>Use compromised dependency (i.e. A-H, recursively)
-<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the binary version of the dependency to add malicious behavior without updating the corresponding source code.
-<td>Applying SLSA recursively to all dependencies would have prevented this particular vector, because the provenance would have indicated that it either wasn't built from a proper builder or that the source did not come from GitHub.
+<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker controls an innocuous dependency and publishes a malicious binary version without a corresponding update to the source code.
+<td>Applying SLSA recursively to all dependencies would prevent this particular vector, because the provenance would indicate that it either wasn't built from a proper builder or that the binary did not match the source.
 <tr>
 <td>E
 <td>Compromise build process

--- a/docs/spec/v1.1/threats-overview.md
+++ b/docs/spec/v1.1/threats-overview.md
@@ -67,7 +67,7 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <tr>
 <td>D
 <td>Use compromised dependency (i.e. A-H, recursively)
-<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior. The update did not match the code submitted to GitHub (i.e. attack F).
+<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior.
 <td>Applying SLSA recursively to all dependencies would have prevented this particular vector, because the provenance would have indicated that it either wasn't built from a proper builder or that the source did not come from GitHub.
 <tr>
 <td>E

--- a/docs/spec/v1.1/threats-overview.md
+++ b/docs/spec/v1.1/threats-overview.md
@@ -67,7 +67,7 @@ Many recent high-profile attacks were consequences of supply chain integrity vul
 <tr>
 <td>D
 <td>Use compromised dependency (i.e. A-H, recursively)
-<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the dependency to add malicious behavior.
+<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker added an innocuous dependency and then later updated the binary version of the dependency to add malicious behavior without updating the corresponding source code.
 <td>Applying SLSA recursively to all dependencies would have prevented this particular vector, because the provenance would have indicated that it either wasn't built from a proper builder or that the source did not come from GitHub.
 <tr>
 <td>E


### PR DESCRIPTION
fixes https://github.com/slsa-framework/slsa/issues/1213

Proposing we remove the detail relating to a mismatch between the uploaded package and its purported source revisions. 
That is _definitely bad_ but the primary threat here is that the producer changed their intent. 

This patch only covers v1.1 and vdraft.