### PR TITLE
security: pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/migrate-to-late-branch.yml
+++ b/.github/workflows/migrate-to-late-branch.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout main (no matter what else is requested)
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4 on 2025-08-13
         with:
           ref: main # Checkout the main branch
           fetch-depth: 1 # We don't need the full history for this operation


### PR DESCRIPTION
# Pin GitHub Actions to commit hashes

This pull request pins all GitHub Actions in workflow files to specific commit hashes to improve security and ensure reproducible builds.

## Changes Made

- Converted version tags (e.g., `v3`, `v4`) to commit hashes
- Added comments showing the original version and date for reference
- Preserved all existing functionality while improving security

## Benefits

- **Security**: Prevents supply chain attacks by ensuring immutable action references  
- **Reproducibility**: Guarantees the same action version is used across all runs
- **Auditability**: Clear tracking of which specific version of each action is being used

## Review Notes

- All pinned actions maintain their original functionality
- Comments preserve the original version information with dates for easy reference
- No workflow behavior changes are expected

This change follows GitHub's security best practices for action pinning.