### PR TITLE
content: draft: address issues in threats.md

### DIFF
--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -987,13 +987,12 @@ two-party review.
 *Threat:* Exploit a cryptographic hash collision weakness to bypass one of the
 other controls.
 
-*Mitigation:* Require cryptographically secure hash functions for commit
-IDs and provenance subjects, such as SHA-256.
+*Mitigation:* Choose secure algorithms when using cryptographic digests, such
+as SHA-256.
 
-*Examples:* Attacker crafts a malicious executable with the same MD5 hash as a
-target benign executable. Attacker replaces the benign executable with
-the malicious executable. Solution: Only accept cryptographic hashes with strong
-collision resistance.
+*Examples:* Attacker crafts a malicious file with the same MD5 hash as a target
+benign file. Attacker replaces the benign file with the malicious file.
+Solution: Only accept cryptographic hashes with strong collision resistance.
 
 </details>
 

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -263,13 +263,7 @@ stamping."
 *Threat:* Forge the change metadata to alter attribution, timestamp, or
 discoverability of a change.
 
-*Mitigation:* Source control platform strongly authenticates actor identity,
-timestamp, and parent revisions.
-
-*Example:* Adversary submits a git commit with a falsified author and timestamp,
-and then rewrites history with a non-fast-forward update to make it appear to
-have been made long ago. Solution: Consumer detects this by seeing that such
-changes are not strongly authenticated and thus not trustworthy.
+*Mitigation:* This threat is not currently addressed by SLSA.
 
 </details>
 
@@ -916,7 +910,7 @@ machine when Dep is loaded at runtime. An end user installs MyPackage, which in
 turn installs the compromised version of Dep. When the user runs MyPackage, it
 loads and executes the malicious code from Dep.
 
-*Mitigation:* N/A - This threat is not currently addressed by SLSA. SLSA's
+*Mitigation:* N/A - SLSA's
 threat model does not explicitly model runtime dependencies. Instead, each
 runtime dependency is considered a distinct artifact with its own threats.
 
@@ -939,15 +933,7 @@ SLSA v1.0 does not address availability threats, though future versions might.
 revision or cause it to get garbage collected, preventing anyone from inspecting
 the code.
 
-*Mitigation:* Some system retains the revision and its version control history,
-making it available for inspection indefinitely. Users cannot delete the
-revision except as part of a transparent legal or privacy process.
-
-*Example:* An adversary submits malicious code to the MyPackage GitHub repo,
-builds from that revision, then does a force push to erase that revision from
-history or deletes the entire repo. This would make the revision
-unavailable for inspection. Solution: Verifier rejects packages built from
-source repos that do not have strong retention guarantees.
+*Mitigation:* This threat is not currently addressed by SLSA.
 
 </details>
 <details><summary>A dependency becomes temporarily or permanently unavailable to the build process</summary>
@@ -963,14 +949,14 @@ impact of this threat.
 
 *Threat:* The package registry stops serving the artifact.
 
-*Mitigation:* N/A - This threat is not currently addressed by SLSA.
+*Mitigation:* This threat is not currently addressed by SLSA.
 
 </details>
 <details><summary>De-list provenance</summary>
 
 *Threat:* The package registry stops serving the provenance.
 
-*Mitigation:* N/A - This threat is not currently addressed by SLSA.
+*Mitigation:* This threat is not currently addressed by SLSA.
 
 </details>
 

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -472,11 +472,12 @@ forged digest is irrelevant.
 build process or provenance generation.
 
 *Example:* MyPackage is built on Awesome Builder under the project "mypackage".
-Adversary is an administrator of the "mypackage" project. Awesome Builder allows
-administrators to debug build machines via SSH. An adversary uses this feature
-to alter a build in progress. Solution: Build L3 requires provenance to be
-resistant to forgery by tenants, so the attacker would be forbidden from
-altering a build in progress.
+Adversary is an owner of the "mypackage" project. Awesome Builder allows
+owners to debug the build environment via SSH. An adversary uses this feature
+to alter a build in progress. Solution: Build L3 requires complete provenance, the
+attackers access and/or actions within the SSH would be enumerated within the
+external parameters. The updated external parameters will not match the declared
+expectations causing verification to fail.
 
 </details>
 <details><summary>Compromise other build <span>(Build L3)</span></summary>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -463,7 +463,9 @@ build process or provenance generation.
 *Example:* MyPackage is built on Awesome Builder under the project "mypackage".
 Adversary is an administrator of the "mypackage" project. Awesome Builder allows
 administrators to debug build machines via SSH. An adversary uses this feature
