### PR TITLE
content: draft: Describe the need for continuity in the source track

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -191,7 +191,7 @@ For systems like GitHub or GitLab, this can be accomplished by enabling branch p
 
 It MUST NOT be possible to delete the entire repository (including all branches) and replace it with different source.
 
-These branch protection enforcements MUST be verified for [continuity](#revision-continuity).
+These branch protection enforcements MUST be verified for [continuity](#revision-control-continuity).
 
 <td><td>✓<td>✓
 <tr id="tag-hygiene"><td>Tag Hygiene<td>
@@ -258,7 +258,7 @@ or if the revision was not the result of an accepted change management process.
 
 The SCS MUST provide a mechanism for organizations to enforce additional
 technical controls which govern changes to a [branch](#definitions). These
-technical controls MAY be verified for [continuity](#revision-continuity).
+technical controls MAY be verified for [continuity](#revision-control-continuity).
 
 For example, this could be accomplished by:
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -191,16 +191,7 @@ For systems like GitHub or GitLab, this can be accomplished by enabling branch p
 
 It MUST NOT be possible to delete the entire repository (including all branches) and replace it with different source.
 
-Continuity exceptions are allowed via the [safe expunging process](#safe-expunging-process).
-
-<td><td>✓<td>✓
-<tr id="continuous-controls"><td>Continuous Controls<td>
-
-The SCS MUST provide a mechanism for organizations to indicate which controls
-are enforced for every revision on a protected branch since that protection was
-enabled.
-
-Continuity exceptions are allowed via the [safe expunging process](#safe-expunging-process).
+These branch protection enforcements MUST be verified for [continuity](#revision-continuity).
 
 <td><td>✓<td>✓
 <tr id="tag-hygiene"><td>Tag Hygiene<td>
@@ -266,9 +257,8 @@ or if the revision was not the result of an accepted change management process.
 <tr id="change-management-process"><td>Enforced change management process<td>
 
 The SCS MUST provide a mechanism for organizations to enforce additional
-technical controls which govern changes to a [branch](#definitions). The
-continuity of these controls MAY be enforced by the
-[continuous controls](#continuous-controls) requirement.
+technical controls which govern changes to a [branch](#definitions). These
+technical controls MAY be verified for [continuity](#revision-continuity).
 
 For example, this could be accomplished by:
 
@@ -279,6 +269,22 @@ For example, this could be accomplished by:
 
 <td><td><td>✓
 </table>
+
+#### Revision continuity
+
+Revisions are created by applying a specific code change (a "diff" in git) on
+top of an earlier revision. Since a single revision does not provide sufficient
+context to assess the source code controls on its own, an SCS MUST provide a
+means to ensure continuity of controls from one revision to another. Continuity
+MAY be accomplished by an SCS ensuring that a control has not lapsed between when
+a revision and its parent are created.
+
+While continuity MUST be established and tracked from a specific point in time,
+an SCS MAY choose not to expose that to consumers in attestations it produces.
+If there is a lapse in continuity for a specific control, that continuity MUST
+be re-established from a new point in time.
+
+Continuity exceptions are allowed via the [safe expunging process](#safe-expunging-process).
 
 ### Provide a change management tool
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -279,10 +279,13 @@ means to ensure continuity of controls from one revision to another. Continuity
 MAY be accomplished by an SCS ensuring that a control has not lapsed between when
 a revision and its parent are created.
 
-While continuity MUST be established and tracked from a specific point in time,
-an SCS MAY choose not to expose that to consumers in attestations it produces.
-If there is a lapse in continuity for a specific control, that continuity MUST
-be re-established from a new point in time.
+Continuity MUST be established and tracked from a specific point in time. If
+there is a lapse in continuity for a specific control, that continuity MUST be
+re-established from a new point in time.
+
+An SCS SHOULD expose the time a control was established in the source provenance
+and other attestations it produces (with the exception of the source summary
+attestation).
 
 Continuity exceptions are allowed via the [safe expunging process](#safe-expunging-process).
 
@@ -434,3 +437,4 @@ Example source provenance attestations:
   phishing resistant.
 -   Protect against authentication token theft by forbidding bearer tokens
   (e.g. PATs).
+-   Including length of continuity in the VSAs

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -194,6 +194,15 @@ It MUST NOT be possible to delete the entire repository (including all branches)
 Continuity exceptions are allowed via the [safe expunging process](#safe-expunging-process).
 
 <td><td>✓<td>✓
+<tr id="continuous-controls"><td>Continuous Controls<td>
+
+The SCS MUST provide a mechanism for organizations to indicate which controls
+are enforced for every revision on a protected branch since that protection was
+enabled.
+
+Continuity exceptions are allowed via the [safe expunging process](#safe-expunging-process).
+
+<td><td>✓<td>✓
 <tr id="tag-hygiene"><td>Tag Hygiene<td>
 
 If the SCS supports tags (or other non-branch tracks), additional care must be
@@ -257,7 +266,9 @@ or if the revision was not the result of an accepted change management process.
 <tr id="change-management-process"><td>Enforced change management process<td>
 
 The SCS MUST provide a mechanism for organizations to enforce additional
-technical controls which govern changes to a [branch](#definitions).
+technical controls which govern changes to a [branch](#definitions). The
+continuity of these controls MAY be enforced by the
+[continuous controls](#continuous-controls) requirement.
 
 For example, this could be accomplished by:
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -48,7 +48,7 @@ Consumers can examine the various source provenance attestations to determine if
 
 When onboarding a branch to the SLSA Source Track or increasing the level of
 that branch, organizations are making claims about how the branch is managed
-from that time or revision forward.
+from that time or revision forward. This establishes [continuity](#revision-control-continuity).
 
 No claims are made for prior revisions.
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -276,7 +276,7 @@ Revisions are created by applying a specific code change (a "diff" in git) on
 top of an earlier revision. Since a single revision does not provide sufficient
 context to assess the source code controls on its own, an SCS MUST provide a
 means to ensure continuity of controls from one revision to another. Continuity
-MAY be accomplished by an SCS ensuring that a control has not lapsed between when
+MAY be accomplished by an SCS showing that a control has been enforced when
 a revision and its parent are created.
 
 Continuity MUST be established and tracked from a specific point in time. If

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -270,7 +270,7 @@ For example, this could be accomplished by:
 <td><td><td>✓
 </table>
 
-#### Revision continuity
+#### Revision control continuity
 
 Revisions are created by applying a specific code change (a "diff" in git) on
 top of an earlier revision. Since a single revision does not provide sufficient


### PR DESCRIPTION
Since revisions are proposed relative to their parent. Since any revision can potentially have at least a partial dependency on its parent, we can only ensure that controls are effectively protecting the current revision by checking that they have been continuously enabled since at least the previous commit.

This is a concept that will be relevant to multiple controls within the source track.