### PR TITLE
fix: Update current version

### DIFF
--- a/docs/_data/versions.yml
+++ b/docs/_data/versions.yml
@@ -15,7 +15,7 @@
 #   <version> = version name, i.e. second component of the URL, e.g. v1.0
 
 spec:
-  current: v1.0
+  current: v1.1
   versions:
     v0.1:
       name: Version 0.1


### PR DESCRIPTION
Header wrongly still claims 1.0 is the current version. This fixes it.