### PR TITLE
content: draft: Source VSAs shouldn't be produced for all revisions.

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -173,12 +173,16 @@ See also [Use cases for non-cryptographic, immutable, digests](https://github.co
 <td>✓<td>✓<td>✓
 <tr id="source-summary"><td>Source Summary Attestations<td>
 
-The SCS MUST generate [summary attestations](#summary-attestation) to enable users to determine the source level of a given revision.
+The SCS MUST generate [source summary attestations](#summary-attestation) to
+indicate the SLSA Source Level of a given revision.
 
-If a consumer is authorized to access source on a particular branch, they MUST be able to fetch the summary attestations for revisions in the history of that branch.
+If a consumer is authorized to access a revision, they MUST be able to fetch the
+corresponding source summary attestations.
 
-It is possible that an SCS can make no claims about a particular revision.
-For example, this would happen if the revision was created on another SCS, or if the revision was not the result of an accepted change management process.
+It is possible that an SCS makes no claims about a particular revision.
+In these cases the SCS MAY NOT generate a summary attestation. Consumers MUST
+interpret the absence of a source summary attestation as though the revision
+is SLSA Source Level 0.
 
 <td>✓<td>✓<td>✓
 <tr id="branches"><td>Branches<td>

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -180,7 +180,8 @@ The summary attestation "interprets" what the data in the source provenance atte
 If a consumer is authorized to access a revision, they MUST be able to fetch the
 corresponding source summary attestations.
 
-If the SCS DOES NOT generate a summary attestation for a revision, the revision MUST be verified as having SLSA Source Level 0.
+If the SCS DOES NOT generate a summary attestation for a revision, the revision
+cannot be verified and thus has Source Level 0.
 
 <td>✓<td>✓<td>✓
 <tr id="branches"><td>Branches<td>

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -174,7 +174,7 @@ See also [Use cases for non-cryptographic, immutable, digests](https://github.co
 <tr id="source-summary"><td>Source Summary Attestations<td>
 
 The SCS MUST generate a [source summary attestation](#summary-attestation) to
-indicate the SLSA Source Level of revisions it wishes to make claims about.
+indicate the SLSA Source Level of any revision at Level 1 or above.
 
 If a consumer is authorized to access a revision, they MUST be able to fetch the
 corresponding source summary attestations.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -180,10 +180,7 @@ The summary attestation "interprets" what the data in the source provenance atte
 If a consumer is authorized to access a revision, they MUST be able to fetch the
 corresponding source summary attestations.
 
-It is possible that an SCS makes no claims about a particular revision.
-In these cases the SCS MAY NOT generate a summary attestation. Consumers MUST
-interpret the absence of a source summary attestation as though the revision
-is SLSA Source Level 0.
+If the SCS DOES NOT generate a summary attestation for a revision, the revision MUST be verified as having SLSA Source Level 0.
 
 <td>✓<td>✓<td>✓
 <tr id="branches"><td>Branches<td>

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -173,15 +173,17 @@ See also [Use cases for non-cryptographic, immutable, digests](https://github.co
 <td>✓<td>✓<td>✓
 <tr id="source-summary"><td>Source Summary Attestations<td>
 
-The SCS MAY generate a [source summary attestation](#summary-attestation) to
-indicate the SLSA Source Level of a revision.
-The summary attestation "interprets" what the data in the source provenance attestation means.
+The SCS MUST generate a [source summary attestation](#summary-attestation) to
+indicate the SLSA Source Level of revisions it wishes to make claims about.
 
 If a consumer is authorized to access a revision, they MUST be able to fetch the
 corresponding source summary attestations.
 
 If the SCS DOES NOT generate a summary attestation for a revision, the revision
 cannot be verified and thus has Source Level 0.
+
+When source provenance is available the SCS MAY use it to generate the
+source summary attestation.
 
 <td>✓<td>✓<td>✓
 <tr id="branches"><td>Branches<td>

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -173,8 +173,9 @@ See also [Use cases for non-cryptographic, immutable, digests](https://github.co
 <td>✓<td>✓<td>✓
 <tr id="source-summary"><td>Source Summary Attestations<td>
 
-The SCS MUST generate [source summary attestations](#summary-attestation) to
-indicate the SLSA Source Level of a given revision.
+The SCS MAY generate a [source summary attestation](#summary-attestation) to
+indicate the SLSA Source Level of a revision.
+The summary attestation "interprets" what the data in the source provenance attestation means.
 
 If a consumer is authorized to access a revision, they MUST be able to fetch the
 corresponding source summary attestations.


### PR DESCRIPTION
Currently the langauge makes it sound like they're produced for all revisions, but we really only need (or want!) them to be produced for ones the SCS wants to make claims about.

This change makes that more clear and indicates how consumers should think about revisions without VSAs.