### PR TITLE
content: draft: MUST NOT be possible -> SCS MUST prevent

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -256,11 +256,11 @@ E.g. The organization may configure the SCS to protect `main` and
 <td><td>✓<td>✓<td>✓
 <tr id="continuity"><td>Branch Continuity<td>
 
-It MUST NOT be possible to rewrite the history of protected branches.
+The SCS MUST prevent rewriting the history of protected branches.
 In other words, if the organization updates a branch from commit A to commit B, commit B MUST be a descendant of A.
 For systems like GitHub or GitLab, this can be accomplished by enabling branch protection rules that prevent force pushes and branch deletions.
 
-It MUST NOT be possible to delete the entire repository (including all branches) and replace it with different source.
+The SCS MUST prevent deletion of the entire repository (including all branches) and replace it with different source.
 
 Continuity exceptions are allowed via the [safe expunging process](#safe-expunging-process).
 
@@ -272,8 +272,8 @@ taken to prevent unintentional changes.
 Unlike branches, tags have no built-in continuity enforcement mechanisms or
 change management processes.
 
-If a tag is used to identify a specific commit to external systems, it MUST NOT
-be possible to move or delete those tags.
+If a tag is used to identify a specific commit to external systems, the SCS MUST
+prevent those tags from being moved or deleted.
 
 <td><td>✓<td>✓<td>✓
 <tr id="identity-management"><td>Identity Management<td>


### PR DESCRIPTION
We have a couple of requirements in the source track that state "It MUST not be possible...". A strict reader might complain that even if there are protections in place that prevent this, it might still "be possible".

To avoid such complaints, and to make it somewhat more clear that these things could still happen, let's try rephrasing these to something like "The SCS MUST prevent...".

That should offer a bit more leeway.

fixes #1383