### PR TITLE
fix: Fix link to current activities

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -219,7 +219,7 @@ testimonials:
                 The community has been hard at work since the release of
                 <a href="spec/v1.0/">SLSA v1.0</a> in 2023 to expand the breadth
                 and depth of the specification with updates and new tracks.
-                For more information, see our <a href="/spec/current-activities">current activities</a> page!
+                For more information, see our <a href="/current-activities">current activities</a> page!
                 <br><br>
 Google has been using an internal version of SLSA since 2013 and requires it for all of their production workloads.</p>
             </div>


### PR DESCRIPTION
The "current activities" link in the "project status" part of the main page goes to the wrong target. Make it go to the right one.