-to alter a build in progress.
+to alter a build in progress. Solution: Build L3 requires provenance to be
+resistant to forgery by tenants, so the attacker would be forbidden from
+altering a build in progress.
 
 </details>
 <details><summary>Compromise other build <span>(Build L3)</span></summary>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -517,6 +517,7 @@ such cache poisoning attacks.
 the source file. Adversary runs a malicious build that creates a "poisoned"
 cache entry with a falsified key, meaning that the value wasn't really produced
 from that source. A subsequent build then picks up that poisoned cache entry.
+Solution: Builder uses a separate cache for each build.
 
 </details>
 <details><summary>Compromise build platform admin <span>(verification)</span></summary>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -945,7 +945,7 @@ revision except as part of a transparent legal or privacy process.
 
 *Example:* An adversary submits malicious code to the MyPackage GitHub repo,
 builds from that revision, then does a force push to erase that revision from
-history (or requests that GitHub delete the repo.) This would make the revision
+history or deletes the entire repo. This would make the revision
 unavailable for inspection. Solution: Verifier rejects packages built from
 source repos that do not have strong retention guarantees.
 

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -929,9 +929,8 @@ revision except as part of a transparent legal or privacy process.
 *Example:* An adversary submits malicious code to the MyPackage GitHub repo,
 builds from that revision, then does a force push to erase that revision from
 history (or requests that GitHub delete the repo.) This would make the revision
-unavailable for inspection. Solution: Verifier rejects the package because it
-lacks a positive attestation showing that some system, such as GitHub, ensured
-retention and availability of the source code.
+unavailable for inspection. Solution: Verifier rejects packages built from
+source repos that do not have strong retention guarantees.
 
 </details>
 <details><summary>A dependency becomes temporarily or permanently unavailable to the build process</summary>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -1002,7 +1002,7 @@ two-party review.
 other controls.
 
 *Mitigation:* Require cryptographically secure hash functions for commit
-checksums and provenance subjects, such as SHA-256.
+IDs and provenance subjects, such as SHA-256.
 
 *Examples:* Attacker crafts a malicious executable with the same MD5 hash as a
 target benign executable. Attacker replaces the benign executable with

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -256,6 +256,23 @@ stamping."
 
 </details>
 
+#### (B4) Render logs ineffective
+
+<details><summary>Forge change metadata</summary>
+
+*Threat:* Forge the change metadata to alter attribution, timestamp, or
+discoverability of a change.
+
+*Mitigation:* Source control platform strongly authenticates actor identity,
+timestamp, and parent revisions.
+
+*Example:* Adversary submits a git commit with a falsified author and timestamp,
+and then rewrites history with a non-fast-forward update to make it appear to
+have been made long ago. Solution: Consumer detects this by seeing that such
+changes are not strongly authenticated and thus not trustworthy.
+
+</details>
+
 ### (C) Source code management
 
 An adversary introduces a change to the source control repository through an
@@ -977,20 +994,6 @@ configuration for MyPackage expects the source repository to be
 `evil/my-package`, and then builds from that repository and uploads a malicious
 version of the package. Solution: Changes to the recorded expectations require
 two-party review.
-
-</details>
-<details><summary>Forge change metadata</summary>
-
-*Threat:* Forge the change metadata to alter attribution, timestamp, or
-discoverability of a change.
-
-*Mitigation:* Source control platform strongly authenticates actor identity,
-timestamp, and parent revisions.
-
-*Example:* Adversary submits a git commit with a falsified author and timestamp,
-and then rewrites history with a non-fast-forward update to make it appear to
-have been made long ago. Solution: Consumer detects this by seeing that such
-changes are not strongly authenticated and thus not trustworthy.
 
 </details>
 <details><summary>Exploit cryptographic hash collisions</summary>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -1004,10 +1004,9 @@ other controls.
 *Mitigation:* Require cryptographically secure hash functions for commit
 checksums and provenance subjects, such as SHA-256.
 
-*Examples:* Construct a benign file and a malicious file with the same SHA-1
-hash. Get the benign file reviewed and then submit the malicious file.
-Alternatively, get the benign file reviewed and submitted and then build from
-the malicious file. Solution: Only accept cryptographic hashes with strong
+*Examples:* Attacker crafts a malicious executable with the same MD5 hash as a
+target benign executable. Attacker replaces the benign executable with
+the malicious executable. Solution: Only accept cryptographic hashes with strong
 collision resistance.
 
 </details>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -256,7 +256,7 @@ stamping."
 
 </details>
 
-#### (B4) Render logs ineffective
+#### (B4) Render change metadata ineffective
 
 <details><summary>Forge change metadata</summary>
 


### PR DESCRIPTION
This change addresses multiple issues in threats.md.

* Don't let an attacker debug an in progress build. Fixes #1302 
* Use a separate cache for each build. refs #1303
  * Leaves this issue open for further work.
* Don't reference source attestations in threats yet. Fixes #1306 
* Move "forge change metadata" to "Source Threats". Fixes #1307 
* Use an executable as a hash collision example instead of source file. Fixes #1308