### PR TITLE
content: draft: Remove provenance requirement

### DIFF
--- a/docs/spec/draft/source-requirements.md
+++ b/docs/spec/draft/source-requirements.md
@@ -379,7 +379,7 @@ technical control.
 
 The SCS MUST record which technical controls were in place during the creation
 of each revision and it MUST ensure each control was in place from a specific
-start revision. If there is a lapse in continuity for a specific control,\
+start revision. If there is a lapse in continuity for a specific control,
 continuity of that control MUST be re-established from a new revision.
 
 Exceptions to the continuity requirement are allowed via the [safe expunging process](#safe-expunging-process).


### PR DESCRIPTION
Creating this PR to get an idea of what it would mean to remove the provenance (and VSA) requirement from the spec.

It seems like the majority of what we're looking for in provenance can be subsumed by other existing requriements we already track with provenance becoming a (convenient) implementation detail.

If we do this we might also want to move the provenance and VSA parts of this page to their own page to keep the level requirements clear.

If we accept this change it would mean that 'provenance' becomes a nice feature of any particular SLSA Source Track implementation but won't be required.