### PR TITLE
impl: add users to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "Jekyll and Netlify",
   "image": "mcr.microsoft.com/devcontainers/ruby:2.7",
+  "containerUser": "vscode",
+  "remoteUser": "vscode",
   "features": {
     "ghcr.io/devcontainers/features/node:1": {
       "version": "lts"


### PR DESCRIPTION
Podman restricts access to /root unless the `--privileged` flag is passed. An alternative is to just specify a `remoteUser` and `containerUser`. This resolves an issue where the IDE might try to install additional tools into the devContainer.