### PR TITLE
fix: prefix anchor tag with 'onepage-'

### DIFF
--- a/docs/_includes/onepage.liquid
+++ b/docs/_includes/onepage.liquid
@@ -19,7 +19,7 @@ This code turns a set of pages contained in a directory into one single page.
    {% capture pattern %}page.url == "{{dir}}{{file}}"{% endcapture %}
    {% assign p = pages | where_exp: "page", pattern | first %}
    <!-- {{p.url}} begins -->
-   <h2 id="{{file}}">{{p.title}}</h2>
+   <h2 id="onepage-{{file}}">{{p.title}}</h2>
    {% include section.liquid content=p.content files=files baseurl=dir noshift=false %}
    <!-- {{p.url}} ends -->
 {% endfor %}


### PR DESCRIPTION
This prefix should disambiguate the tags used in assembling this page. Unfortunately it won't ensure there aren't conflict tags elsewhere.

refs #1426