### PR TITLE
nonspec: Update to add Slack channel for Dependency Track  on current-activities.md

### DIFF
--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -45,5 +45,3 @@ S2C2F provides a guide for the safe consumption of open source dependencies.
 
 As part of this ongoing effort, community members from both SLSA and S2C2F are collaborating to translate the practices outlined in S2C2F, into requirements that align with the structure of existing SLSA specifications.
 Join the discussions and ongoing efforts [on the SLSA Dependency Track Slack channel](https://openssf.slack.com/archives/C03THTH3RSM).
-
-

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -44,7 +44,6 @@ There is an ongoing effort to develop this track, building upon the foundation l
 S2C2F provides a guide for the safe consumption of open source dependencies.
 
 As part of this ongoing effort, community members from both SLSA and S2C2F are collaborating to translate the practices outlined in S2C2F, into requirements that align with the structure of existing SLSA specifications.
-
 Join the discussions and ongoing efforts [on the SLSA Dependency Track Slack channel](https://openssf.slack.com/archives/C03THTH3RSM)
 
 

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -44,3 +44,7 @@ There is an ongoing effort to develop this track, building upon the foundation l
 S2C2F provides a guide for the safe consumption of open source dependencies.
 
 As part of this ongoing effort, community members from both SLSA and S2C2F are collaborating to translate the practices outlined in S2C2F, into requirements that align with the structure of existing SLSA specifications.
+
+Join the discussions and ongoing efforts [on the SLSA Dependency Track Slack channel](https://openssf.slack.com/archives/C03THTH3RSM)
+
+

--- a/docs/current-activities.md
+++ b/docs/current-activities.md
@@ -44,6 +44,6 @@ There is an ongoing effort to develop this track, building upon the foundation l
 S2C2F provides a guide for the safe consumption of open source dependencies.
 
 As part of this ongoing effort, community members from both SLSA and S2C2F are collaborating to translate the practices outlined in S2C2F, into requirements that align with the structure of existing SLSA specifications.
-Join the discussions and ongoing efforts [on the SLSA Dependency Track Slack channel](https://openssf.slack.com/archives/C03THTH3RSM)
+Join the discussions and ongoing efforts [on the SLSA Dependency Track Slack channel](https://openssf.slack.com/archives/C03THTH3RSM).
 
 


### PR DESCRIPTION
Per request in previous PR, adding a link to the OpenSSF SLSA Dependency Track slack channel