### PR TITLE
blog: Announce SLSA 1.2 RC2

### DIFF
--- a/docs/_posts/2025-11-10-slsa-v1.2-rc2.md
+++ b/docs/_posts/2025-11-10-slsa-v1.2-rc2.md
@@ -30,7 +30,7 @@ during which the community at large is invited to review the draft and
 raise any issues. If you do find any issue, please, open an issue on
 [GitHub]. If no major issues are found during this review period the v1.2
 RC2 draft will then be published as Version 1.2, the new [Approved
-Specification], effectively replacing Version 1.1. Otherwise a v1.2 RC2
+Specification], effectively replacing Version 1.1. Otherwise a v1.2 RC3
 will be published instead.
 
 [Community Specification]: https://github.com/CommunitySpecification/Community_Specification/blob/main/


### PR DESCRIPTION
Create a blog post announcing SLSA 1.2 RC2.

The link won't work until #1510 is merged, so _don't_ merge this PR until that happens. :)

This is mostly a copy of [the prior post](https://slsa.dev/blog/2025/06/slsa-v1.2-rc1) to provide full context to readers instead of making them look at older posts.