### PR TITLE
fix: Disable MD059 for old blog posts

### DIFF
--- a/docs/_posts/2022-06-20-slsa-github-workflows.md
+++ b/docs/_posts/2022-06-20-slsa-github-workflows.md
@@ -4,6 +4,8 @@ author: "Laurent Simon, Asra Ali, Ian Lewis, Mark Lodato, Jose Palafox, Joshua L
 is_guest_post: false
 ---
 
+<!-- markdownlint-disable MD059 -->
+
 A couple of months ago, Google and GitHub demonstrated how to generate non-forgeable SLSA 3 provenance for packages/binaries created via GitHub Actions ([1](https://security.googleblog.com/2022/04/improving-software-supply-chain.html), [2](https://github.blog/2022-04-07-slsa-3-compliance-with-github-actions/)). Since then, we've been working hard to turn the reference example into a production-ready system for everyone to use. Today, we're announcing the v1 release of the [trusted builders](https://github.com/slsa-framework/slsa-github-generator) that can be used in GitHub Actions and [verification tools](https://github.com/slsa-framework/slsa-verifier).
 
 As a reminder, [SLSA provenance](/provenance/) extends the principle of artifact signing. Where a signature endorses the final binary, provenance details exactly where and how the artifact was built. Generating SLSA 3 provenance ensures users can trust and verify an artifact's build integrity. By making this information available, you can help your users protect against attacks that tamper with the build process, such as changing the source material or uploading a modified binary that sidelined the authorized build recipe.

--- a/docs/_posts/2022-09-26-eo-in-plain-english.md
+++ b/docs/_posts/2022-09-26-eo-in-plain-english.md
@@ -4,6 +4,8 @@ author: "Isaac Hepworth"
 is_guest_post: true
 ---
 
+<!-- markdownlint-disable MD059 -->
+
 You may have heard about [EO 14028](https://www.whitehouse.gov/briefing-room/presidential-actions/2021/05/12/executive-order-on-improving-the-nations-cybersecurity/), the “Executive Order on Improving the Nation’s Cybersecurity”, which mandates the establishment of minimum supply chain security standards for all software consumed by the US government. On September 14th the White House Office of Management and Budget (OMB) issued [a memorandum](https://www.whitehouse.gov/wp-content/uploads/2022/09/M-22-18.pdf) setting firm and aggressive timelines for implementation of guidelines stemming from the EO, and you might reasonably be wondering what it all means. If so, this post is for you. We’re going to try to lay it out in plain English and share steps to help you get ready to meet the timelines
 
 ## Background


### PR DESCRIPTION
A linter upgrade created a new rule that's being broken by old content.

Disabling that rule for the content that violates that rule.