### PR TITLE
content: draft: build L3 requires complete external parameters, not provenance

### DIFF
--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -480,10 +480,11 @@ build process or provenance generation.
 *Example:* MyPackage is built on Awesome Builder under the project "mypackage".
 Adversary is an owner of the "mypackage" project. Awesome Builder allows
 owners to debug the build environment via SSH. An adversary uses this feature
-to alter a build in progress. Solution: Build L3 requires complete provenance, the
-attackers access and/or actions within the SSH would be enumerated within the
-external parameters. The updated external parameters will not match the declared
-expectations causing verification to fail.
+to alter a build in progress. Solution: Build L3 requires the external parameters
+to be complete in the provenance. The attackers access and/or actions within the
+SSH connection would be enumerated within the external parameters. The updated
+external parameters will not match the declared expectations causing verification
+to fail.
 
 </details>
 <details><summary>Compromise other build <span>(Build L3)</span></summary>


### PR DESCRIPTION
It was raised in the review of 1.1-RC2 that build L3 does not require provenance to be complete. Instead, it only requires the external parameters to be complete. With this requirement, it is still sufficient to mitigate an attack by SSH on the artifact as the verifier would be able to ensure that the external parameters meet expectations.

ref: https://github.com/slsa-framework/slsa/pull/1298#discussion_r2018863889

Signed-off-by: arewm <arewm@users.noreply.github.com>