### PR TITLE
content: draft: Retitle pages/nav to be track aware

### DIFF
--- a/docs/_data/nav/draft.yml
+++ b/docs/_data/nav/draft.yml
@@ -65,21 +65,33 @@
     url: /spec/draft/provenance
     description: Provides a description of the concept of provenance and links to the various tracks specific definitions.
 
-  - title: Producing artifacts
+  - title: Build: Producing artifacts
     url: /spec/draft/build-requirements
     description: Detailed technical requirements for producing software artifacts, intended for platform implementers
 
-  - title: Distributing provenance
+  - title: Build: Distributing provenance
     url: /spec/draft/distributing-provenance
     description: Detailed technical requirements for distributing provenance, intended for platform implementers and software distributors
 
-  - title: Verifying artifacts
+  - title: Build: Verifying artifacts
     url: /spec/draft/verifying-artifacts
     description: Guidance for verifying software artifacts and their SLSA provenance, intended for platform implementers and software consumers
 
-  - title: Assessing build platforms
+  - title: Build: Assessing platforms
     url: /spec/draft/assessing-build-platforms
     description: Guidelines for securing SLSA Build L3+ builders, intended for platform implementers
+
+  - title: Source: Producing source
+    url: /spec/draft/source-requirements
+    description: Overview of the Source track
+
+  - title: Source: Verifying source
+    url: /spec/draft/verifying-source
+    description: Guidelines for verifying source provenance
+
+  - title: Source: Assessing source control systems
+    url: /spec/draft/assessing-source-systems
+    description: Guidelines for assessing source control system security.    
 
   - title: Attesting build environments
     url: /spec/draft/build-env-track-basics
@@ -88,18 +100,6 @@
   - title: Threats & mitigations
     url: /spec/draft/threats
     description: Detailed information about specific supply chain attacks and how SLSA helps
-
-  - title: Securing source code
-    url: /spec/draft/source-requirements
-    description: Overview of the Source track
-
-  - title: Verifying source code
-    url: /spec/draft/verifying-source
-    description: Guidelines for verifying source provenance
-
-  - title: Assessing source control systems
-    url: /spec/draft/assessing-source-systems
-    description: Guidelines for assessing source control system security.
 
   - title: Verified Properties
     url: /spec/draft/verified-properties

--- a/docs/_data/nav/draft.yml
+++ b/docs/_data/nav/draft.yml
@@ -65,27 +65,27 @@
     url: /spec/draft/provenance
     description: Provides a description of the concept of provenance and links to the various tracks specific definitions.
 
-  - title: Build: Producing artifacts
+  - title: "Build: Producing artifacts"
     url: /spec/draft/build-requirements
     description: Detailed technical requirements for producing software artifacts, intended for platform implementers
 
-  - title: Build: Distributing provenance
+  - title: "Build: Distributing provenance"
     url: /spec/draft/distributing-provenance
     description: Detailed technical requirements for distributing provenance, intended for platform implementers and software distributors
 
-  - title: Build: Verifying artifacts
+  - title: "Build: Verifying artifacts"
     url: /spec/draft/verifying-artifacts
     description: Guidance for verifying software artifacts and their SLSA provenance, intended for platform implementers and software consumers
 
-  - title: Build: Assessing platforms
+  - title: "Build: Assessing platforms"
     url: /spec/draft/assessing-build-platforms
     description: Guidelines for securing SLSA Build L3+ builders, intended for platform implementers
 
-  - title: Source: Producing source
+  - title: "Source: Producing source"
     url: /spec/draft/source-requirements
     description: Overview of the Source track
 
-  - title: Source: Verifying source
+  - title: "Source: Verifying source"
     url: /spec/draft/verifying-source
     description: Guidelines for verifying source provenance
 

--- a/docs/_data/nav/draft.yml
+++ b/docs/_data/nav/draft.yml
@@ -89,7 +89,7 @@
     url: /spec/draft/verifying-source
     description: Guidelines for verifying source provenance
 
-  - title: Source: Assessing source control systems
+  - title: "Source: Assessing source control systems"
     url: /spec/draft/assessing-source-systems
     description: Guidelines for assessing source control system security.    
 

--- a/docs/_data/nav/main.yml
+++ b/docs/_data/nav/main.yml
@@ -268,27 +268,27 @@
       url: /spec/draft/provenance
       description: Provides a description of the concept of provenance and links to the various tracks specific definitions.
 
-    - title: Build: Producing artifacts
+    - title: "Build: Producing artifacts"
       url: /spec/draft/build-requirements
       description: Detailed technical requirements for producing software artifacts, intended for platform implementers
 
-    - title: Build: Distributing provenance
+    - title: "Build: Distributing provenance"
       url: /spec/draft/distributing-provenance
       description: Detailed technical requirements for distributing provenance, intended for platform implementers and software distributors
 
-    - title: Build: Verifying artifacts
+    - title: "Build: Verifying artifacts"
       url: /spec/draft/verifying-artifacts
       description: Guidance for verifying software artifacts and their SLSA provenance, intended for platform implementers and software consumers
 
