### PR TITLE
nonspec: Add tombedfordgit to maintainers

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -22,6 +22,7 @@ permissions in this repository.
 | Mark Lodato | lodato@google.com |  @Mark Lodato | [MarkLodato](https://github.com/MarkLodato) | Google
 | Michael Lieberman | mlieberman85@gmail.com | @Michael Lieberman | [mlieberman85](https://github.com/mlieberman85) | Kusari
 | Pavel Iakovenko | paveliak@github.com | @Pavel Iakovenko | [paveliak](https://github.com/paveliak) | GitHub
+| Tom Bedford | tbedford9@bloomberg.net | @Tom Bedford | [tombedfordgit](https://github.com/tombedfordgit) | Bloomberg
 | Tom Hennen | tomhennen@google.com | @Tom Hennen | [TomHennen](https://github.com/TomHennen) | Google
 | Trishank Karthik Kuppusamy | trishank.kuppusamy@datadoghq.com | @trishank | [trishankatdatadog](https://github.com/trishankatdatadog) | Datadog
 | Zachariah Cox | zachariahcox@github.com | @zachariahcox | [zachariahcox](https://github.com/zachariahcox) | GitHub


### PR DESCRIPTION
Following a brief chat with @meder and @adriandiglio, self-nominating myself as a maintainer.
I believe I meet the criteria through my work on the incoming Dependency Track