### PR TITLE
fix: Remove heading, it messes up summary rendering.

### DIFF
--- a/docs/_posts/2025-07-22-slsa-e2e.md
+++ b/docs/_posts/2025-07-22-slsa-e2e.md
@@ -4,8 +4,6 @@ author: "Andrew McNamara, Tom Hennen"
 is_guest_post: false
 ---
 
-## Goal
-
 This is a request for examples (RFE) for an end-to-end
 implementation of the Supply-chain Levels for Software Artifacts
 ([SLSA](slsa.dev)) framework. The goal is to create a comprehensive


### PR DESCRIPTION
Fixes the summary display at slsa.dev/blog

<img width="1263" height="425" alt="image" src="https://github.com/user-attachments/assets/dd566dbd-bc1e-4cb1-8d9b-0b6952f8e2f0" />
