### PR TITLE
content: draft: Update 'unreviewable change' to reference a JPEG

### DIFF
--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -197,8 +197,9 @@ message, but the reviewer is only presented with a diff of the binary
 file contents. The reviewer is unable to parse the contents themselves
 so they do not have enough context to provide a meaningful review.
 Solution: the code review system should present the reviewer with a
-rendering of the image and the embedded metadata, allowing them to make
-an informed decision.
+rendering of the image and the [embedded
+metadata](https://en.wikipedia.org/wiki/Exif), allowing them to make an
+informed decision.
 
 </details>
 <details><summary>Copy a reviewed change to another context</summary>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -192,11 +192,13 @@ benign but is actually malicious.
 *Mitigation:* Code review system ensures that all reviews are informed and
 meaningful.
 
-*Example:* A proposed change updates a file, but the reviewer is only presented
-with a diff of the cryptographic hash, not of the file contents. Thus, the
-reviewer does not have enough context to provide a meaningful review.
-Solution: the code review system should present the reviewer with a content diff or some
-other information to make an informed decision.
+*Example:* A proposed change updates a JPEG file to include a malicious
+message, but the reviewer is only presented with a diff of the binary
+file contents. The reviewer is unable to parse the contents themselves
+so they do not have enough context to provide a meaningful review.
+Solution: the code review system should present the reviewer with a
+rendering of the image and the embedded metadata, allowing them to make
+an informed decision.
 
 </details>
 <details><summary>Copy a reviewed change to another context</summary>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -190,7 +190,8 @@ They may:
 benign but is actually malicious.
 
 *Mitigation:* Code review system ensures that all reviews are informed and
-meaningful.
+meaningful to the extent possible. For example the system could show
+& resolve symlinks, render images, or verify & display provenance.
 
 *Example:* A proposed change updates a JPEG file to include a malicious
 message, but the reviewer is only presented with a diff of the binary


### PR DESCRIPTION
This provides a more clear example of how a change might not be reviewable.

This use case is more common and seems like it is easier to understand vs why
a code review system would just display the cryptographic hash of a file.

fixes #1300