### PR TITLE
content: draft: Expand 'organization requirements'

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -179,24 +179,19 @@ Organizations SHOULD prefer to make logs public if possible.
 <tr id="specify-control-expectations"><td>Specify control expectations<td>
 
 The organization MUST specify what technical controls consumers can expect to be
-enforced for revisions in each branch.
+enforced for revisions in each branch using the
+[Enforced change management process](#enforced-change-management-process).
 
 For example, an organization may wish consumers to form an expectation that
 revisions on 'main' require unit tests to have passed prior to merge.  The
 organization would then configure the SCS to enforce this requirement and
-embed the relevant metadata in the [source summary](#summary-attestation) and/or
-[source provenance](#provenance-attestations) attestations for all affected
-revisions.  Consumers of those revisions would be able to determine if these
-expectations have been met via those attestations.
+embed the `USER_SOURCE_UNIT_TESTED` tag in the
+[source summary](#summary-attestation) and have the SCS store a corresponding
+[test result attestation].  Consumers of those revisions would be able to
+determine if these expectations have been met by looking for the
+`USER_SOURCE_UNIT_TESTED` tag in the VSA.
 
-Organizations SHOULD NOT specify technical controls they do not wish consumers
-to form expectations on.
-
-For example, an organization may be conducting a trial of a new control and
-they are not yet sure if they will keep it, or it may have implemented a
-proprietary control it does not want to publicize. In these cases the
-organization would not configure the SCS to embed metadata about this control
-into the attestations.
+[test result attestation]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
 
 <td><td><td>✓<td>✓
 
@@ -317,7 +312,7 @@ For example, this would happen if the revision was created on another SCS,
 or if the revision was not the result of an accepted change management process.
 
 <td><td><td>✓<td>✓
-<tr id="change-management-process"><td>Enforced change management process<td>
+<tr id="enforced-change-management-process"><td>Enforced change management process<td>
 
 The SCS MUST
 
@@ -379,7 +374,7 @@ Examples:
 
 ### Provide a change management tool
 
-The change management tool MUST be able to authoritatively state that each new revision reachable from the protected branch represents only the changes managed via the [process](#change-management-process).
+The change management tool MUST be able to authoritatively state that each new revision reachable from the protected branch represents only the changes managed via the [process](#enforced-change-management-process).
 
 <table>
 <tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -319,12 +319,24 @@ or if the revision was not the result of an accepted change management process.
 <td><td><td>✓<td>✓
 <tr id="change-management-process"><td>Enforced change management process<td>
 
-The SCS MUST ensure organization-defined technical controls are enforced for
-changes made to protected branches.  It MUST also embed relevant metadata about
-these controls in the [source summary](#summary-attestation) and/or
-[source provenance](#provenance-attestations) attestations
+The SCS MUST
 
-For example, this could be accomplished by:
+-   Ensure organization-defined technical controls are enforced for changes made
+   to protected branches.
+-   Allow organizations to specify
+   [additional tags](#additional-tags) to be included in the
+   [source summary](#summary-attestation) when the corresponding controls are
+enforced.
+-   Allow organizations to distribute additional attestations related to their
+   technical controls to consumers authorized to access the corresponding source
+   revision.
+
+The SCS MUST NOT allow organization specified tags to begin with any value other
+than `USER_SOURCE_` or `INTERNAL_USER_` unless the SCS endorses the veracity of
+any corresponding claims.
+
+Enforcement of the organization defined technical controls could be accomplished
+by, for example:
 
 -   The configuration of branch protection rules (e.g.[GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html)) which require additional checks to 'pass'
     (e.g. unit tests, linters), or
@@ -427,6 +439,8 @@ MAY include additional properties as asserted by the SCS.  The SCS MUST include 
 
 The SCS MAY issue these attestations based on its understanding of the underlying system (e.g. based on design docs, security reviews, etc...),
 but at SLSA Source Level 3 MUST use tamper-proof [provenance attestations](#provenance-attestations) appropriate to their SCS when making the assessment.
+
+#### Additional tags
 
 The SLSA source track MAY create additional tags to include in `verifiedLevels` which attest
 to other properties of a revision (e.g. if it was code reviewed).  All SLSA source tags will start with `SLSA_SOURCE_`.  Consumers MAY assume all SLSA source tags are meant

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -185,11 +185,12 @@ enforced for revisions in each branch using the
 For example, an organization may claim that revisions on `main` passed unit
 tests before being accepted.  The organization could then configure the SCS to
 enforce this requirement and store corresponding [test result attestations] for
-all affected revisions.  They may then embed the `USER_SOURCE_UNIT_TESTED` tag
-in the [source summary attestations](#summary-attestation). Consumers would then
-expect that future revisions on `main` have been united tested and determine if
-that expectation has been met by looking for the `USER_SOURCE_UNIT_TESTED` tag
-in the VSAs and, if desired, consult the [test result attestations] as well.
+all affected revisions.  They may then embed the `USER_SOURCE_UNIT_TESTED`
+property in the [source summary attestations](#summary-attestation). Consumers
+would then expect that future revisions on `main` have been united tested and
+determine if that expectation has been met by looking for the
+`USER_SOURCE_UNIT_TESTED` property in the VSAs and, if desired, consult the
+[test result attestations] as well.
 
 [test result attestations]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
 
@@ -319,16 +320,16 @@ The SCS MUST
 -   Ensure organization-defined technical controls are enforced for changes made
    to protected branches.
 -   Allow organizations to specify
-   [additional tags](#additional-tags) to be included in the
+   [additional properties](#additional-properties) to be included in the
    [source summary](#summary-attestation) when the corresponding controls are
 enforced.
 -   Allow organizations to distribute additional attestations related to their
    technical controls to consumers authorized to access the corresponding source
    revision.
 
-The SCS MUST NOT allow organization specified tags to begin with any value other
-than `USER_SOURCE_` or `INTERNAL_USER_` unless the SCS endorses the veracity of
-any corresponding claims.
+The SCS MUST NOT allow organization specified properties to begin with any value
+other than `USER_SOURCE_` or `INTERNAL_USER_` unless the SCS endorses the
+veracity of any corresponding claims.
 
 Enforcement of the organization-defined technical controls could be accomplished
 by, for example:
@@ -435,22 +436,24 @@ MAY include additional properties as asserted by the SCS.  The SCS MUST include 
 The SCS MAY issue these attestations based on its understanding of the underlying system (e.g. based on design docs, security reviews, etc...),
 but at SLSA Source Level 3 MUST use tamper-proof [provenance attestations](#provenance-attestations) appropriate to their SCS when making the assessment.
 
-#### Additional tags
+#### Additional properties
 
-The SLSA source track MAY create additional tags to include in `verifiedLevels` which attest
-to other properties of a revision (e.g. if it was code reviewed).  All SLSA source tags will start with `SLSA_SOURCE_`.  Consumers MAY assume all SLSA source tags are meant
+The SLSA source track MAY create additional properties to include in
+`verifiedLevels` which attest to other claims concerning a revision (e.g. if it
+was code reviewed). All SLSA source properties will start with `SLSA_SOURCE_`.
+Consumers MAY assume all SLSA source properties are meant
 
-The SCS MAY embed user-provided tags within `verifiedLevels` corresponding to
+The SCS MAY embed user-provided properties within `verifiedLevels` corresponding to
 technical controls enforced by the SCS if they are prefixed with:
 
--   `USER_SOURCE_` to indicate a tag that is meant for consumption by external
-   consumers.
--   `INTERNAL_USER_` to indicate a tag that is not meant for consumption by
+-   `USER_SOURCE_` to indicate a property that is meant for consumption by
+   external consumers.
+-   `INTERNAL_USER_` to indicate a property that is not meant for consumption by
    external consumers.
 
-The meaning of the tags is left entirely to the organization. Inclusion of user
-provided tags within `verifiedLevels` SHOULD NOT be considered an endorsement of
-the veracity of the organization defined claim by the SCS.
+The meaning of the properties is left entirely to the organization. Inclusion of
+user provided properties within `verifiedLevels` SHOULD NOT be considered an
+endorsement of the veracity of the organization defined property by the SCS.
 
 #### Populating source_refs
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -182,15 +182,14 @@ The organization MUST specify what technical controls consumers can expect to be
 enforced for revisions in each branch using the
 [Enforced change management process](#enforced-change-management-process).
 
-For example, an organization may claim that revisions on `main` passed unit tests before being accepted.  The organization could then
-configure the SCS to enforce this requirement and store
-corresponding [test result attestations] for all affected revisions. 
-They may then embed the `USER_SOURCE_UNIT_TESTED` tag in the
-[source summary attestations](#summary-attestation).
-Consumers would be able to establish the expectation that revisions on `main`
-have been united tested and determine if that expectation has been met by
-looking for the `USER_SOURCE_UNIT_TESTED` tag in the VSA and, if desired,
-consult the [test result attestations] as well.
+For example, an organization may claim that revisions on `main` passed unit
+tests before being accepted.  The organization could then configure the SCS to
+enforce this requirement and store corresponding [test result attestations] for
+all affected revisions.  They may then embed the `USER_SOURCE_UNIT_TESTED` tag
+in the [source summary attestations](#summary-attestation). Consumers would then
+expect that future revisions on `main` have been united tested and determine if
+that expectation has been met by looking for the `USER_SOURCE_UNIT_TESTED` tag
+in the VSAs and, if desired, consult the [test result attestations] as well.
 
 [test result attestations]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -179,8 +179,8 @@ Organizations SHOULD prefer to make logs public if possible.
 
 <tr id="specify-control-expectations"><td>Specify control expectations<td>
 
-The organization MUST specify what technical controls consumers can expect
-revisions on a branch to have met.
+The organization MUST specify what technical controls consumers can expect to be
+enforced for revisions in each branch.
 
 For example, an organization may wish consumers to form an expectation that
 revisions on 'main' require unit tests to have passed prior to merge.  The
@@ -189,6 +189,15 @@ embed the relevant metadata in the [source summary](#summary-attestation) and/or
 [source provenance](#provenance-attestations) attestations for all affected
 revisions.  Consumers of those revisions would be able to determine if these
 expectations have been met via those attestations.
+
+Organizations SHOULD NOT specify technical controls they do not wish consumers
+to form expectations on.
+
+For example, an organization may be conducting a trial of a new control and
+they are not yet sure if they will keep it, or it may have implemented a
+proprietary control it does not want to publicize. In these cases the
+organization would not configure the SCS to embed metadata about this control
+into the attestations.
 
 <td><td><td>✓<td>✓
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -52,33 +52,6 @@ from that time or revision forward.
 
 No claims are made for prior revisions.
 
-## Safe Expunging Process
-
-SCSs MAY allow the organization to expunge (remove) content from a repository and its change history without leaving a public record of the removed content,
-but the organization MUST only allow these changes in order to meet legal or privacy compliance requirements.
-Content changed under this process includes changing files, history, references, or any other metadata stored by the SCS.
-
-### Warning
-
-Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact.
-For example, in VCSs like Git, removal of a revision changes the object IDs of all subsequent revisions that were built on top of it, breaking downstream consumers' ability to refer to source they've already integrated into their products.
-
-It may be the case that the specific set of changes targeted by a legal takedown can be expunged in ways that do not impact consumed revisions, which can mitigate these problems.
-
-It is also the case that removing content from a repository won't necessarily remove it everywhere.
-The content may still exist in other copies of the repository, either in backups or on developer machines.
-
-### Process
-
-An organization MUST document the Safe Expunging Process and describe how requests and actions are tracked and SHOULD log the fact that content was removed.
-Different organizations and tech stacks may have different approaches to the problem.
-
-SCSs SHOULD have technical mechanisms in place which require an Administrator plus, at least, one additional 'trusted person' to trigger any expunging (removals) made under this process.
-
-The application of the safe expunging process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
-and regulations which may require the change to be kept private to the extent possible.
-Organizations SHOULD prefer to make logs public if possible.
-
 ## Levels
 
 ### Level 1: Version controlled
@@ -155,9 +128,8 @@ attestations.
 
 <tr id="choose-process"><td>Choose an appropriate change management process<td>
 
-At Level 2+ an organization producing source revisions MUST implement a change
-management process to ensure changes to source matches the organization's
-intent.
+An organization producing source revisions MUST implement a change management
+process to ensure changes to source matches the organization's intent.
 
 <td><td>✓<td>✓<td>✓
 
@@ -172,6 +144,35 @@ intends for 'main' to be protected then it MUST indicate to the SCS that 'main'
 should be protected. From that point forward revisions on 'main' will be
 eligible for Source Level 2+ while revisions made solely on 'experimental' will
 not.
+
+<td><td>✓<td>✓<td>✓
+
+<tr id="safe-expunging-process"><td>Safe Expunging Process<td>
+
+SCSs MAY allow the organization to expunge (remove) content from a repository and its change history without leaving a public record of the removed content,
+but the organization MUST only allow these changes in order to meet legal or privacy compliance requirements.
+Content changed under this process includes changing files, history, references, or any other metadata stored by the SCS.
+
+#### Warning
+
+Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact.
+For example, in VCSs like Git, removal of a revision changes the object IDs of all subsequent revisions that were built on top of it, breaking downstream consumers' ability to refer to source they've already integrated into their products.
+
+It may be the case that the specific set of changes targeted by a legal takedown can be expunged in ways that do not impact consumed revisions, which can mitigate these problems.
+
+It is also the case that removing content from a repository won't necessarily remove it everywhere.
+The content may still exist in other copies of the repository, either in backups or on developer machines.
+
+#### Process
+
+An organization MUST document the Safe Expunging Process and describe how requests and actions are tracked and SHOULD log the fact that content was removed.
+Different organizations and tech stacks may have different approaches to the problem.
+
+SCSs SHOULD have technical mechanisms in place which require an Administrator plus, at least, one additional 'trusted person' to trigger any expunging (removals) made under this process.
+
+The application of the safe expunging process and the resulting logs MAY be private to both prevent calling attention to potentially sensitive data (e.g. PII) or to comply with local laws
+and regulations which may require the change to be kept private to the extent possible.
+Organizations SHOULD prefer to make logs public if possible.
 
 <td><td>✓<td>✓<td>✓
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -182,16 +182,17 @@ The organization MUST specify what technical controls consumers can expect to be
 enforced for revisions in each branch using the
 [Enforced change management process](#enforced-change-management-process).
 
-For example, an organization may wish consumers to form an expectation that
-revisions on 'main' require unit tests to have passed prior to merge.  The
-organization would then configure the SCS to enforce this requirement and
-embed the `USER_SOURCE_UNIT_TESTED` tag in the
-[source summary](#summary-attestation) and have the SCS store a corresponding
-[test result attestation].  Consumers of those revisions would be able to
-determine if these expectations have been met by looking for the
-`USER_SOURCE_UNIT_TESTED` tag in the VSA.
+For example, an organization may wish claim that revisions on 'main' require
+unit tests to have passed prior to merge.  The organization could then
+configure the SCS to enforce this requirement and embed the
+`USER_SOURCE_UNIT_TESTED` tag in the
+[source summary attestations](#summary-attestation) and have the SCS store
+corresponding [test result attestations] for all affected revisions.
+Consumers of those revisions would be able to determine if these expectations
+have been met by looking for the `USER_SOURCE_UNIT_TESTED` tag in the VSA and,
+if desired, consult the [test result attestations] as well.
 
-[test result attestation]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
+[test result attestations]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
 
 <td><td><td>✓<td>✓
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -328,8 +328,8 @@ enforced.
    revision.
 
 The SCS MUST NOT allow organization specified properties to begin with any value
-other than `ORG_SOURCE_` or `INTERNAL_ORG_` unless the SCS endorses the
-veracity of any corresponding claims.
+other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
+corresponding claims.
 
 Enforcement of the organization-defined technical controls could be accomplished
 by, for example:
@@ -444,12 +444,14 @@ was code reviewed).
 
 The SCS MAY embed organization-provided properties within `verifiedLevels`
 corresponding to technical controls enforced by the SCS. If such properties are
-provided they MUST be prefixed with:
+provided they MUST be prefixed with `ORG_SOURCE_` to distinguish them from other
+properties the SCS may wish use.
+
 
 -   `ORG_SOURCE_` to indicate a property that is meant for consumption by
    external consumers.
--   `INTERNAL_ORG_` to indicate a property that is not meant for consumption by
-   external consumers.
+-   `ORG_SOURCE_INTERNAL_` to indicate a property that is not meant for
+   consumption by external consumers.
 
 The meaning of the properties is left entirely to the organization. Inclusion of
 organization-provided properties within `verifiedLevels` SHOULD NOT be

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -139,7 +139,10 @@ Many examples in this document use the [git version control system](https://git-
 
 [Organization]: #organization
 
-#### Choose an appropriate source control system
+<table>
+<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
+
+<tr id="choose-scs"><td>Choose an appropriate source control system<td>
 
 An organization producing source revisions MUST select a SCS capable of reaching
 their desired SLSA Source Level.
@@ -148,11 +151,46 @@ For example, if an organization wishes to produce revisions at Source Level 3,
 they MUST choose a source control system capable of producing Source Level 3
 attestations.
 
-#### Choose an appropriate change management process
+<td>✓<td>✓<td>✓<td>✓
+
+<tr id="choose-process"><td>Choose an appropriate change management process<td>
 
 At Level 2+ an organization producing source revisions MUST implement a change
 management process to ensure changes to source matches the organization's
 intent.
+
+<td><td>✓<td>✓<td>✓
+
+<tr id="specify-protection"><td>Specify which branches and tags are protected<td>
+
+The organization MUST indicated which branches and tags it protects with Source
+Level 2+ controls.  Only those indicated branches and tags will be eligible for
+Source Level 2+.
+
+For example, if an organization has branches 'main' and 'experimental' and it
+intends for 'main' to be protected then it MUST indicate to the SCS that 'main'
+should be protected. From that point forward revisions on 'main' will be
+eligible for Source Level 2+ while revisions made solely on 'experimental' will
+not.
+
+<td><td>✓<td>✓<td>✓
+
+<tr id="specify-control-expectations"><td>Specify what control expectations<td>
+
+The organization MUST specify what technical controls consumers can expect
+revisions on a branch to have met.
+
+For example, an organization may wish consumers to form an expectation that
+revisions on 'main' require unit tests to have passed prior to merge.  The
+organization would then configure the SCS to enforce this requirement and
+embed the relevant metadata in the [source summary](#summary-attestation) and/or
+[source provenance](#provenance-attestations) attestations for all affected
+revisions.  Consumers of those revisions would be able to determine if these
+expectations have been met via those attestations.
+
+<td><td><td>✓<td>✓
+
+</table>
 
 ### Source Control System
 
@@ -271,8 +309,10 @@ or if the revision was not the result of an accepted change management process.
 <td><td><td>✓<td>✓
 <tr id="change-management-process"><td>Enforced change management process<td>
 
-The SCS MUST provide a mechanism for organizations to enforce additional
-technical controls which govern changes to a [branch](#definitions).
+The SCS MUST ensure organization defined technical controls are enforced for
+changes made to protected branches.  It MUST also embed relevant metadata about
+these controls in the [source summary](#summary-attestation) and/or
+[source provenance](#provenance-attestations) attestations
 
 For example, this could be accomplished by:
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -137,8 +137,7 @@ process to ensure changes to source matches the organization's intent.
 <tr id="specify-protection"><td>Specify which branches and tags are protected<td>
 
 The organization MUST indicate which branches and tags it protects with Source
-Level 2+ controls.  Only those indicated branches and tags will be eligible for
-Source Level 2+.
+Level 2+ controls.
 
 For example, if an organization has branches 'main' and 'experimental' and it
 intends for 'main' to be protected then it MUST indicate to the SCS that 'main'

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -182,15 +182,16 @@ The organization MUST specify what technical controls consumers can expect to be
 enforced for revisions in each branch using the
 [Enforced change management process](#enforced-change-management-process).
 
-For example, an organization may wish claim that revisions on 'main' require
+For example, an organization may wish claim that revisions on `main` require
 unit tests to have passed prior to merge.  The organization could then
 configure the SCS to enforce this requirement and embed the
 `USER_SOURCE_UNIT_TESTED` tag in the
 [source summary attestations](#summary-attestation) and have the SCS store
 corresponding [test result attestations] for all affected revisions.
-Consumers of those revisions would be able to determine if these expectations
-have been met by looking for the `USER_SOURCE_UNIT_TESTED` tag in the VSA and,
-if desired, consult the [test result attestations] as well.
+Consumers would be able to establish the expectation that revisions on `main`
+have been united tested and determine if that expectation has been met by
+looking for the `USER_SOURCE_UNIT_TESTED` tag in the VSA and, if desired,
+consult the [test result attestations] as well.
 
 [test result attestations]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -447,7 +447,6 @@ corresponding to technical controls enforced by the SCS. If such properties are
 provided they MUST be prefixed with `ORG_SOURCE_` to distinguish them from other
 properties the SCS may wish use.
 
-
 -   `ORG_SOURCE_` to indicate a property that is meant for consumption by
    external consumers.
 -   `ORG_SOURCE_INTERNAL_` to indicate a property that is not meant for

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -176,7 +176,7 @@ Organizations SHOULD prefer to make logs public if possible.
 
 <td><td>✓<td>✓<td>✓
 
-<tr id="specify-control-expectations"><td>Specify what control expectations<td>
+<tr id="specify-control-expectations"><td>Specify control expectations<td>
 
 The organization MUST specify what technical controls consumers can expect
 revisions on a branch to have met.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -182,8 +182,7 @@ The organization MUST specify what technical controls consumers can expect to be
 enforced for revisions in each branch using the
 [Enforced change management process](#enforced-change-management-process).
 
-For example, an organization may wish claim that revisions on `main` require
-unit tests to have passed prior to merge.  The organization could then
+For example, an organization may claim that revisions on `main` passed unit tests before being accepted.  The organization could then
 configure the SCS to enforce this requirement and embed the
 `USER_SOURCE_UNIT_TESTED` tag in the
 [source summary attestations](#summary-attestation) and have the SCS store

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -183,10 +183,10 @@ enforced for revisions in each branch using the
 [Enforced change management process](#enforced-change-management-process).
 
 For example, an organization may claim that revisions on `main` passed unit tests before being accepted.  The organization could then
-configure the SCS to enforce this requirement and embed the
-`USER_SOURCE_UNIT_TESTED` tag in the
-[source summary attestations](#summary-attestation) and have the SCS store
-corresponding [test result attestations] for all affected revisions.
+configure the SCS to enforce this requirement and store
+corresponding [test result attestations] for all affected revisions. 
+They may then embed the `USER_SOURCE_UNIT_TESTED` tag in the
+[source summary attestations](#summary-attestation).
 Consumers would be able to establish the expectation that revisions on `main`
 have been united tested and determine if that expectation has been met by
 looking for the `USER_SOURCE_UNIT_TESTED` tag in the VSA and, if desired,

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -310,7 +310,7 @@ or if the revision was not the result of an accepted change management process.
 <td><td><td>✓<td>✓
 <tr id="change-management-process"><td>Enforced change management process<td>
 
-The SCS MUST ensure organization defined technical controls are enforced for
+The SCS MUST ensure organization-defined technical controls are enforced for
 changes made to protected branches.  It MUST also embed relevant metadata about
 these controls in the [source summary](#summary-attestation) and/or
 [source provenance](#provenance-attestations) attestations

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -332,7 +332,7 @@ The SCS MUST NOT allow organization specified tags to begin with any value other
 than `USER_SOURCE_` or `INTERNAL_USER_` unless the SCS endorses the veracity of
 any corresponding claims.
 
-Enforcement of the organization defined technical controls could be accomplished
+Enforcement of the organization-defined technical controls could be accomplished
 by, for example:
 
 -   The configuration of branch protection rules (e.g.[GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html)) which require additional checks to 'pass'

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -136,7 +136,7 @@ process to ensure changes to source matches the organization's intent.
 
 <tr id="specify-protection"><td>Specify which branches and tags are protected<td>
 
-The organization MUST indicated which branches and tags it protects with Source
+The organization MUST indicate which branches and tags it protects with Source
 Level 2+ controls.  Only those indicated branches and tags will be eligible for
 Source Level 2+.
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -421,15 +421,27 @@ SCSs that do not use cryptographic digests MUST define a canonical type that is 
     -   git references MUST be fully qualified (e.g. `refs/head/main` or `refs/tags/v1.0`) to reduce the likelihood of confusing downstream tooling.
 4.  `resourceUri` MUST be set to the URI of the repository, preferably using [SPDX Download Location](https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field).
 E.g. `git+https://github.com/foo/hello-world`.
-5.  `verifiedLevels` MUST include the SLSA source track level the verifier asserts the revision meets. One of `SLSA_SOURCE_LEVEL_0`, `SLSA_SOURCE_LEVEL_1`, `SLSA_SOURCE_LEVEL_2`, `SLSA_SOURCE_LEVEL_3`.
-MAY include additional properties as asserted by the verifier.  The verifier MUST include _only_ the highest SLSA source level met by the revision.
+5.  `verifiedLevels` MUST include the SLSA source track level the SCS asserts the revision meets. One of `SLSA_SOURCE_LEVEL_0`, `SLSA_SOURCE_LEVEL_1`, `SLSA_SOURCE_LEVEL_2`, `SLSA_SOURCE_LEVEL_3`.
+MAY include additional properties as asserted by the SCS.  The SCS MUST include _only_ the highest SLSA source level met by the revision.
 6.  `dependencyLevels` MAY be empty as source revisions are typically terminal nodes in a supply chain.
 
-Verifiers MAY issue these attestations based on their understanding of the underlying system (e.g. based on design docs, security reviews, etc...),
+The SCS MAY issue these attestations based on its understanding of the underlying system (e.g. based on design docs, security reviews, etc...),
 but at SLSA Source Level 3 MUST use tamper-proof [provenance attestations](#provenance-attestations) appropriate to their SCS when making the assessment.
 
 The SLSA source track MAY create additional tags to include in `verifiedLevels` which attest
-to other properties of a revision (e.g. if it was code reviewed).  All SLSA source tags will start with `SLSA_SOURCE_`.
+to other properties of a revision (e.g. if it was code reviewed).  All SLSA source tags will start with `SLSA_SOURCE_`.  Consumers MAY assume all SLSA source tags are meant
+
+The SCS MAY embed user-provided tags within `verifiedLevels` corresponding to
+technical controls enforced by the SCS if they are prefixed with:
+
+-   `USER_SOURCE_` to indicate a tag that is meant for consumption by external
+   consumers.
+-   `INTERNAL_USER_` to indicate a tag that is not meant for consumption by
+   external consumers.
+
+The meaning of the tags is left entirely to the organization. Inclusion of user
+provided tags within `verifiedLevels` SHOULD NOT be considered an endorsement of
+the veracity of the organization defined claim by the SCS.
 
 #### Populating source_refs
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -185,11 +185,11 @@ enforced for revisions in each branch using the
 For example, an organization may claim that revisions on `main` passed unit
 tests before being accepted.  The organization could then configure the SCS to
 enforce this requirement and store corresponding [test result attestations] for
-all affected revisions.  They may then embed the `USER_SOURCE_UNIT_TESTED`
+all affected revisions.  They may then embed the `ORG_SOURCE_UNIT_TESTED`
 property in the [source summary attestations](#summary-attestation). Consumers
 would then expect that future revisions on `main` have been united tested and
 determine if that expectation has been met by looking for the
-`USER_SOURCE_UNIT_TESTED` property in the VSAs and, if desired, consult the
+`ORG_SOURCE_UNIT_TESTED` property in the VSAs and, if desired, consult the
 [test result attestations] as well.
 
 [test result attestations]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
@@ -328,7 +328,7 @@ enforced.
    revision.
 
 The SCS MUST NOT allow organization specified properties to begin with any value
-other than `USER_SOURCE_` or `INTERNAL_USER_` unless the SCS endorses the
+other than `ORG_SOURCE_` or `INTERNAL_ORG_` unless the SCS endorses the
 veracity of any corresponding claims.
 
 Enforcement of the organization-defined technical controls could be accomplished
@@ -443,17 +443,19 @@ The SLSA source track MAY create additional properties to include in
 was code reviewed). All SLSA source properties will start with `SLSA_SOURCE_`.
 Consumers MAY assume all SLSA source properties are meant
 
-The SCS MAY embed user-provided properties within `verifiedLevels` corresponding to
-technical controls enforced by the SCS if they are prefixed with:
+The SCS MAY embed organization-provided properties within `verifiedLevels`
+corresponding to technical controls enforced by the SCS if they are prefixed
+with:
 
--   `USER_SOURCE_` to indicate a property that is meant for consumption by
+-   `ORG_SOURCE_` to indicate a property that is meant for consumption by
    external consumers.
--   `INTERNAL_USER_` to indicate a property that is not meant for consumption by
+-   `INTERNAL_ORG_` to indicate a property that is not meant for consumption by
    external consumers.
 
 The meaning of the properties is left entirely to the organization. Inclusion of
-user provided properties within `verifiedLevels` SHOULD NOT be considered an
-endorsement of the veracity of the organization defined property by the SCS.
+organization-provided properties within `verifiedLevels` SHOULD NOT be
+considered an endorsement of the veracity of the organization defined property
+by the SCS.
 
 #### Populating source_refs
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -27,7 +27,7 @@ Consumers can examine the various source provenance attestations to determine if
 | Source Provenance | Information about how a revision came to exist, where it was hosted, when it was generated, what process was used, who the contributors were, and what parent revisions it was based on.
 | Repository / Repo | A uniquely identifiable instance of a VCS. The repository controls access to the Source in the VCS. The objective of a repository is to reflect the intent of the organization that controls it.
 | Branch | A named, moveable, pointer to a revision that tracks development in the named context over time. Branches may be modified to point to different revisions by authorized actors. Different branches may have different security requirements.
-| Tag | A named pointer to a revision that does not typically move. Tags may be created (and sometimes modified) by authorized actors. Different tags may be used for different purposes (e.g. denote a specific version of the software, or the 'latest' release).
+| Tag | A named pointer to a revision that does not typically move. Similar to branches, tags may be modified by authorized actors. Tags are often used by producers to indicate a more permanent name for a revision.
 | Change | A set of modifications to the source in a specific context. A change can be proposed and reviewed before being accepted.
 | Change History | A record of the history of revisions that preceded a specific revision.
 | Push / upload / publish | When an actor authenticates to a Repository to add or modify content. Typically makes a new revision reachable from a branch.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -440,12 +440,11 @@ but at SLSA Source Level 3 MUST use tamper-proof [provenance attestations](#prov
 
 The SLSA source track MAY create additional properties to include in
 `verifiedLevels` which attest to other claims concerning a revision (e.g. if it
-was code reviewed). All SLSA source properties will start with `SLSA_SOURCE_`.
-Consumers MAY assume all SLSA source properties are meant
+was code reviewed).
 
 The SCS MAY embed organization-provided properties within `verifiedLevels`
-corresponding to technical controls enforced by the SCS if they are prefixed
-with:
+corresponding to technical controls enforced by the SCS. If such properties are
+provided they MUST be prefixed with:
 
 -   `ORG_SOURCE_` to indicate a property that is meant for consumption by
    external consumers.

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -156,7 +156,7 @@ Content changed under this process includes changing files, history, references,
 #### Warning
 
 Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact.
-For example, in VCSs like Git, removal of a revision changes the object IDs of all subsequent revisions that were built on top of it, breaking downstream consumers' ability to refer to source they've already integrated into their products.
+For example, in VCSs like Git, each revision ID is based on the ones before it. When you remove a revision, you must generate new revisions (and new revision IDs) for any revisions that were built on top of it. Consumers who took a dependency on the old revisions may now be unable to refer to the source they've already integrated into their products.
 
 It may be the case that the specific set of changes targeted by a legal takedown can be expunged in ways that do not impact consumed revisions, which can mitigate these problems.
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -26,7 +26,8 @@ Consumers can examine the various source provenance attestations to determine if
 | Source Control System (SCS) | A suite of tools and services (self-hosted or SaaS) relied upon by the organization to produce new revisions of the source. The role of the SCS may be fulfilled by a single service (e.g., GitHub / GitLab) or rely on a combination of services (e.g., GitLab with Gerrit code reviews, GitHub with OpenSSF Scorecard, etc).
 | Source Provenance | Information about how a revision came to exist, where it was hosted, when it was generated, what process was used, who the contributors were, and what parent revisions it was based on.
 | Repository / Repo | A uniquely identifiable instance of a VCS. The repository controls access to the Source in the VCS. The objective of a repository is to reflect the intent of the organization that controls it.
-| Branch | A named, moveable, pointer to a revision. Branches may be modified to point to different revisions by authorized actors. Different branches may have different security requirements.
+| Branch | A named, moveable, pointer to a revision that tracks development in the named context over time. Branches may be modified to point to different revisions by authorized actors. Different branches may have different security requirements.
+| Tag | A named pointer to a revision that does not typically move. Tags may be created (and sometimes modified) by authorized actors. Different tags may be used for different purposes (e.g. denote a specific version of the software, or the 'latest' release).
 | Change | A set of modifications to the source in a specific context. A change can be proposed and reviewed before being accepted.
 | Change History | A record of the history of revisions that preceded a specific revision.
 | Push / upload / publish | When an actor authenticates to a Repository to add or modify content. Typically makes a new revision reachable from a branch.


### PR DESCRIPTION
Require orgs to:

1. Specify which branches and tags are protected (L2+)
2. Specify what additional controls they want users to expect (L3+)

_Allow_ orgs to define properties to be included in the VSA to communicate which controls they've enabled.

Updated the 'Enforced change management process' to be require the SCS enforce the technical controls from #2.

Moved "safe expunging process" into this table (it was an org requirement anyways). Only requiring at L2+ because that's when branch continuity comes into play anyways (prior to that folks can technically make whatever changes they want to a repo).

fixes #1361