### PR TITLE
fix: Restore build-track-basics to nav

### DIFF
--- a/docs/_data/nav/main.yml
+++ b/docs/_data/nav/main.yml
@@ -260,6 +260,10 @@
       are the requirements you'll need to meet.
     children:
 
+    - title: Basics
+      url: /spec/draft/build-track-basics
+      description: The SLSA build track is organized into a series of levels that provide increasing supply chain security guarantees. This gives you confidence that software hasn't been tampered with and can be securely traced back to its source. This page is a descriptive overview of the SLSA build track levels, describing their intent.
+
     - title: Terminology
       url: /spec/draft/terminology
       description: Terminology and model used by SLSA

--- a/docs/spec/draft/onepage.md
+++ b/docs/spec/draft/onepage.md
@@ -8,6 +8,6 @@ A single page containing all the following files as different sections
 {%- endcomment -%}
 
 {% assign dir = "/spec/draft/" %}
-{% assign filenames = "whats-new,about,threats-overview,use-cases,principles,faq,future-directions,tracks,terminology,build-requirements,distributing-provenance,verifying-artifacts,assessing-build-platforms,build-env-track-basics,source-requirements,verifying-source,assessing-source-systems,threats,verified-properties,attestation-model,provenance,build-provenance,verification_summary" %}
+{% assign filenames = "whats-new,about,threats-overview,use-cases,principles,faq,future-directions,tracks,build-track-basics,terminology,build-requirements,distributing-provenance,verifying-artifacts,assessing-build-platforms,build-env-track-basics,source-requirements,verifying-source,assessing-source-systems,threats,verified-properties,attestation-model,provenance,build-provenance,verification_summary" %}
 
 {% include onepage.liquid dir=dir filenames=filenames %}


### PR DESCRIPTION
At some point this content was removed from the nav, but I think we might still want it listed.

Putting it ahead of terminology as the idea is it's the first thing people can/should read about the build track.