### PR TITLE
editorial: draft: Fix formatting in "Enforced Change Management Process"

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -267,18 +267,17 @@ enforced.
 -   Allow organizations to distribute additional attestations related to their
    technical controls to consumers authorized to access the corresponding source
    revision.
+-   Prevent organization-specified properties from beginning with any value
+   other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
+   corresponding claims.
 
-The SCS MUST prevent organization-specified properties from beginning with any value
-other than `ORG_SOURCE_` unless the SCS endorses the veracity of the
-corresponding claims.
-
-> For example: enforcement of the organization-defined technical controls could be accomplished
-by:
->
-> -   The configuration of branch protection rules (e.g.[GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets), [GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html)) which require additional checks to 'pass'
-    (e.g. unit tests, linters), or
-> -   the application and verification of [gittuf](https://github.com/gittuf/gittuf) policies, or
-> -   some other mechanism as enforced by the [Change management tool](#change-management-tool-requirements).
+> For example: enforcement of the organization-defined technical controls could
+be accomplished by the configuration of branch protection rules (e.g.
+[GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets),
+[GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html))
+which require additional checks to 'pass' (e.g. unit tests, linters) or the
+application and verification of [gittuf](https://github.com/gittuf/gittuf)
+policies.
 
 <td><td>✓<td>✓<td>✓
 <tr id="continuity"><td>Continuity<td>


### PR DESCRIPTION
fixes #1410

* Example doesn't use bullets anymore. (should fix rendering issue)
* Example dropped reference to "some other mechanism as enforced by the Change management tool."
  * The referenced tool doesn't exist anymore.
  * The example doesn't need to be exhaustive, so it should be fine to remove.
* Added "The SCS MUST prevent organization-specified" to the other bulleted list.
  * Makes it more cohesive with the other requirements
  * Makes it more clear the example applies to the list, not just the "MUST prevent ..." language.