### PR TITLE
content: draft: Update VSA spec to handle SLSA levels beyond the build track

### DIFF
--- a/docs/spec/draft/verification_summary.md
+++ b/docs/spec/draft/verification_summary.md
@@ -373,13 +373,18 @@ verifiers they add to their roots of trust.
 </div>
 
 The result of evaluating an artifact (or set of artifacts) against SLSA.
-SHOULD be one of these values:
+SHOULD be the [SLSA Track](#tracks) level the referenced artifact meant as
+`SLSA_<TRACK_NAME>_LEVEL_<LEVEL_NUMBER>` or
+`SLSA_<TRACK NAME>_LEVEL_UNEVALUATED` if the VSA issuer does not want to make
+a statement about the track level an artifact meets.
+
+For example:
 
 -   `SLSA_BUILD_LEVEL_UNEVALUATED`
 -   `SLSA_BUILD_LEVEL_0`
--   `SLSA_BUILD_LEVEL_1`
--   `SLSA_BUILD_LEVEL_2`
 -   `SLSA_BUILD_LEVEL_3`
+-   `SLSA_SOURCE_LEVEL_2`
+-   `SLSA_SOURCE_LEVEL_4`
 -   `FAILED` (Indicates policy evaluation failed)
 
 Note that each SLSA level implies the levels below it in the same track.
@@ -391,6 +396,8 @@ Users MAY use custom values here but MUST NOT use custom values starting with
 
 ## Change history
 
+-   1.2:
+    -   Update SlsaResult definition to discuss how to refer to new tracks.
 -   1.1:
     -   Changed the `policy` object to recommend that the `digest` field of
         the `ResourceDescriptor` is set.

--- a/docs/spec/draft/verification_summary.md
+++ b/docs/spec/draft/verification_summary.md
@@ -401,7 +401,9 @@ Users MAY use custom values here but MUST NOT use custom values starting with
 ## Change history
 
 -   1.2:
-    -   Update SlsaResult definition to discuss how to refer to new tracks.
+    -   Update SlsaResult definition to discuss how to refer to new tracks and
+        link to [verified properties](verified-properties) for additional SLSA
+        endorsed values.
 -   1.1:
     -   Changed the `policy` object to recommend that the `digest` field of
         the `ResourceDescriptor` is set.

--- a/docs/spec/draft/verification_summary.md
+++ b/docs/spec/draft/verification_summary.md
@@ -373,10 +373,14 @@ verifiers they add to their roots of trust.
 </div>
 
 The result of evaluating an artifact (or set of artifacts) against SLSA.
-SHOULD be the [SLSA Track](#tracks) level the referenced artifact meant as
-`SLSA_<TRACK_NAME>_LEVEL_<LEVEL_NUMBER>` or
-`SLSA_<TRACK NAME>_LEVEL_UNEVALUATED` if the VSA issuer does not want to make
-a statement about the track level an artifact meets.
+SHOULD be
+
+-   The [SLSA Track](#tracks) level the referenced artifact qualifies for as
+`SLSA_<TRACK_NAME>_LEVEL_<LEVEL_NUMBER>`, or
+-   `SLSA_<TRACK NAME>_LEVEL_UNEVALUATED` if the VSA issuer does not want to
+    make a claim about the track level an artifact meets, or
+-   The SLSA [verified property](verified-properties) the referenced artifact
+    qualifies for.
 
 For example:
 


### PR DESCRIPTION
This basically follows the same strategy as before but provides a formula
instead of a full enumeration and links to verified-properties.md for
additional SLSA_ values.

I've decided _not_ to include a prohibition on `ORG_` prefixed policies because
the SlsaResult documentation already tells users (i.e. VSA issuers) that they
MAY use custom values as long as they don't start with `SLSA_`. `ORG_`
prefixed values, as they're defined by the organization, _are_ custom values
so it seems we're already aligned with the spec.  We're also not trying to
establish (within SLSA) any specific meaning for these ORG properties.
That's left to the org itself to document.

fixes https://github.com/slsa-framework/slsa/issues/1369