### PR TITLE
style: Add redirects for source/build

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -66,6 +66,8 @@
 # disambiguate.
 /spec/draft/levels        /spec/draft/tracks      301
 /spec/draft/provenance    /spec/draft/build-provenance   302
+/spec/v1.2-rc1/build      /spec/v1.2-rc1/tracks#build-track  302
+/spec/v1.2-rc1/source     /spec/v1.2-rc1/tracks#source-track  302
 
 # Note: Versions prior to v1.0 stay in /verification_summary.
 /verification_summary           /spec/latest/verification_summary   302  # floating


### PR DESCRIPTION
This should make it a bit easier to tell people the links and put them on slides, etc.

Once we release 1.2 it would be nice to have just slsa.dev/source, slsa.dev/build.