### PR TITLE
content: draft: Improve 'strong auth' requirement wording

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -233,8 +233,9 @@ for this purpose.
 For cloud-based SCSs, this will typically be the identity used to push to a
 repository.
 
-A second factor MUST be required when a user enrolls new access tokens (e.g.
-ssh keys, PATs).
+A second factor MUST be required when a user enrolls new access tokens that
+enable modifications (e.g. ssh keys, PATs), or when enrolling additional
+second factors (e.g. hardware tokens, authenticator apps).
 
 Other forms of identity MAY be included as informational.
 Examples include a git commit's "author" and "committer" fields and a gpg

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -224,16 +224,23 @@ The SCS MUST document how actors are identified for the purposes of attribution.
 Activities conducted on the SCS SHOULD be attributed to authenticated identities.
 
 <td><td>✓<td>✓
-<tr id="strong-authentication"><td>Strong Authentication<td>
+<tr id="multi-factor-authentication"><td>Multi-factor Authentication<td>
 
-User accounts that can modify the source or the project's configuration must use multi-factor authentication or its equivalent.
-This strongly authenticated identity MUST be used for the generation of source provenance attestations.
-The SCS MUST declare which forms of identity it considers to be trustworthy for this purpose.
-For cloud-based SCSs, this will typically be the identity used to push to a repository.
+User accounts that can modify the source or the project's configuration must
+use multi-factor authentication or its equivalent.
+The SCS MUST declare which forms of identity it considers to be trustworthy
+for this purpose.
+For cloud-based SCSs, this will typically be the identity used to push to a
+repository.
+
+A second factor MUST be required when a user enrolls new access tokens (e.g.
+ssh keys, PATs).
 
 Other forms of identity MAY be included as informational.
-Examples include a git commit's "author" and "committer" fields and a gpg signature's "user id."
-These forms of identity are user-provided and not typically verified by the source provenance attestation issuer.
+Examples include a git commit's "author" and "committer" fields and a gpg
+signature's "user id."
+These forms of identity are user-provided and not typically verified by the
+source provenance attestation issuer.
 
 See [source roles](#source-roles).
 
@@ -407,3 +414,12 @@ Example source provenance attestations:
  describe which source quality tools were run on the revision.
 
 [^1]: in-toto attestations allow non-cryptographic digest types: https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md#supported-algorithms.
+
+## Future Considerations
+
+### Authentication
+
+* Better protect against phishing by forbidding second factors that are not
+  phishing resistant.
+* Protect against authentication token theft by forbidding bearer tokens
+  (e.g. PATs).

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -229,7 +229,9 @@ Activities conducted on the SCS SHOULD be attributed to authenticated identities
 User accounts that can modify the source or the project's configuration must
 use multi-factor authentication or its equivalent.
 The SCS MUST declare which forms of identity it considers to be trustworthy
-for this purpose.
+for this purpose. All other forms of identity SHOULD be considered informational
+and SHOULD NOT be used for authentication or attribution.
+
 For cloud-based SCSs, this will typically be the identity used to push to a
 repository.
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -232,9 +232,6 @@ The SCS MUST declare which forms of identity it considers to be trustworthy
 for this purpose. All other forms of identity SHOULD be considered informational
 and SHOULD NOT be used for authentication.
 
-For cloud-based SCSs, this will typically be the identity used to push to a
-repository.
-
 A second factor MUST be required when a user enrolls new access tokens that
 enable modifications (e.g. ssh keys, PATs), or when enrolling additional
 second factors (e.g. hardware tokens, authenticator apps).

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -230,7 +230,7 @@ User accounts that can modify the source or the project's configuration must
 use multi-factor authentication or its equivalent.
 The SCS MUST declare which forms of identity it considers to be trustworthy
 for this purpose. All other forms of identity SHOULD be considered informational
-and SHOULD NOT be used for authentication or attribution.
+and SHOULD NOT be used for authentication.
 
 For cloud-based SCSs, this will typically be the identity used to push to a
 repository.
@@ -238,12 +238,6 @@ repository.
 A second factor MUST be required when a user enrolls new access tokens that
 enable modifications (e.g. ssh keys, PATs), or when enrolling additional
 second factors (e.g. hardware tokens, authenticator apps).
-
-Other forms of identity MAY be included as informational.
-Examples include a git commit's "author" and "committer" fields and a gpg
-signature's "user id."
-These forms of identity are user-provided and not typically verified by the
-source provenance attestation issuer.
 
 See [source roles](#source-roles).
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -419,7 +419,7 @@ Example source provenance attestations:
 
 ### Authentication
 
-* Better protect against phishing by forbidding second factors that are not
+* Better protection against phishing by forbidding second factors that are not
   phishing resistant.
 * Protect against authentication token theft by forbidding bearer tokens
   (e.g. PATs).

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -420,7 +420,7 @@ Example source provenance attestations:
 
 ### Authentication
 
-* Better protection against phishing by forbidding second factors that are not
+-   Better protection against phishing by forbidding second factors that are not
   phishing resistant.
-* Protect against authentication token theft by forbidding bearer tokens
+-   Protect against authentication token theft by forbidding bearer tokens
   (e.g. PATs).


### PR DESCRIPTION
* Indicate that when new auth tokens are added (e.g. ssh keys, PATs)
  the second factor must be used.
* Indicate that token theft and stronger phishing resistance are
  'future considerations'.