-    - title: Build: Assessing platforms
+    - title: "Build: Assessing platforms"
       url: /spec/draft/assessing-build-platforms
       description: Guidelines for securing SLSA Build L3+ builders, intended for platform implementers
 
-    - title: Source: Producing source
+    - title: "Source: Producing source"
       url: /spec/draft/source-requirements
       description: Overview of the Source track
 
-    - title: Source: Verifying source
+    - title: "Source: Verifying source"
       url: /spec/draft/verifying-source
       description: Guidelines for verifying source provenance
 

--- a/docs/_data/nav/main.yml
+++ b/docs/_data/nav/main.yml
@@ -292,7 +292,7 @@
       url: /spec/draft/verifying-source
       description: Guidelines for verifying source provenance
 
-    - title: Source: Assessing source control systems
+    - title: "Source: Assessing source control systems"
       url: /spec/draft/assessing-source-systems
       description: Guidelines for assessing source control system security. 
 

--- a/docs/_data/nav/main.yml
+++ b/docs/_data/nav/main.yml
@@ -268,21 +268,33 @@
       url: /spec/draft/provenance
       description: Provides a description of the concept of provenance and links to the various tracks specific definitions.
 
-    - title: Producing artifacts
+    - title: Build: Producing artifacts
       url: /spec/draft/build-requirements
       description: Detailed technical requirements for producing software artifacts, intended for platform implementers
 
-    - title: Distributing provenance
+    - title: Build: Distributing provenance
       url: /spec/draft/distributing-provenance
       description: Detailed technical requirements for distributing provenance, intended for platform implementers and software distributors
 
-    - title: Verifying artifacts
+    - title: Build: Verifying artifacts
       url: /spec/draft/verifying-artifacts
       description: Guidance for verifying software artifacts and their SLSA provenance, intended for platform implementers and software consumers
 
-    - title: Assessing build platforms
+    - title: Build: Assessing platforms
       url: /spec/draft/assessing-build-platforms
       description: Guidelines for securing SLSA Build L3+ builders, intended for platform implementers
+
+    - title: Source: Producing source
+      url: /spec/draft/source-requirements
+      description: Overview of the Source track
+
+    - title: Source: Verifying source
+      url: /spec/draft/verifying-source
+      description: Guidelines for verifying source provenance
+
+    - title: Source: Assessing source control systems
+      url: /spec/draft/assessing-source-systems
+      description: Guidelines for assessing source control system security. 
 
     - title: Attesting build environments
       url: /spec/draft/build-env-track-basics
@@ -291,18 +303,6 @@
     - title: Threats & mitigations
       url: /spec/draft/threats
       description: Detailed information about specific supply chain attacks and how SLSA helps
-
-    - title: Securing source code
-      url: /spec/draft/source-requirements
-      description: Overview of the Source track
-
-    - title: Verifying source code
-      url: /spec/draft/verifying-source
-      description: Guidelines for verifying source provenance
-
-    - title: Assessing source control systems
-      url: /spec/draft/assessing-source-systems
-      description: Guidelines for assessing source control system security.
 
     - title: Verified Properties
       url: /spec/draft/verified-properties

--- a/docs/spec/draft/assessing-build-platforms.md
+++ b/docs/spec/draft/assessing-build-platforms.md
@@ -1,5 +1,5 @@
 ---
-title: Build: Verifying build platforms
+title: "Build: Assessing build platforms"
 description: Guidelines for assessing build platform security.
 ---
 

--- a/docs/spec/draft/assessing-build-platforms.md
+++ b/docs/spec/draft/assessing-build-platforms.md
@@ -1,5 +1,5 @@
 ---
-title: Verifying build platforms
+title: Build: Verifying build platforms
 description: Guidelines for assessing build platform security.
 ---
 

--- a/docs/spec/draft/assessing-source-systems.md
+++ b/docs/spec/draft/assessing-source-systems.md
@@ -1,5 +1,5 @@
 ---
-title: Assessing source control systems
+title: "Source: Assessing source control systems"
 description: Guidelines for assessing source control system security.
 ---
 

--- a/docs/spec/draft/build-provenance.md
+++ b/docs/spec/draft/build-provenance.md
@@ -1,5 +1,5 @@
 ---
-title: Build: Provenance
+title: "Build: Provenance"
 description: Description of SLSA build provenance specification for verifying where, when, and how something was produced.
 layout: standard
 ---

--- a/docs/spec/draft/build-provenance.md
+++ b/docs/spec/draft/build-provenance.md
@@ -1,5 +1,5 @@
 ---
-title: Build Provenance
+title: Build: Provenance
 description: Description of SLSA build provenance specification for verifying where, when, and how something was produced.
 layout: standard
 ---

--- a/docs/spec/draft/build-requirements.md
+++ b/docs/spec/draft/build-requirements.md
@@ -1,5 +1,5 @@
 ---
