### PR TITLE
fix: Fix draft header

### DIFF
--- a/docs/_includes/header.html
+++ b/docs/_includes/header.html
@@ -60,13 +60,10 @@
         {%- if version.draft %}
           {%- if spec_version == "draft" %}
             <p>This is a working draft. This document may be modified, replaced, or discarded at any time.</p>
-        {%- else %}
+          {%- else %}
             <p>This is a working draft of {{ spec_version }}. This document may be modified, replaced, or discarded at any time.</p>
+          {%- endif %}
         {%- endif %}
-        <p style="font-size: smaller">For the latest release candidate or approved
-          version, please use the version selector.</p>
-        {%- endif %}
-
         {%- if spec_version != spec.current %}
           {%- assign current_version = spec.versions[spec.current] %}
           {%- if current_version %}
@@ -78,7 +75,7 @@
             {%- if other_page %}
               {%- assign new_url = other_page.url %}
             {%- else %}
-              {%- assign new_url = "/" + spec_id + "/" + spec.current %}
+              {%- assign new_url = "/" | append: spec_id | append: "/" | append: spec.current %}
             {%- endif %}
             <p>{{ current_version.name }} is the current version. See <a href="{{ new_url }}">the {{ current_version.name }} documentation</a>.</p>
           {%- endif %}

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -23,9 +23,7 @@
       | default: site.data.nav.config.url_to_key["latest"] %}
   {%- assign nav = site.data.nav[key] %}
   {%- assign expand = true %}
-<!-- @@ here -->
 {% else %}
-<!-- @@ there -->
   {%- assign expand = false %}
 {% endif %}
 <nav class="site-nav">


### PR DESCRIPTION
We no longer have a version selector so the header should not direct the user to use it...
Plus (and more importantly) this fixes a Liquid coding bug that is silently ignored (gotta love this platform!!) and leads to linking to the wrong page.