### PR TITLE
blog: Announce SLSA 1.2

### DIFF
--- a/docs/_posts/2025-11-24-announce-slsa-v1.2.md
+++ b/docs/_posts/2025-11-24-announce-slsa-v1.2.md
@@ -9,8 +9,9 @@ the latest version of the SLSA specification.
 
 With the introduction of the _Source Track_, SLSA v1.2 represents a major
 milestone in the development of SLSA. The Source Track covers threats from
-the authoring and reviewing and management of source code. You can find more
-details on how SLSA addresses these threats [here](/threats). 
+the authoring and reviewing and management of source code. For more details on
+how SLSA addresses these threats please refer to
+[Threats & mitigations](/threats).
 
 Please, refer to the [What's new](/spec/v1.2/whats-new) section for further
 details.


### PR DESCRIPTION
A blog post announcing the release of SLSA 1.2.

This PR must not be merged until #1516 is live.

refs #1515 