### PR TITLE
blog: Add blog post announcing 1.2 RC1

### DIFF
--- a/docs/_posts/2025-06-20-slsa-v1.2-rc1.md
+++ b/docs/_posts/2025-06-20-slsa-v1.2-rc1.md
@@ -1,0 +1,38 @@
+---
+title: Announcing SLSA v1.2 Release Candidate 1
+author: "SLSA Community"
+is_guest_post: false
+---
+
+Today we’re releasing for public review [SLSA Version 1.2
+RC1](/spec/v1.2-rc1/), a Release Candidate of SLSA v1.2. We are seeking
+comments on this specification by July 6th, 2025.
+
+With the introduction of the _Source Track_, SLSA v1.2 represents a major
+milestone in the development of SLSA. Indeed, while SLSA v1.0 introduced
+the notion of tracks with different levels focusing on different aspects of
+the software supply chain, its scope was limited to the _Build Track_, a
+narrower scope than what SLSA v0.1 covered. The _Source Track_ picks up the
+source management related requirements that v0.1 touched on but in a much
+more complete and thorough way, comparable to what was done in the _Build
+Track_.
+
+Please, refer to the [What's new](/spec/v1.2-rc1/whats-new) section for
+further details.
+
+SLSA v1.2 is backwards compatible with SLSA v1.1.
+
+The SLSA specification follows the [Community Specification] lifecycle
+going through several [stages of maturation](/spec-stages). The publication
+of a candidate for [Approved Specification] starts a 2 week review period
+during which the community at large is invited to review the draft and
+raise any issues. If you do find any issue, please, open an issue on
+[GitHub]. If no major issues are found during this review period the v1.2
+RC1 draft will then be published as Version 1.2, the new [Approved
+Specification], effectively replacing Version 1.1. Otherwise a v1.2 RC2
+will be published instead.
+
+[Community Specification]: https://github.com/CommunitySpecification/Community_Specification/blob/main/
+[GitHub]: https://github.com/slsa-framework/slsa/issues
+[backlog]: https://github.com/orgs/slsa-framework/projects/1/views/1
+[Approved Specification]: /spec-stages#approved

--- a/docs/_posts/2025-06-20-slsa-v1.2-rc1.md
+++ b/docs/_posts/2025-06-20-slsa-v1.2-rc1.md
@@ -6,7 +6,7 @@ is_guest_post: false
 
 Today we’re releasing for public review [SLSA Version 1.2
 RC1](/spec/v1.2-rc1/), a Release Candidate of SLSA v1.2. We are seeking
-comments on this specification by July 6th, 2025.
+comments on this specification by July 18th, 2025.
 
 With the introduction of the _Source Track_, SLSA v1.2 represents a major
 milestone in the development of SLSA. Indeed, while SLSA v1.0 introduced


### PR DESCRIPTION
Not sure the dates are right. This might need adjustment when we know for sure when 1.2 RC1 gets published. But please, let me know if you'd like to change anything else.
I'll mark this as a draft until the publication is out.
