### PR TITLE
editorial: draft: Note the purpose of the provenance build model diagram

### DIFF
--- a/docs/spec/draft/build-provenance.md
+++ b/docs/spec/draft/build-provenance.md
@@ -44,6 +44,10 @@ software artifacts through execution of the `buildDefinition`.
 
 ![Build Model](images/provenance-model.svg)
 
+> NOTE: This diagram depicts how the SLSA Provenance format is structured.  It
+> elaborates on the [SLSA Build Model](terminology#build-model) but only applies
+> to the SLSA Provenance format specifically and not to builds in general.
+
 The model is as follows:
 
 -   Each build runs as an independent process on a multi-tenant build platform.


### PR DESCRIPTION
We have two diagrams that are very similar and both depict the build model.

This one, which is specific to the provenance format, and the one on the https://slsa.dev/spec/draft/terminology#build-model page which is less specific.  We probably want both versions.  So, instead of updating the diagrams I've added an explanatory note with a link to prevent confusion.

fixes #1290