### PR TITLE
nonspec: Add some documentation about the website internals

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -218,7 +218,7 @@ paths that can be updated without requiring any content change.
 
 This lists some of the steps one must take to publish a new version of the specification:
 
-* Edit `docs/_data/versions.yml` to add the new version, with its status, and possibly update the status of the previous one.
-* Edit `docs/_data/nav/config.yml` to add the new version
-* Edit `docs/_data/main.yml` to add the new version and possibly remove any older versions to be hidden. If you remove an old version, make sure that a version specific file exists because it will be needed if the hidden version is accessed directly.
-* Edit `docs/_redirects` as necessary including the definition of `/spec/latest/*`
+-   Edit `docs/_data/versions.yml` to add the new version, with its status, and possibly update the status of the previous one.
+-   Edit `docs/_data/nav/config.yml` to add the new version
+-   Edit `docs/_data/main.yml` to add the new version and possibly remove any older versions to be hidden. If you remove an old version, make sure that a version specific file exists because it will be needed if the hidden version is accessed directly.
+-   Edit `docs/_redirects` as necessary including the definition of `/spec/latest/*`

--- a/docs/README.md
+++ b/docs/README.md
@@ -214,6 +214,9 @@ Typical website configuration type of file, defining a bunch of redirects used
 to maintain backwards compatibility and provide for some resilience by defining
 paths that can be updated without requiring any content change.
 
+Addition of new redirects should be kept to a minimum to limit maintenance
+burden.
+
 ## Publishing a new version of the SLSA specification
 
 This lists some of the steps one must take to publish a new version of the specification:

--- a/docs/README.md
+++ b/docs/README.md
@@ -167,3 +167,58 @@ deploy**.
 ![screenshot of rollback button](../readme_images/netlify_rollback_screenshot.png)
 
 This will stay active until the next push to `main`.
+
+## Insights on some of the internals of the SLSA website
+
+This section provides a collection of tips on some of the internals of how the
+slsa.dev website. This is not complete but it should list all the files to know
+about when publishing a new version of the SLSA specification.
+
+### Configuration files
+
+Several configuration files govern the website layout and behavior.
+
+#### docs/_data/versions.yml
+
+This files used to control the version selector for the specification. The
+version selector has been abandoned but the file also serves to indicate the
+status of a given version: Draft, Approved, or Retired which is still in use.
+
+#### docs/_data/nav/*
+
+This folder contains a set of files defining the navigation side bars to be
+used for the different versions of the specification.
+
+When the version selector was abandoned we switched to only using one global
+navigation menu for all pages and versions of the spec meant to be accessible
+through the navigation menu (i.e., not hidden). This menu is defined in
+`main.yaml`.
+
+The version specific files, such as `v0.1.yml`, are used when someone directly
+accesses an older version which is "hidden" (i.e., not part of the main
+navigation bar and only accessible via a direct link from an old blog post for
+instance).
+
+The content of the navigation files is used (in `docs/_includes/nav.html`) to
+define the navigation side bar but also to define (in
+`docs/_includes/pagination.html`) how pages are chained via the previous and
+next links displayed at the bottom of a page).
+
+The `config.yml` file defines the mapping of the version of the specification
+taken from the page URL to the key in the site.data.nav array where the various
+navigation menu definitions are stored.
+
+### docs/_redirects
+
+Typical website configuration type of file, defining a bunch of redirects used
+to maintain backwards compatibility and provide for some resilience by defining
+paths that can be updated without requiring any content change.
+
+## Publishing a new version of the SLSA specification
+
+This lists some of the steps one must take to publish a new version of the specification:
+
+* Edit `docs/_data/versions.yml` to add the new version, with its status, and possibly update the status of the previous one.
+* Edit `docs/_data/nav/config.yml` to add the new version
+* Edit `docs/_data/main.yml` to add the new version and possibly remove any older versions to be hidden. If you remove an old version, make sure that a version specific file exists because it will be needed if the hidden version is accessed directly.
+* Edit `docs/_redirects` as necessary including the definition of `/spec/latest/*`

--- a/docs/README.md
+++ b/docs/README.md
@@ -180,9 +180,13 @@ Several configuration files govern the website layout and behavior.
 
 #### docs/_data/versions.yml
 
-This files used to control the version selector for the specification. The
-version selector has been abandoned but the file also serves to indicate the
-status of a given version: Draft, Approved, or Retired which is still in use.
+This file defines the status of the different versions of the specification
+(Draft, Approved, or Retired) along with which version is the current one
+(which is used to bring up the header indicating the version being looked at is
+not the current one with a pointer to the current version).
+
+The `hidden` property was used by the version selector which was abandoned and
+is no longer in use.
 
 #### docs/_data/nav/*
 
@@ -198,6 +202,13 @@ The version specific files, such as `v0.1.yml`, are used when someone directly
 accesses an older version which is "hidden" (i.e., not part of the main
 navigation bar and only accessible via a direct link from an old blog post for
 instance).
+
+Care must be taken to ensure that every hidden version has an associated
+navigation file or no navigation side menu will be rendered, making it
+impossible to navigate through the pages of that version of the
+specification. Practically speaking this means that, when you remove a specific
+version from `main.yaml` you should always create a corresponding `v***.yaml`
+if none exists already.
 
 The content of the navigation files is used (in `docs/_includes/nav.html`) to
 define the navigation side bar but also to define (in


### PR DESCRIPTION
I had a first brain dump about some of the internals of slsa.dev that ought to be better documented because anyone trying to publish a new version of the spec will need to know about these.

I still plan to do some additional investigation and update as necessary but I thought it'd be better to share it earlier rather than later. I invite anyone who's interested to have a look and ask any questions you may have. This will only help me add whatever else is missing and might be helpful in the future.
