### PR TITLE
fix: remove left-over line

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -75,7 +75,6 @@ Allows source consumers to track changes to the software over time and attribute
 Summary:
 The SCS generates credible, tamper-resistant, and contemporaneous evidence of how a specific revision was created.
 It is provided to authorized users of the source repository in a documented format.
-of how a specific revision was created to authorized users of the source repository.
 
 Intended for:
 Organizations that want strong guarantees and auditability of their change management processes.


### PR DESCRIPTION
As I was reading through the source track draft I noticed an extra line that was left-over from some previous editing. This deletes it.