### PR TITLE
nonspec: Waiting period begins on the last substantial change.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,8 +227,7 @@ Review process:
 
 3.  Wait an appropriate amount of time to allow for lazy consensus. Different
     types have different minimum waiting periods. The waiting period begins at
-    the timestamp of either the final required approval or the latest non-author
-    comment, whichever is later.
+    the timestamp of the last substantial change to the PR.
     -   If a few days have passed without any feedback please feel free to ping
     the PR and [in Slack](https://openssf.slack.com/archives/C03NUSAPKC6).
 


### PR DESCRIPTION
This matches how we've been working. 

Releases follow their own process
https://github.com/slsa-framework/governance/blob/main/5._Governance.md#4-specification-development-process which provides ampel time for feedback.