### PR TITLE
fix: fix broken 'provenance model' link in 1.0, 1.1, draft, RCs

### DIFF
--- a/docs/spec/draft/verifying-systems.md
+++ b/docs/spec/draft/verifying-systems.md
@@ -78,10 +78,11 @@ and outputs.
 ![image](images/build-model.svg)
 
 The following sections detail these elements of the build model and give prompts
-for assessing a build platform's ability to produce SLSA Build L3 provenance. The
-assessment SHOULD take into account the security model used to identify the
-transitive closure of the `builder.id` for the [provenance model], specifically
-around the platform's boundaries, actors, and interfaces.
+for assessing a build platform's ability to produce SLSA Build L3 provenance.
+The assessment SHOULD take into account the security model used to identify the
+transitive closure of the `builder.id` for the
+[provenance model](build-provenance.md#model), specifically around the
+platform's boundaries, actors, and interfaces.
 
 ### External parameters
 

--- a/docs/spec/v1.0/verifying-systems.md
+++ b/docs/spec/v1.0/verifying-systems.md
@@ -80,7 +80,7 @@ and outputs.
 The following sections detail these elements of the build model and give prompts
 for assessing a build platform's ability to produce SLSA Build L3 provenance. The
 assessment SHOULD take into account the security model used to identify the
-transitive closure of the `builder.id` for the [provenance model], specifically
+transitive closure of the `builder.id` for the [provenance model](provenance.md#model), specifically
 around the platform's boundaries, actors, and interfaces.
 
 ### External parameters

--- a/docs/spec/v1.1-rc1/verifying-systems.md
+++ b/docs/spec/v1.1-rc1/verifying-systems.md
@@ -80,7 +80,7 @@ and outputs.
 The following sections detail these elements of the build model and give prompts
 for assessing a build platform's ability to produce SLSA Build L3 provenance. The
 assessment SHOULD take into account the security model used to identify the
-transitive closure of the `builder.id` for the [provenance model], specifically
+transitive closure of the `builder.id` for the [provenance model](provenance.md#model), specifically
 around the platform's boundaries, actors, and interfaces.
 
 ### External parameters

--- a/docs/spec/v1.1-rc2/verifying-systems.md
+++ b/docs/spec/v1.1-rc2/verifying-systems.md
@@ -80,7 +80,7 @@ and outputs.
 The following sections detail these elements of the build model and give prompts
 for assessing a build platform's ability to produce SLSA Build L3 provenance. The
 assessment SHOULD take into account the security model used to identify the
-transitive closure of the `builder.id` for the [provenance model], specifically
+transitive closure of the `builder.id` for the [provenance model](provenance.md#model), specifically
 around the platform's boundaries, actors, and interfaces.
 
 ### External parameters

--- a/docs/spec/v1.1/verifying-systems.md
+++ b/docs/spec/v1.1/verifying-systems.md
@@ -80,7 +80,7 @@ and outputs.
 The following sections detail these elements of the build model and give prompts
 for assessing a build platform's ability to produce SLSA Build L3 provenance. The
 assessment SHOULD take into account the security model used to identify the
-transitive closure of the `builder.id` for the [provenance model], specifically
+transitive closure of the `builder.id` for the [provenance model](provenance.md#model), specifically
 around the platform's boundaries, actors, and interfaces.
 
 ### External parameters


### PR DESCRIPTION
fixes #1389

This link was broken pretty pervasively.  This should fix things ~everywhere.

Just a fix as no content was changed.