### PR TITLE
editorial: Remove mention of conformance program

### DIFF
--- a/docs/spec/draft/verifying-artifacts.md
+++ b/docs/spec/draft/verifying-artifacts.md
@@ -53,8 +53,7 @@ Once, when bootstrapping the verifier:
     Different verifiers might use different roots of trust, but usually a
     verifier uses the same roots of trust for all packages. This configuration
     is likely in the form of a map from (builder public key identity,
-    `builder.id`) to (SLSA Build level) drawn from the SLSA Conformance
-    Program (coming soon).
+    `builder.id`) to (SLSA Build level).
 
     <details>
     <summary>Example root of trust configuration</summary>

--- a/docs/spec/v1.1/verifying-artifacts.md
+++ b/docs/spec/v1.1/verifying-artifacts.md
@@ -53,8 +53,7 @@ Once, when bootstrapping the verifier:
     Different verifiers might use different roots of trust, but usually a
     verifier uses the same roots of trust for all packages. This configuration
     is likely in the form of a map from (builder public key identity,
-    `builder.id`) to (SLSA Build level) drawn from the SLSA Conformance
-    Program (coming soon).
+    `builder.id`) to (SLSA Build level).
 
     <details>
     <summary>Example root of trust configuration</summary>


### PR DESCRIPTION
The 'conformance program' is no longer 'coming soon' so we shouldn't say that it is.

Updating both 1.1 (current) and draft.

As this doesn't change the meaning of the spec I've listed this as 'editorial' and I don't think we need (or should) increment the 1.1 version number.  If anyone thinks otherwise (or that we should just not update 1.1) LMK.

fixes #1364 