### PR TITLE
fix: Company name nitpick in sprint blog by-line

### DIFF
--- a/docs/_posts/2025-04-29-slsa-source-sprint.md
+++ b/docs/_posts/2025-04-29-slsa-source-sprint.md
@@ -1,6 +1,6 @@
 ---
 title: Source Track Sprint Recap
-author: "Andrew McNamara (RedHat), Tom Hennen (Google), Zachariah Cox (GitHub)"
+author: "Andrew McNamara (Red Hat), Tom Hennen (Google), Zachariah Cox (GitHub)"
 is_guest_post: false
 ---
 


### PR DESCRIPTION
Use the official correct way to spell "Red Hat".

(See https://www.redhat.com/en/about/brand/standards/naming-and-trademarks about half way down under the "Referring to Red Hat" heading.)