### PR TITLE
content: reorganize levels, update requirement text

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -561,8 +561,7 @@ Downstream users are expected to be familiar with the method used by the issuer.
 Example implementations:
 
 -   Issue a new VSA for each merged Pull Request and add the destination branch to `sourceRefs`.
--   Issue a new VSA each time a 'consumable branch' is updated to point to a new revision.
--   Issue a new VSA each time a 'consumable tag' is created to point to a new revision.
+-   Issue a new VSA each time a Named Reference is updated to point to a new revision.
 
 #### Example
 


### PR DESCRIPTION
Related to points 2 and 3 of https://github.com/slsa-framework/slsa/issues/1459

This PR reorganizes the levels to achieve slightly different goals. 
There is still work to do here 😅 

Major content changes:
1. Level 2 now focuses on providing evidence that a revision has reliable history. Dropped the generic term "protect" in favor of specific requirements for access and branch technical controls.
1. Level 3 now focuses on the _continuous enforcement_ aspect of technical controls. The continuity concept replaces the previous "org intent" / "consumable branches" concepts.
2. Protected tags and branches were consolidated into just "named references." The requirement to prevent tags from moving was moved from the SCS to the Org.

Minor content changes:
1. Lots of minor text edits to requirements text to align with the major changes.
3. Additional examples were added to clear up the difference between "revision ancestry" and branch "pointer history." 
7. Removed the term "change management process" in favor of "technical controls" in all cases.
