### PR TITLE
content: draft: Merge change mgmt tool requirements with SCS

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -189,6 +189,18 @@ When source provenance is available the SCS MAY use it to generate the
 source summary attestation.
 
 <td>✓<td>✓<td>✓<td>✓
+<tr id="context"><td>Context<td>
+
+The SCS MUST record the specific code change (a "diff" in git) or instructions
+to recreate it. In git, this typically defined to be three revision IDs: the tip
+of the "topic" branch, the tip of the target branch, and closest shared ancestor
+between the two (such as determined by `git-merge-base`).
+
+The SCS MUST record the "target" context for the change and the previous
+revision in that context. For example, for the git version control system, the
+SCS MUST record the branch name that was updated.
+
+<td><td>✓<td>✓<td>✓
 <tr id="branches"><td>Protected Branches<td>
 
 The SCS MUST provide a mechanism for organizations to indicate which branches
@@ -313,26 +325,6 @@ Examples:
 -   Dependabot
 
 <td><td><td><td>✓
-</table>
-
-### Provide a change management tool
-
-The change management tool MUST be able to authoritatively state that each new revision reachable from the protected branch represents only the changes managed via the [process](#change-management-process).
-
-<table>
-<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
-
-<tr id="context"><td>Context<td>
-
-The change management tool MUST record the specific code change (a "diff" in git) or instructions to recreate it.
-In git, this typically defined to be three revision IDs: the tip of the "topic" branch, the tip of the target branch, and closest shared ancestor between the two (such as determined by `git-merge-base`).
-
-The change management tool MUST record the "target" context for the change proposal and the previous revision in that context.
-For example, for the git version control system, the change management tool MUST record the branch name that was updated.
-
-Branches may have differing security postures, and a change can be approved for one context while being unapproved for another.
-
-<td><td><td>✓<td>✓
 </table>
 
 ## Communicating source levels

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -333,12 +333,6 @@ For example, for the git version control system, the change management tool MUST
 Branches may have differing security postures, and a change can be approved for one context while being unapproved for another.
 
 <td><td><td>✓<td>✓
-<tr id="verified-timestamps"><td>Verified Timestamps<td>
-
-The change management tool MUST record timestamps for all contributions and review-related activities.
-User-provided timestamps MUST NOT be used.
-
-<td><td><td>✓<td>✓
 </table>
 
 ## Communicating source levels

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -192,7 +192,7 @@ source summary attestation.
 <tr id="context"><td>Context<td>
 
 The SCS MUST record the specific code change (a "diff" in git) or instructions
-to recreate it. In git, this typically defined to be three revision IDs: the tip
+to recreate it. In git, this is typically defined to be three revision IDs: the tip
 of the "topic" branch, the tip of the target branch, and closest shared ancestor
 between the two (such as determined by `git-merge-base`).
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -198,7 +198,7 @@ between the two (such as determined by `git-merge-base`).
 
 The SCS MUST record the "target" context for the change and the previous
 revision in that context. For example, for the git version control system, the
-SCS MUST record the branch name that was updated.
+SCS MUST record the branch name that was updated, its new revision and its previous revision.
 
 <td><td>✓<td>✓<td>✓
 <tr id="branches"><td>Protected Branches<td>


### PR DESCRIPTION
1. Removes the 'Verified timestamp' requirement as the SLSA Source track doesn't seem to be the right place to address this.
2. Moves the 'Context' requirement up to the "Source Control System" section.
3. Removes the "Branches may have differing security postures, and a change can be approved for one context while being unapproved for another." statement as it's a) explanation rather than requirement, b) covered by other requirements that talk about how some branches need to be protected and others don't.
4. Updated the 'Context' requirement to apply at Level 2 (instead of starting at Level 3) as I believe this is a fairly basic feature of VCSes.  AIUI this requirement isn't about storing this data in provenance, just making it available.  If it _is_ about what gets encoded in provenance, then we can move it there. :)

It's possible the language can use some additional tweaks for clarity, but I think it's better to address those separately.

fixes #1352 