### PR TITLE
Threat model for the BuildEnv track (take 2)

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -30,4 +30,7 @@
     {%- if page.noindex %}
     <meta name="robots" content="noindex">
     {% endif -%}
+    {%- if page.mermaid %}
+    {% include mermaid.html %}  
+    {% endif -%}
 </head>

--- a/docs/_includes/mermaid.html
+++ b/docs/_includes/mermaid.html
@@ -1,0 +1,11 @@
+<script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11.4.1/+esm';
+    let config = { 
+        startOnLoad: true,
+        flowchart: { 
+            useMaxWidth: true, 
+            htmlLabels: true 
+        } 
+    };
+    mermaid.initialize(config);
+</script>

--- a/docs/spec/draft/terminology.md
+++ b/docs/spec/draft/terminology.md
@@ -102,7 +102,7 @@ of build types](/provenance/v1#index-of-build-types).
 | <span id="platform">Platform</span> | System that allows tenants to run builds. Technically, it is the transitive closure of software and services that must be trusted to faithfully execute the build. It includes software, hardware, people, and organizations.
 | Admin | A privileged user with administrative access to the platform, potentially allowing them to tamper with builds or the control plane.
 | Tenant | An untrusted user that builds an artifact on the platform. The tenant defines the build steps and external parameters.
-| Control plane | Build platform component that orchestrates each independent build execution and produces provenance. The control plane is managed by an admin and trusted to be outside the tenant's control.
+| <span id="control-plane">Control plane</span> | Build platform component that orchestrates each independent build execution and produces provenance. The control plane is managed by an admin and trusted to be outside the tenant's control.
 | Build | Process that converts input sources and dependencies into output artifacts, defined by the tenant and executed within a single build environment on a platform.
 | Steps | The set of actions that comprise a build, defined by the tenant.
 | <span id="build-environment">Build environment</span> | The independent execution context in which the build runs, initialized by the control plane. In the case of a distributed build, this is the collection of all such machines/containers/VMs that run steps.


### PR DESCRIPTION
This is an alternative PR for the https://github.com/slsa-framework/slsa/issues/1267

For the most part it reiterates threats expressed in the original PR but it takes an effort to group threats differently into these classes:
- _in transit_ (during the image distribution) aligning those with `L1` level
- _at rest_ threats aligning those with `L2`
- _in use_ threats aligning those with `L3`

We think that such an alignment provides a better mental model for BuildEnv track levels and gives users a clear picture of what kind of threats are expected to be mitigated if certain BuidlEnv level is implemented by a Build Platform.

CC @marcelamelara 