### PR TITLE
content: draft: Just "Platform Operations Track"

### DIFF
--- a/docs/spec/draft/future-directions.md
+++ b/docs/spec/draft/future-directions.md
@@ -32,12 +32,12 @@ following requirements, which **may or may not** be part of a future Build L4:
 
 </section>
 
-<section id="build-platform-operations-track">
+<section id="platform-operations-track">
 
-## Build Platform Operations track
+## Platform Operations track
 
-A Build Platform Operations track could provide assurances around the hardening
-of build platforms as they are operated.
+A Platform Operations track could provide assurances around the hardening of
+platforms (e.g. build or source platforms) as they are operated.
 
 The initial [draft version (v0.1)] of SLSA included a section on
 [common requirements](../v0.1/requirements.md#common-requirements) that formed

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -288,8 +288,8 @@ to push a malicious version of the software.
 *Mitigation:* The source platform must have controls in place to prevent and
 detect abusive behavior from administrators (e.g. two-person approvals for
 changes to the infrastructure, audit logging). A future [Platform
-Operations Track](future-directions#build-platform-operations-track) may
-provide more specific guidance on how to secure the underlying platform.
+Operations Track](future-directions#platform-operations-track) may provide
+more specific guidance on how to secure the underlying platform.
 
 *Example 1:* GitHostingService employee uses an internal tool to push changes to
 the MyPackage source repo.


### PR DESCRIPTION
Future directions talks about a 'Platform Operations Track' that would provide guidance on how to run a secure platform (e.g. ACLing, logging, secret management).  It _had_ been labeled the "_Build_ Platform Operations Track" but was referenced from areas that weren't _build_ platforms.  In fact this guidance would apply broadly for all platforms.  So, this change removes the 'build' qualifier.

It remains to be seen when/if this track will be developed.

fixes #1301 