-title: Build: Requirements for producing artifacts
+title: "Build: Requirements for producing artifacts"
 description: This page covers the detailed technical requirements for producing artifacts at each SLSA level. The intended audience is platform implementers and security engineers.
 ---
 

--- a/docs/spec/draft/build-requirements.md
+++ b/docs/spec/draft/build-requirements.md
@@ -1,5 +1,5 @@
 ---
-title: Producing artifacts
+title: Build: Requirements for producing artifacts
 description: This page covers the detailed technical requirements for producing artifacts at each SLSA level. The intended audience is platform implementers and security engineers.
 ---
 

--- a/docs/spec/draft/build-track-basics.md
+++ b/docs/spec/draft/build-track-basics.md
@@ -1,5 +1,5 @@
 ---
-title: Build Track Level Basics
+title: Build: Track Basics
 description: The SLSA build track is organized into a series of levels that provide increasing supply chain security guarantees. This gives you confidence that software hasn’t been tampered with and can be securely traced back to its source. This page is a descriptive overview of the SLSA build track levels, describing their intent.
 ---
 

--- a/docs/spec/draft/build-track-basics.md
+++ b/docs/spec/draft/build-track-basics.md
@@ -1,5 +1,5 @@
 ---
-title: Build: Track Basics
+title: "Build: Track Basics"
 description: The SLSA build track is organized into a series of levels that provide increasing supply chain security guarantees. This gives you confidence that software hasn’t been tampered with and can be securely traced back to its source. This page is a descriptive overview of the SLSA build track levels, describing their intent.
 ---
 

--- a/docs/spec/draft/distributing-provenance.md
+++ b/docs/spec/draft/distributing-provenance.md
@@ -1,5 +1,5 @@
 ---
-title: Distributing provenance
+title: Build: Distributing provenance
 description: This page covers the detailed technical requirements for distributing provenance at each SLSA level. The intended audience is platform implementers and software distributors.
 ---
 

--- a/docs/spec/draft/distributing-provenance.md
+++ b/docs/spec/draft/distributing-provenance.md
@@ -1,5 +1,5 @@
 ---
-title: Build: Distributing provenance
+title: "Build: Distributing provenance"
 description: This page covers the detailed technical requirements for distributing provenance at each SLSA level. The intended audience is platform implementers and software distributors.
 ---
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -1,4 +1,7 @@
-# SLSA Source Track
+---
+title: Source: Requirements for producing source
+description: This page covers the detailed technical requirements for producing producing source revisions at each SLSA level. The intended audience is source control system implementers and security engineers.
+---
 
 ## Objective
 

--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -1,5 +1,5 @@
 ---
-title: Source: Requirements for producing source
+title: "Source: Requirements for producing source"
 description: This page covers the detailed technical requirements for producing producing source revisions at each SLSA level. The intended audience is source control system implementers and security engineers.
 ---
 

--- a/docs/spec/draft/verifying-artifacts.md
+++ b/docs/spec/draft/verifying-artifacts.md
@@ -1,5 +1,5 @@
 ---
-title: Verifying artifacts
+title: Build: Verifying artifacts
 description: SLSA uses provenance to indicate whether an artifact is authentic or not, but provenance doesn't do anything unless somebody inspects it. SLSA calls that inspection verification, and this page describes how to verify artifacts and their SLSA provenance. The intended audience is platform implementers, security engineers, and software consumers.
 ---
 

--- a/docs/spec/draft/verifying-artifacts.md
+++ b/docs/spec/draft/verifying-artifacts.md
@@ -1,5 +1,5 @@
 ---
-title: Build: Verifying artifacts
+title: "Build: Verifying artifacts"
 description: SLSA uses provenance to indicate whether an artifact is authentic or not, but provenance doesn't do anything unless somebody inspects it. SLSA calls that inspection verification, and this page describes how to verify artifacts and their SLSA provenance. The intended audience is platform implementers, security engineers, and software consumers.
 ---
 

--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -1,5 +1,5 @@
 ---
-title: Verifying source
+title: Source: Verifying source
 description: |
   SLSA uses attestations to indicate security claims associated with a repository revision, but attestations don't do anything unless somebody inspects them.
   SLSA calls that inspection verification, and this page describes how to verify properties of source revisions using their SLSA source provenance attestations.

--- a/docs/spec/draft/verifying-source.md
+++ b/docs/spec/draft/verifying-source.md
@@ -1,5 +1,5 @@
 ---
-title: Source: Verifying source
+title: "Source: Verifying source"
 description: |
   SLSA uses attestations to indicate security claims associated with a repository revision, but attestations don't do anything unless somebody inspects them.
   SLSA calls that inspection verification, and this page describes how to verify properties of source revisions using their SLSA source provenance attestations.


### PR DESCRIPTION
Added 'Build' and 'Source' prefixes to pages that are specific to build and source tracks.

Also updated the nav to use these tags.

I didn't update the `Attesting build environments` nav because I'm not sure what the short name for that track should be. :)


I also reordered pages to put the source pages directly under build so the track stuff is closer together.

I don't feel strongly about this setup, open to other suggestions.

fixes #1421 