### PR TITLE
nonspec: Update home page

### DIFF
--- a/docs/_data/nav/config.yml
+++ b/docs/_data/nav/config.yml
@@ -6,12 +6,12 @@ url_to_key:
   v1.0-rc1: v10-rc1
   v1.0-rc2: v10-rc2
   v1.0: v10
-  v1: v10
   v1-rc1: v10-rc1
   v1-rc2: v10-rc2
   v1.1-rc1: v11-rc1
   v1.1-rc2: v11-rc2
   v1.1: v11
+  v1: v11
   latest: v11
 
 # TODO: when viewing spec v0.1, it would be better to link to attestations v0.2.

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -57,9 +57,10 @@
 
 /spec                   /spec/v1.0              302
 /spec/faq               /spec/v1.0/faq          302
-/spec/v1/*              /spec/v1.0/:splat       302
+/spec/v1/*              /spec/v1.1/:splat       302
 /spec/v1.1/*            /spec/v1.1-rc2/:splat   302
 /spec/current-activities /current-activities    301
+/spec/latest            /spec/v1.1/             302
 
 # Note: Versions prior to v1.0 stay in /verification_summary.
 /verification_summary           /spec/v1.0/verification_summary     302  # floating

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -58,9 +58,9 @@
 /spec                   /spec/v1.0              302
 /spec/faq               /spec/v1.0/faq          302
 /spec/v1/*              /spec/v1.1/:splat       302
-/spec/v1.1/*            /spec/v1.1-rc2/:splat   302
+/spec/v1.1/*            /spec/v1.1/:splat       302
 /spec/current-activities /current-activities    301
-/spec/latest            /spec/v1.1/             302
+/spec/latest/*          /spec/v1.1/:splat       302
 
 # Note: Versions prior to v1.0 stay in /verification_summary.
 /verification_summary           /spec/v1.0/verification_summary     302  # floating

--- a/docs/index.md
+++ b/docs/index.md
@@ -192,36 +192,13 @@ testimonials:
                 </a>
             </div>
             <div class="w-full md:w-1/2 getting_started_card md:pl-4">
-              <a href="spec/v1.0/" class="hover:no-underline">
+              <a href="spec/latest/" class="hover:no-underline">
                   <div class="bg-white h-full rounded-lg p-10 flex flex-col">
                       <p class="h3 font-semibold mb-8 md:mb-6">Review the specifications</p>
                       <p>Want to learn about how it fits your organization’s security? Here’s the documentation behind the framework, with use cases, specific threats (and their prevention), provenance and fully detailed requirements.</p>
                       <p class="cta-link h5 font-semibold mt-auto pt-8 md:pt-0">Learn more</p>
                   </div>
                 </a>
-            </div>
-        </div>
-    </div>
-</section>
-<section class="section bg-green-dark flex justify-center items-center">
-    <div class="wrapper inner w-full">
-        <div class="md:flex justify-between items-start text-white">
-            <div class="text w-full md:w-1/3">
-<div class="h2 p-0 -mt-16 mb-8 md:mb-0">
-
-## Project status
-
-</div>
-            </div>
-            <div class="w-full md:w-1/2">
-                <div class="rounded-lg text-green p-5 border border-green-400 inline-block mb-8 h4">SLSA v1.0 is available now!</div>
-                <p>
-                The community has been hard at work since the release of
-                <a href="spec/v1.0/">SLSA v1.0</a> in 2023 to expand the breadth
-                and depth of the specification with updates and new tracks.
-                For more information, see our <a href="/current-activities">current activities</a> page!
-                <br><br>
-Google has been using an internal version of SLSA since 2013 and requires it for all of their production workloads.</p>
             </div>
         </div>
     </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ testimonials:
             </div>
             <div class="w-full md:w-1/2 md:mt-0 mt-8">
                 <p>Any software can introduce vulnerabilities into a supply chain. As a system gets more complex, it’s critical to already have checks and best practices in place to guarantee artifact integrity, that the source code you’re relying on is the code you’re actually using. Without solid foundations and a plan for the system as it grows, it’s difficult to focus your efforts against tomorrow’s next hack, breach or compromise.</p>
-                <a href="spec/v1.0/threats-overview" class="cta-link h5 font-semibold mt-8">More about supply chain attacks</a>
+                <a href="spec/latest/threats-overview" class="cta-link h5 font-semibold mt-8">More about supply chain attacks</a>
             </div>
         </div>
         <img class="mt-16 mx-auto w-full md:w-3/4" src="images/SupplyChainDiagram.svg" alt="the supply chain problem image">
@@ -76,7 +76,7 @@ testimonials:
                 <h4 class="h2 mb-8">Levels of assurance</h4>
                 <p>SLSA levels are like a common language to talk about how secure software, supply chains and their component parts really are. From source to platform, the levels blend together industry-recognized best practices to create four compliance levels of increasing assurance.
                 These look at the builds, sources and dependencies in open source or commercial software. Starting with easy, basic steps at the lower levels to build up and protect against advanced threats later, bringing SLSA into your work means prioritized, practical measures to prevent unauthorized modifications to software, and a plan to harden that security over time.</p>
-                <a href="spec/v1.0/levels" class="cta-link h5 font-semibold mt-8">Read the level specifications</a>
+                <a href="spec/latest/levels" class="cta-link h5 font-semibold mt-8">Read the level specifications</a>
             </div>
             <div class="w-full md:w-2/4 md:mt-0 mt-8 pl-12">
                 <img class="w-3/4 mx-auto" src="images/badge-exploded.svg" alt="SLSA levels badge">


### PR DESCRIPTION
Removes the project status section which is outdated and no longer needed since we have "current activities" in the navigation bar.
Also adds some config and redirect to make the homepage more resilient to the publication of new spec versions.
