### PR TITLE
content: draft: Define the process for verifying source.

### DIFF
--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -35,8 +35,8 @@ Instead the source consumer checks:
 First, check the SLSA Source level by comparing the artifact to its VSA and the
 VSA to a preconfigured root of trust. The goal is to ensure that the VSA
 actually applies to the artifact in question and to assess the trustworthiness
-of the VSA. This mitigates some of the threats "B" and "C", depending on SLSA
-Build level.
+of the VSA. This mitigates threats within "B" and "C", depending on SLSA Source
+level.
 
 Once, when bootstrapping the verifier:
 

--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -121,9 +121,9 @@ fields:
 ## Forming Expectations
 
 <dfn>Expectations</dfn> are known values that indicate the corresponding
-revision is authentic. For example, an SCS package ecosystem may
-maintain a mapping between repository branch & tags and the controls they
-claim to implement. That mapping constitutes a set of expectations.
+revision is authentic. For example, an SCS may maintain a mapping between
+repository branches & tags and the controls they claim to implement. That
+mapping constitutes a set of expectations.
 
 Possible models for forming expectations include:
 

--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -42,9 +42,9 @@ Once, when bootstrapping the verifier:
 
 -   Configure the verifier's roots of trust, meaning the recognized SCS
     identities and the maximum SLSA Source level each SCS is trusted up to.
-    Different verifiers MAY use different roots of trust for repositories. This
-    configuration is likely in the form of a map from (SCS public key identity,
-    VSA `verifier.id`) to (SLSA Source level).
+    Different verifiers MAY use different roots of trust for repositories. The
+    root of trust configuration is likely in the form of a map from (SCS public
+    key identity, VSA `verifier.id`) to (SLSA Source level).
 
     <details>
     <summary>Example root of trust configuration</summary>

--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -17,7 +17,7 @@ VSA may be issued by a VSA provider to make a SLSA source level determination ba
 ## How to verify SLSA a source revision
 
 Verification of a source revision revolves around use of the [
-Verification Summary Attestation (VSA)](/spec/draft/source-requirements#summary-attestation)
+Verification Summary Attestation (VSA)]
 by the consumer of the source code.  This shields the consumer from the details
 of an SCS's bespoke provenance format, and from the specifics about the
 producers change management process.  Instead the source consumer checks:
@@ -26,6 +26,8 @@ producers change management process.  Instead the source consumer checks:
    revision they've fetched.
 2.  If the claims made in the VSA match their expectations for how the source
    should be managed.
+
+[Verification Summary Attestation (VSA)]: source-requirements#summary-attestation
 
 ### Step 1: Check the SCS
 

--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -42,8 +42,7 @@ Once, when bootstrapping the verifier:
 
 -   Configure the verifier's roots of trust, meaning the recognized SCS
     identities and the maximum SLSA Source level each SCS is trusted up to.
-    Different verifiers might use different roots of trust, but usually a
-    verifier uses the same roots of trust for all repositories. This
+    Different verifiers MAY use different roots of trust for repositories. This
     configuration is likely in the form of a map from (SCS public key identity,
     VSA `verifier.id`) to (SLSA Source level).
 

--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -16,11 +16,12 @@ VSA may be issued by a VSA provider to make a SLSA source level determination ba
 
 ## How to verify SLSA a source revision
 
-Verification of a source revision revolves around use of the [
-Verification Summary Attestation (VSA)]
-by the consumer of the source code.  This shields the consumer from the details
-of an SCS's bespoke provenance format, and from the specifics about the
-producers change management process.  Instead the source consumer checks:
+Verification of a source revision revolves around use of the
+[Verification Summary Attestation (VSA)] by the consumer of the source code.
+This shields the consumer from the details of an SCS's bespoke provenance
+format, and from the specifics about the producers change management process.
+
+Instead the source consumer checks:
 
 1.  If they trust the SCS that issued the VSA and if the VSA applies to the
    revision they've fetched.


### PR DESCRIPTION
This borrows _heavily_ from https://slsa.dev/spec/draft/verifying-artifacts attempting make changes where needed.

While we might think there is enough overlap that the two could share the same content, I think that's unlikely. There are enough cases where details differ that it would likely be more confusing.

This change DOES NOT include "Resulting threat mitigation" which is included in 'Step 1' of 'verifying-artifacts'.  We may want to include that in the future or we might prefer to leave it to the threats.md page.

refs #1356