### PR TITLE
editorial: Update principles.md to align verbiage

### DIFF
--- a/docs/spec/v1.1/principles.md
+++ b/docs/spec/v1.1/principles.md
@@ -85,7 +85,7 @@ manual security analysis. Where possible:
 
 Securely trace all software back to source code rather than trust individuals who have write access to package registries.
 
-**Reasoning**: Code is static and analyzable. People, on the other hand, are prone to mistakes,
+**Reasoning**: Code is static and analyzable. Individuals, on the other hand, are prone to mistakes,
 credential compromise, and sometimes malicious action.
 
 **Benefits**: Removes the possibility for a trusted individual---or an


### PR DESCRIPTION
Aligning the verbiage, so that we consistently refer to users as 'individuals' rather than 'people'.

Per #1376, reviewing uses of the term's 'people' and 'person' In the principles section, we headline with the term 'individuals', but later refer to them as 'people'. This change replaces 'people' with 'individuals.