### PR TITLE
content: draft: More aggressively combine control requirements

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -145,10 +145,7 @@ The organization MUST use the SCS provided
 and roles that are allowed to perform sensitive actions on protected branches
 and tags.
 
-> For example, an organization may configure the SCS to:
->
-> 1.  Assign users to a `maintainers` role.
-> 2.  Only allow users in `maintainers` to make updates to `main`.
+> For example, an organization may configure the SCS to assign users to a `maintainers` role and only allow users in `maintainers` to make updates to `main`.
 
 The organization MUST specify what technical controls consumers can expect to be
 enforced for revisions in each protected branch and tag using the

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -128,6 +128,27 @@ process to ensure changes to source matches the organization's intent.
 
 <td><td>✓<td>✓<td>✓
 
+<tr id="specify-control-expectations"><td>Specify control expectations<td>
+
+The organization MUST specify what technical controls consumers can expect to be
+enforced for revisions in each branch using the
+[Enforced change management process](#enforced-change-management-process)
+and it MUST document the meaning of those controls.
+
+For example, an organization may claim that revisions on `main` passed unit
+tests before being accepted.  The organization could then configure the SCS to
+enforce this requirement and store corresponding [test result attestations] for
+all affected revisions.  They may then embed the `ORG_SOURCE_UNIT_TESTED`
+property in the [source summary attestations](#summary-attestation). Consumers
+would then expect that future revisions on `main` have been united tested and
+determine if that expectation has been met by looking for the
+`ORG_SOURCE_UNIT_TESTED` property in the VSAs and, if desired, consult the
+[test result attestations] as well.
+
+[test result attestations]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
+
+<td><td>✓<td>✓<td>✓
+
 <tr id="specify-protection"><td>Specify which branches and tags are protected<td>
 
 The organization MUST indicate which branches and tags it protects with Source
@@ -169,26 +190,6 @@ and regulations which may require the change to be kept private to the extent po
 Organizations SHOULD prefer to make logs public if possible.
 
 <td><td>✓<td>✓<td>✓
-
-<tr id="specify-control-expectations"><td>Specify control expectations<td>
-
-The organization MUST specify what technical controls consumers can expect to be
-enforced for revisions in each branch using the
-[Enforced change management process](#enforced-change-management-process).
-
-For example, an organization may claim that revisions on `main` passed unit
-tests before being accepted.  The organization could then configure the SCS to
-enforce this requirement and store corresponding [test result attestations] for
-all affected revisions.  They may then embed the `ORG_SOURCE_UNIT_TESTED`
-property in the [source summary attestations](#summary-attestation). Consumers
-would then expect that future revisions on `main` have been united tested and
-determine if that expectation has been met by looking for the
-`ORG_SOURCE_UNIT_TESTED` property in the VSAs and, if desired, consult the
-[test result attestations] as well.
-
-[test result attestations]: https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md
-
-<td><td><td>✓<td>✓
 
 </table>
 
@@ -247,6 +248,33 @@ should be protected by SLSA Source Level 2+ requirements.
 
 E.g. The organization may configure the SCS to protect `main` and
 `refs/heads/releases/*`, but not `refs/heads/playground/*`.
+
+<td><td>✓<td>✓<td>✓
+<tr id="enforced-change-management-process"><td>Enforced change management process<td>
+
+The SCS MUST
+
+-   Ensure organization-defined technical controls are enforced for changes made
+   to protected branches.
+-   Allow organizations to specify
+   [additional properties](#additional-properties) to be included in the
+   [source summary](#summary-attestation) when the corresponding controls are
+enforced.
+-   Allow organizations to distribute additional attestations related to their
+   technical controls to consumers authorized to access the corresponding source
+   revision.
+
+The SCS MUST NOT allow organization specified properties to begin with any value
+other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
+corresponding claims.
+
+Enforcement of the organization-defined technical controls could be accomplished
+by, for example:
+
+-   The configuration of branch protection rules (e.g.[GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html)) which require additional checks to 'pass'
+    (e.g. unit tests, linters), or
+-   the application and verification of [gittuf](https://github.com/gittuf/gittuf) policies, or
+-   some other mechanism as enforced by the [Change management tool](#change-management-tool-requirements).
 
 <td><td>✓<td>✓<td>✓
 <tr id="continuity"><td>Continuity<td>
@@ -318,33 +346,6 @@ provenance documents for relevant revisions.
 It is possible that an SCS can make no claims about a particular revision.
 For example, this would happen if the revision was created on another SCS,
 or if the revision was not the result of an accepted change management process.
-
-<td><td><td>✓<td>✓
-<tr id="enforced-change-management-process"><td>Enforced change management process<td>
-
-The SCS MUST
-
--   Ensure organization-defined technical controls are enforced for changes made
-   to protected branches.
--   Allow organizations to specify
-   [additional properties](#additional-properties) to be included in the
-   [source summary](#summary-attestation) when the corresponding controls are
-enforced.
--   Allow organizations to distribute additional attestations related to their
-   technical controls to consumers authorized to access the corresponding source
-   revision.
-
-The SCS MUST NOT allow organization specified properties to begin with any value
-other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
-corresponding claims.
-
-Enforcement of the organization-defined technical controls could be accomplished
-by, for example:
-
--   The configuration of branch protection rules (e.g.[GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html)) which require additional checks to 'pass'
-    (e.g. unit tests, linters), or
--   the application and verification of [gittuf](https://github.com/gittuf/gittuf) policies, or
--   some other mechanism as enforced by the [Change management tool](#change-management-tool-requirements).
 
 <td><td><td>✓<td>✓
 <tr id="two-party-review"><td>Two party review<td>

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -269,7 +269,7 @@ enforced.
    technical controls to consumers authorized to access the corresponding source
    revision.
 
-The SCS MUST NOT allow organization specified properties to begin with any value
+The SCS MUST prevent organization-specified properties from beginning with any value
 other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
 corresponding claims.
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -136,6 +136,11 @@ should be protected. From that point forward revisions on 'main' will be
 eligible for Source Level 2+ while revisions made solely on 'experimental' will
 not.
 
+The organization MUST use the SCS provided
+[Identity Management capability](#identity-management) to configure the actors
+and roles that are allowed to perform sensitive actions on protected branches
+and tags.
+
 The organization MUST specify what technical controls consumers can expect to be
 enforced for revisions in each protected branch and tag using the
 [Enforced change management process](#enforced-change-management-process)
@@ -310,16 +315,23 @@ The SCS MUST prevent protected tags from being moved or deleted.
 <td><td>✓<td>✓<td>✓
 <tr id="identity-management"><td>Identity Management<td>
 
-There exists an identity management system or some other means of identifying
-and authenticating actors. Depending on the SCS, identity management may be
-provided by source control services (e.g., GitHub, GitLab), implemented using
-cryptographic signatures (e.g., using gittuf to manage public keys for actors),
-or extend existing authentication systems used by the organization (e.g., Active
-Directory, Okta, etc.).
+The SCS MUST provide an identity management system or some other means of
+identifying and authenticating actors.
+
+The SCS MUST allow organizations to specify which actors and roles are allowed
+to perform sensitive actions within a repository (e.g. creation or updates of
+branches, approval of changes).
+
+Depending on the SCS, identity management may be provided by source control
+services (e.g., GitHub, GitLab), implemented using cryptographic signatures
+(e.g., using gittuf to manage public keys for actors), or extend existing
+authentication systems used by the organization (e.g., Active Directory, Okta,
+etc.).
 
 The SCS MUST document how actors are identified for the purposes of attribution.
 
-Activities conducted on the SCS SHOULD be attributed to authenticated identities.
+Activities conducted on the SCS SHOULD be attributed to authenticated
+identities.
 
 <td><td>✓<td>✓<td>✓
 <tr id="source-provenance"><td>Source Provenance<td>

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -146,8 +146,9 @@ and roles that are allowed to perform sensitive actions on protected branches
 and tags.
 
 > For example, an organization may configure the SCS to:
-> 1. Assign users to a `maintainers` role.
-> 2. Only allow users in `maintainers` to make updates to `main`.
+>
+> 1.  Assign users to a `maintainers` role.
+> 2.  Only allow users in `maintainers` to make updates to `main`.
 
 The organization MUST specify what technical controls consumers can expect to be
 enforced for revisions in each protected branch and tag using the

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -145,6 +145,10 @@ The organization MUST use the SCS provided
 and roles that are allowed to perform sensitive actions on protected branches
 and tags.
 
+> For example, an organization may configure the SCS to:
+> 1. Assign users to a `maintainers` role.
+> 2. Only allow users in `maintainers` to make updates to `main`.
+
 The organization MUST specify what technical controls consumers can expect to be
 enforced for revisions in each protected branch and tag using the
 [Enforced change management process](#enforced-change-management-process)

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -59,16 +59,20 @@ Intended for: Organizations currently storing source in non-standard ways who wa
 Benefits:
 Migrating to the appropriate tools is an important first step on the road to operational maturity.
 
-### Level 2: Branch History
+### Level 2: Controls
 
 Summary:
-Clarifies which branches in a repo are consumable and guarantees that all changes to protected branches are recorded.
+Clarifies which branches and tags in a repo are consumable and guarantees that
+all changes to protected branches and tags are recorded and subject to the
+organization's technical controls.
 
 Intended for:
 All organizations of any size producing software of any kind.
 
 Benefits:
-Allows source consumers to track changes to the software over time and attribute those changes to the people that made them.
+Allows organizations and source consumers the ability to ensure the change
+management process has been followed to track changes to the software over time
+and attribute those changes to the actors that made them.
 
 ### Level 3: Authenticatable and Auditable Provenance
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -115,27 +115,33 @@ Many examples in this document use the [git version control system](https://git-
 An organization producing source revisions MUST select a SCS capable of reaching
 their desired SLSA Source Level.
 
-For example, if an organization wishes to produce revisions at Source Level 3,
+> For example, if an organization wishes to produce revisions at Source Level 3,
 they MUST choose a source control system capable of producing Source Level 3
 attestations.
 
 <td>✓<td>✓<td>✓<td>✓
 
-<tr id="choose-process"><td>Choose an appropriate change management process<td>
+<tr id="protect-consumable-branches-and-tags"><td>Protect consumable branches and tags<td>
 
 An organization producing source revisions MUST implement a change management
 process to ensure changes to source matches the organization's intent.
 
-<td><td>✓<td>✓<td>✓
+The organization MUST specify which branches and tags are covered by the process
+and are intended for use in its own applications or services or those of
+downstream consumers of the software.
 
-<tr id="specify-control-expectations"><td>Specify control expectations<td>
+> For example, if an organization has branches 'main' and 'experimental' and it
+intends for 'main' to be protected then it MUST indicate to the SCS that 'main'
+should be protected. From that point forward revisions on 'main' will be
+eligible for Source Level 2+ while revisions made solely on 'experimental' will
+not.
 
 The organization MUST specify what technical controls consumers can expect to be
-enforced for revisions in each branch using the
+enforced for revisions in each protected branch and tag using the
 [Enforced change management process](#enforced-change-management-process)
 and it MUST document the meaning of those controls.
 
-For example, an organization may claim that revisions on `main` passed unit
+> For example, an organization may claim that revisions on `main` passed unit
 tests before being accepted.  The organization could then configure the SCS to
 enforce this requirement and store corresponding [test result attestations] for
 all affected revisions.  They may then embed the `ORG_SOURCE_UNIT_TESTED`
@@ -149,19 +155,6 @@ determine if that expectation has been met by looking for the
 
 <td><td>✓<td>✓<td>✓
 
-<tr id="specify-protection"><td>Specify which branches and tags are protected<td>
-
-The organization MUST indicate which branches and tags it protects with Source
-Level 2+ controls.
-
-For example, if an organization has branches 'main' and 'experimental' and it
-intends for 'main' to be protected then it MUST indicate to the SCS that 'main'
-should be protected. From that point forward revisions on 'main' will be
-eligible for Source Level 2+ while revisions made solely on 'experimental' will
-not.
-
-<td><td>✓<td>✓<td>✓
-
 <tr id="safe-expunging-process"><td>Safe Expunging Process<td>
 
 SCSs MAY allow the organization to expunge (remove) content from a repository and its change history without leaving a public record of the removed content,
@@ -171,7 +164,7 @@ Content changed under this process includes changing files, history, references,
 #### Warning
 
 Removing a revision from a repository is similar to deleting a package version from a registry: it's almost impossible to estimate the amount of downstream supply chain impact.
-For example, in VCSs like Git, each revision ID is based on the ones before it. When you remove a revision, you must generate new revisions (and new revision IDs) for any revisions that were built on top of it. Consumers who took a dependency on the old revisions may now be unable to refer to the source they've already integrated into their products.
+> For example, in VCSs like Git, each revision ID is based on the ones before it. When you remove a revision, you must generate new revisions (and new revision IDs) for any revisions that were built on top of it. Consumers who took a dependency on the old revisions may now be unable to refer to the source they've already integrated into their products.
 
 It may be the case that the specific set of changes targeted by a legal takedown can be expunged in ways that do not impact consumed revisions, which can mitigate these problems.
 
@@ -237,7 +230,8 @@ of the "topic" branch, the tip of the target branch, and closest shared ancestor
 between the two (such as determined by `git-merge-base`).
 
 The SCS MUST record the "target" context for the change and the previous
-revision in that context. For example, for the git version control system, the
+revision in that context.
+> For example, for the git version control system, the
 SCS MUST record the branch name that was updated, its new revision and its previous revision.
 
 <td><td>✓<td>✓<td>✓
@@ -268,13 +262,13 @@ The SCS MUST NOT allow organization specified properties to begin with any value
 other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
 corresponding claims.
 
-Enforcement of the organization-defined technical controls could be accomplished
-by, for example:
-
--   The configuration of branch protection rules (e.g.[GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html)) which require additional checks to 'pass'
+> For example: enforcement of the organization-defined technical controls could be accomplished
+by:
+>
+> -   The configuration of branch protection rules (e.g.[GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html)) which require additional checks to 'pass'
     (e.g. unit tests, linters), or
--   the application and verification of [gittuf](https://github.com/gittuf/gittuf) policies, or
--   some other mechanism as enforced by the [Change management tool](#change-management-tool-requirements).
+> -   the application and verification of [gittuf](https://github.com/gittuf/gittuf) policies, or
+> -   some other mechanism as enforced by the [Change management tool](#change-management-tool-requirements).
 
 <td><td>✓<td>✓<td>✓
 <tr id="continuity"><td>Continuity<td>
@@ -344,7 +338,8 @@ If a consumer is authorized to access, they MUST be able to fetch the source
 provenance documents for relevant revisions.
 
 It is possible that an SCS can make no claims about a particular revision.
-For example, this would happen if the revision was created on another SCS,
+
+> For example, this would happen if the revision was created on another SCS,
 or if the revision was not the result of an accepted change management process.
 
 <td><td><td>✓<td>✓

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -246,32 +246,42 @@ revision in that context.
 SCS MUST record the branch name that was updated, its new revision and its previous revision.
 
 <td><td>✓<td>✓<td>✓
-<tr id="branches"><td>Protected Branches<td>
+<tr id="protect-branches-and-tags"><td>Protect branches and tags<td>
 
 The SCS MUST provide a mechanism for organizations to indicate which branches
-should be protected by SLSA Source Level 2+ requirements.
+and tags are protected by the change management process.
 
-E.g. The organization may configure the SCS to protect `main` and
+> For example the organization may configure the SCS to protect `main` and
 `refs/heads/releases/*`, but not `refs/heads/playground/*`.
 
-<td><td>✓<td>✓<td>✓
-<tr id="enforced-change-management-process"><td>Enforced change management process<td>
+_History:_
 
-The SCS MUST
+The SCS MUST prevent tampering with or deleting the history of revisions on
+protected branches and it MUST prevent the entire repository from being deleted
+and replaced by different source.
 
--   Ensure organization-defined technical controls are enforced for changes made
+The SCS MUST prevent protected tags from being moved or deleted.
+
+> For example on systems like GitHub or GitLab, this can be accomplished by
+enabling branch and protection rules that prevent force pushes, deletions,
+and updates as needed.
+
+_Organization defined controls:_
+
+The SCS MUST ...
+
+-  Ensure organization-defined technical controls are enforced for changes made
    to protected branches.
--   Allow organizations to specify
+-  Allow organizations to specify
    [additional properties](#additional-properties) to be included in the
    [source summary](#summary-attestation) when the corresponding controls are
 enforced.
--   Allow organizations to distribute additional attestations related to their
+-  Allow organizations to distribute additional attestations related to their
    technical controls to consumers authorized to access the corresponding source
    revision.
-
-The SCS MUST prevent organization-specified properties from beginning with any value
-other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
-corresponding claims.
+-  Prevent organization-specified properties from beginning with any value
+   other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
+   corresponding claims.
 
 > For example: enforcement of the organization-defined technical controls could be accomplished
 by:
@@ -281,42 +291,13 @@ by:
 > -   the application and verification of [gittuf](https://github.com/gittuf/gittuf) policies, or
 > -   some other mechanism as enforced by the [Change management tool](#change-management-tool-requirements).
 
-<td><td>✓<td>✓<td>✓
-<tr id="continuity"><td>Continuity<td>
+_Continuity:_
+The SCS MUST establish the continuity of these controls from a specific
+revision. If there is a lapse in continuity for any control, that continuity
+MUST be re-established from a new revision.
 
-Revisions are created by applying a specific code change (a "diff" in git) on
-top of an earlier revision of a branch. The SCS MUST prevent tampering with the
-history of revisions on protected branches.
-
-In other words, if the organization updates a branch from commit A to commit B,
-commit B MUST be a descendant of A. For systems like GitHub or GitLab, this can
-be accomplished by enabling branch protection rules that prevent force pushes
-and branch deletions.
-
-The SCS MUST prevent the entire repository (including all branches) from being
-deleted and replaced by different source.
-
-Continuity MUST be established and tracked from a specific revision. If there is
-a lapse in continuity for a specific control, that continuity MUST be
-re-established from a new revision.
-
-Continuity MUST also apply to any [change management processes](#enforced-change-management-process)
-which are enforced on the protected branches.
-
-Continuity exceptions are allowed via the [safe expunging process](#safe-expunging-process).
-
-<td><td>✓<td>✓<td>✓
-<tr id="protected-tags"><td>Protected Tags<td>
-
-If the SCS supports tags (or other non-branch revision trackers), additional
-care must be taken to prevent unintentional changes.
-Unlike branches, tags have no built-in continuity enforcement mechanisms or
-change management processes.
-
-The SCS MUST provide a mechanism for organizations to indicate which tags should
-be protected by SLSA Source Level 2+ requirements.
-
-The SCS MUST prevent protected tags from being moved or deleted.
+Continuity exceptions are allowed via the
+[safe expunging process](#safe-expunging-process).
 
 <td><td>✓<td>✓<td>✓
 <tr id="identity-management"><td>Identity Management<td>

--- a/docs/spec/draft/threats.md
+++ b/docs/spec/draft/threats.md
@@ -189,7 +189,7 @@ does enforce any controls. They then update the `release_1.2` tag to point to
 Source Control System does not allow protected tags to be updated.
 
 </details>
-<details><summary>Skip required checks<span>(Source L3+)</span></summary>
+<details><summary>Skip required checks<span>(Source L2+)</span></summary>
 
 *Threat:* Code is submitted without following the producers documented
 development process, introducing unintended behavior.


### PR DESCRIPTION
This builds on https://github.com/slsa-framework/slsa/pull/1395 to further combine the SCS's control related requirements.

This is fairly aggressive but I think the gist is what we're looking for?  "Protected branches and tags have the change management process followed, their history and semantic meaning are maintained."
