### PR TITLE
New source track filenames and editorial changes

### DIFF
--- a/docs/spec/draft/real-world-examples.md
+++ b/docs/spec/draft/real-world-examples.md
@@ -1,0 +1,207 @@
+## Mapping to real-world ecosystems
+
+Most real-world ecosystems fit the package model above but use different terms.
+The table below attempts to document how various ecosystems map to the SLSA
+Package model. There are likely mistakes and omissions; corrections and
+additions are welcome!
+
+<!-- Please keep this list sorted alphabetically within each section. -->
+
+<table>
+  <tr>
+    <th>Package ecosystem
+    <th>Package registry
+    <th>Package name
+    <th>Package artifact
+  <tr>
+    <td colspan=4><em>Languages</em>
+  <tr>
+    <td><a href="https://doc.rust-lang.org/cargo/appendix/glossary.html">Cargo</a> (Rust)
+    <td><a href="https://doc.rust-lang.org/cargo/appendix/glossary.html#registry">Registry</a>
+    <td><a href="https://doc.rust-lang.org/cargo/appendix/glossary.html#crate">Crate name</a>
+    <td><a href="https://doc.rust-lang.org/cargo/appendix/glossary.html#artifact">Artifact</a>
+  <tr>
+    <td><a href="https://www.cpan.org">CPAN</a> (Perl)
+    <td><a href="https://pause.perl.org/pause/query?ACTION=pause_04about">PAUSE</a>
+    <td><a href="https://neilb.org/2015/09/05/cpan-glossary.html#distribution">Distribution</a>
+    <td><a href="https://neilb.org/2015/09/05/cpan-glossary.html#release">Release</a> (or <a href="https://neilb.org/2015/09/05/cpan-glossary.html#distribution">Distribution</a>)
+  <tr>
+    <td><a href="https://go.dev/ref/mod">Go</a>
+    <td><a href="https://go.dev/ref/mod#glos-module-proxy">Module proxy</a>
+    <td><a href="https://go.dev/ref/mod#glos-module-path">Module path</a>
+    <td><a href="https://go.dev/ref/mod#glos-module">Module</a>
+  <tr>
+    <td><a href="https://maven.apache.org/glossary">Maven</a> (Java)
+    <td>Repository
+    <td>Group ID + Artifact ID
+    <td>Artifact
+  <tr>
+    <td><a href="https://www.npmjs.com/">npm</a> (JavaScript)
+    <td><a href="https://docs.npmjs.com/about-the-public-npm-registry">Registry</a>
+    <td><a href="https://docs.npmjs.com/package-name-guidelines">Package Name</a>
+    <td><a href="https://docs.npmjs.com/about-packages-and-modules">Package</a>
+  <tr>
+    <td><a href="https://docs.microsoft.com/en-us/nuget/nuget-org/overview-nuget-org">NuGet</a> (C#)
+    <td>Host
+    <td>Project
+    <td>Package
+  <tr>
+    <td><a href="https://packaging.python.org/en/latest/specifications/binary-distribution-format/#file-name-convention">PyPA</a> (Python)
+    <td><a href="https://packaging.python.org/en/latest/glossary/#term-Package-Index">Index</a>
+    <td><a href="https://packaging.python.org/en/latest/glossary/#term-Project">Project Name</a>
+    <td><a href="https://packaging.python.org/en/latest/glossary/#term-Distribution-Package">Distribution</a>
+  <tr>
+    <td colspan=4><em>Operating systems</em>
+  <tr>
+    <td><a href="https://wiki.debian.org/Teams/Dpkg">Dpkg </a> (e.g. Debian)
+    <td><em>?</em>
+    <td>Package name
+    <td>Package
+  <tr>
+    <td><a href="https://docs.flatpak.org/en/latest/introduction.html#terminology">Flatpak</a>
+    <td>Repository
+    <td>Application
+    <td>Bundle
+  <tr>
+    <td><a href="https://docs.brew.sh/Manpage">Homebrew</a> (e.g. Mac)
+    <td>Repository (Tap)
+    <td>Package name (Formula)
+    <td>Binary package (Bottle)
+  <tr>
+    <td><a href="https://wiki.archlinux.org/title/Pacman">Pacman</a> (e.g. Arch)
+    <td>Repository
+    <td>Package name
+    <td>Package
+  <tr>
+    <td><a href="https://rpm.org">RPM</a> (e.g. Red Hat)
+    <td>Repository
+    <td>Package name
+    <td>Package
+  <tr>
+    <td><a href="https://nixos.org/manual/nix">Nix</a> (e.g. <a href="https://nixos.org/">NixOS</a>)
+    <td>Repository (e.g. <a href="https://github.com/NixOS/nixpkgs">Nixpkgs</a>) or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-binary-cache">binary cache</a>
+    <td><a href="https://nixos.org/manual/nix/stable/language/derivations.html">Derivation name</a>
+    <td><a href="https://nixos.org/manual/nix/stable/language/derivations.html">Derivation</a> or <a href="https://nixos.org/manual/nix/stable/glossary.html#gloss-store-object">store object</a>
+  <tr>
+    <td colspan=4><em>Storage systems</em>
+  <tr>
+    <td><a href="https://cloud.google.com/storage/docs/key-terms">GCS</a>
+    <td><em>n/a</em>
+    <td>Object name
+    <td>Object
+  <tr>
+    <td><a href="https://github.com/opencontainers/distribution-spec/blob/main/spec.md#definitions">OCI</a>/Docker
+    <td>Registry
+    <td>Repository
+    <td>Object
+  <tr>
+    <td colspan=4><em>Meta</em>
+  <tr>
+    <td><a href="https://deps.dev/glossary">deps.dev</a>: <a href="https://deps.dev/glossary#system">System</a>
+    <td><a href="https://deps.dev/glossary#packaging-authority">Packaging authority</a>
+    <td><a href="https://deps.dev/glossary#package">Package</a>
+    <td><em>n/a</em>
+  <tr>
+    <td><a href="https://github.com/package-url/purl-spec/blob/master/PURL-SPECIFICATION.rst">purl</a>: type
+    <td>Namespace
+    <td>Name
+    <td><em>n/a</em>
+</table>
+
+Notes:
+
+-   [Go](https://go.dev) (golang) uses a significantly different distribution model than other ecosystems.
+    In Go, the package name is a source repository URL. While clients can fetch
+    directly from that URL---in which case there is no "package" or
+    "registry"---they usually fetch a zip file from a *module proxy*. The module
+    proxy acts as both a builder (by constructing the package artifact from
+    source) and a registry (by mapping package name to package artifact). People
+    trust the module proxy because builds are independently reproducible, and a
+    *checksum database* guarantees that all clients receive the same artifact
+    for a given URL.
+
+### Real-world supply chain examples
+
+Many recent high-profile attacks were consequences of supply chain integrity vulnerabilities, and could have been prevented by SLSA's framework. For example:
+
+<table>
+<thead>
+<tr>
+<th>
+<th>Threats from
+<th>Known example
+<th>How SLSA could help
+<tbody>
+<tr>
+<td>A
+<td>Producer
+<td><a href="https://en.wikipedia.org/wiki/SpySheriff">SpySheriff</a>: Software producer purports to offer anti-spyware software, but that software is actually malicious.
+<td>SLSA does not directly address this threat but could make it easier to discover malicious behavior in open source software, by forcing it into the publicly available source code.
+For closed source software SLSA does not provide any solutions for malicious producers.
+<tr>
+<td>B
+<td>Authoring & reviewing
+<td><a href="https://arstechnica.com/information-technology/2021/09/cryptocurrency-launchpad-hit-by-3-million-supply-chain-attack/">SushiSwap</a>: Contractor with repository access pushed a malicious commit redirecting cryptocurrency to themself.
+<td>Two-person review could have caught the unauthorized change.
+<tr>
+<td>C
+<td>Source code management
+<td><a href="https://news-web.php.net/php.internals/113838">PHP</a>: Attacker compromised PHP's self-hosted git server and injected two malicious commits.
+<td>A better-protected source code system would have been a much harder target for the attackers.
+<tr>
+<td>D
+<td>External build parameters
+<td><a href="https://www.reddit.com/r/HobbyDrama/comments/jouwq7/open_source_development_the_great_suspender_saga/">The Great Suspender</a>: Attacker published software that was not built from the purported sources.
+<td>A SLSA-compliant build server would have produced provenance identifying the actual sources used, allowing consumers to detect such tampering.
+<tr>
+<td>E
+<td>Build process
+<td><a href="https://www.crowdstrike.com/blog/sunspot-malware-technical-analysis/">SolarWinds</a>: Attacker compromised the build platform and installed an implant that injected malicious behavior during each build.
+<td>Higher SLSA Build levels have <a href="requirements#build-platform">stronger security requirements for the build platform</a>, making it more difficult for an attacker to forge the SLSA provenance and gain persistence.
+<tr>
+<td>F
+<td>Artifact publication
+<td><a href="https://about.codecov.io/apr-2021-post-mortem/">CodeCov</a>: Attacker used leaked credentials to upload a malicious artifact to a GCS bucket, from which users download directly.
+<td>Provenance of the artifact in the GCS bucket would have shown that the artifact was not built in the expected manner from the expected source repo.
+<tr>
+<td>G
+<td>Distribution channel
+<td><a href="https://theupdateframework.io/papers/attacks-on-package-managers-ccs2008.pdf">Attacks on Package Mirrors</a>: Researcher ran mirrors for several popular package registries, which could have been used to serve malicious packages.
+<td>Similar to above (F), provenance of the malicious artifacts would have shown that they were not built as expected or from the expected source repo.
+<tr>
+<td>H
+<td>Package selection
+<td><a href="https://blog.sonatype.com/damaging-linux-mac-malware-bundled-within-browserify-npm-brandjack-attempt">Browserify typosquatting</a>: Attacker uploaded a malicious package with a similar name as the original.
+<td>SLSA does not directly address this threat, but provenance linking back to source control can enable and enhance other solutions.
+<tr>
+<td>I
+<td>Usage
+<td><a href="https://www.horizon3.ai/attack-research/disclosures/cve-2023-27524-insecure-default-configuration-in-apache-superset-leads-to-remote-code-execution/">Default credentials</a>: Attacker could leverage default credentials to access sensitive data.
+<td>SLSA does not address this threat.
+<tr>
+<td>N/A
+<td>Dependency threats (i.e. A-H, recursively)
+<td><a href="https://web.archive.org/web/20210909051737/https://schneider.dev/blog/event-stream-vulnerability-explained/">event-stream</a>: Attacker controls an innocuous dependency and publishes a malicious binary version without a corresponding update to the source code.
+<td>Applying SLSA recursively to all dependencies would prevent this particular vector, because the provenance would indicate that it either wasn't built from a proper builder or that the binary did not match the source.
+</table>
+
+<table>
+<thead>
+<tr>
+<th>
+<th>Availability threat
+<th>Known example
+<th>How SLSA could help
+<tbody>
+<tr>
+<td>N/A
+<td>Dependency becomes unavailable
+<td><a href="https://www.techradar.com/news/this-popular-code-library-is-causing-problems-for-hundreds-of-thousands-of-devs">Mimemagic</a>: Producer intentionally removes package or version of package from repository with no warning. Network errors or service outages may also make packages unavailable temporarily.
+<td>SLSA does not directly address this threat.
+</table>
+
+A SLSA level helps give consumers confidence that software has not been tampered
+with and can be securely traced back to source—something that is difficult, if
+not impossible, to do with most software today.
+
+ 

--- a/docs/spec/draft/source-track-assessment.md
+++ b/docs/spec/draft/source-track-assessment.md
@@ -1,0 +1,221 @@
+---
+title: "Source Track: Assessment"
+description: This page describes the parts of an Source Constrol System (SCS) platform that consumers SHOULD assess in order to verify an artifact's security.
+---
+
+# {Source Track: Assessment}
+
+**About this page:** the *Source Track: Assessment* page explains the parts of a Source Control System (SCS) platform that consumers SHOULD assess in order to verify an artifact's security.
+
+**Intended audience:** {add appropriate audience}
+
+**Topics covered:** adversary threats, source control system assessments and prompts
+
+**Internet standards:** [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119), {other standards as required}
+
+>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**For more information, see:** [Threats & mitigations](threats.md).
+
+## Overview of Source Track Assessment
+
+One of SLSA's guiding [principles](principles.md) is to "trust platforms, verify
+artifacts". However, consumers cannot trust source control systems (SCSs) unless
+they have some proof that an SCS meets its
+[requirements](source-requirements.md). This page will provide information and example prompts to help assess and verify a SCS.
+
+## Adversary Threats
+
+SLSA's purpose is to help people defend against adversaries that threaten the software supply chain. By understanding adversary goals and profiles, you can assess your source  control system more easily.
+
+### The adversary's goals
+
+The SLSA Source track defends against an adversary whose primary goal is to
+inject unofficial behavior into protected source code while avoiding detection.
+Organizations typically establish change management processes to prevent this
+unofficial behavior from being introduced. The adversary's goal is to bypass the
+change management process.
+
+### Adversary profiles
+
+Consumers SHOULD also evaluate the source control systems' ability to defend
+against the following types of adversaries.
+
+1.  Project contributors, who can:
+    -   Propose changes to protected branches of the source repo.
+    -   Upload new content to the source repo.
+2.  Project maintainer, who can:
+    -   Do everything listed under "project contributors".
+    -   Define the purpose of the source repo.
+    -   Add or remove contributors to the source repo.
+    -   Add or remove permissions granted to contributors of the source repo.
+    -   Modify security controls within the source repo.
+    -   Modify controls used to enforce the change management process on the
+        source repo.
+3.  Source control system administrators, who can:
+    -   Do everything listed under "project contributors" and "project
+        maintainers".
+    -   Modify the source repo while bypassing the project maintainer's controls.
+    -   Modify the behavior of the Source Control System itself.
+    -   Access the control plane's cryptographic secrets.
+
+## Source Control System components to assess
+
+Consumers SHOULD consider at least these elements when assessing a Source
+Control System for SLSA conformance: control configuration, change management
+interface, control plane, verifier, storage.
+
+![source control system components](images/source-control-system-components.svg)
+
+The following section details these elements.
+
+### Change management interface
+
+The change management interface is the user interface for proposing and
+approving changes to protected branches within a source repository. During
+normal operation all such changes go through this interface.
+
+### Control configuration
+
+Control configuration is how organizations establish technical controls in a
+given source repository. If done well the configuration will reflect the intent
+of the organization.
+
+### Technical controls
+
+Technical controls are the organization configured settings that are used to
+determine if a revision can be introduced into storage within any particular
+context and who has access to those revisions.
+
+The technical controls component is responsible for the storage of these
+settings while the [control plane](#control-plane) is responsible for enforcing
+the configured controls.
+
+They include:
+
+-   Read/write ACLs,
+-   If approvals are required to introduce changes within a given context
+-   Which actors are allowed to issue those approvals
+-   Organization defined
+    [change management processes](#enforced-change-management-process)
+    requirements
+-   etc...
+
+### Control plane
+
+The control plane is the SCS component that orchestrates the introduction and
+creation of new revisions into a source repository. It is responsible for
+enforcing [technical controls](#technical-controls) and, at SLSA Source L3+,
+generating and signing source provenance for each revision. The control plane is
+operated by one or more administrators, who have privileges to modify the
+control plane.
+
+### Verifier
+
+The verifier is the SCS component that evaluates source provenance and generates
+and signs a
+[verification summary attestation](source-requirements#summary-attestation)
+(VSA).
+
+### Storage
+
+Storage holds source revisions and their provenance and summary attestations.
+
+## Assessing components with prompts
+
+The following are prompts for assessing a Source Control System's ability to
+meet the SLSA requirements.
+
+### Sample prompts for assessing the change management interface
+
+-   How does the SCS manage which actors are permitted to approve changes?
+-   What types of non-plain-text changes can the change management interface
+    render? How well does the SCS render those changes?
+-   What controls does the change management interface provide for enabling
+    Trusted Robot Contributions? Example: SLSA Build L3+ provenance, built from
+    SLSA Source L4+ source.
+
+### Sample prompts for assessing control configuration & technical controls
+
+-   How does the SCS prevent regression in control configurations?
+    Examples: built-in controls that cannot change, notifying project
+    maintainers when controls change, requiring public declaration of control
+    changes.
+-   How does the SCS prevent individual project maintainers from tampering with
+    controls configured by the project?
+-   How does the SCS prevent SCS administrators from tampering with a project's
+    configured technical controls?
+
+### Sample prompts for assessing the control plane & verifier
+
+**Note:** The control plane and verifier perform related roles within the SCS and
+should typically be assessed together.
+
+-   Administration
+    -   What are the ways an SCS administrator can use privileged access to
+        influence a revision creation, provenance generation, or VSA generation?
+        Examples: physical access, terminal access, access to cryptographic
+        secrets
+    -   What controls are in place to detect or prevent an SCS administrator
+        from abusing such access? Examples: two-person approvals, audit logging,
+        workload identities
+    -   Roughly how many SCS maintainers have such access?
+    -   How are privileged accounts protected? Examples: two-factor
+        authentication, client device security policies
+    -   What plans do you have for recovering from security incidents and
+        platform outages? Are they tested? How frequently?
+
+-   Control effectiveness
+    -   How does the SCS ensure the control plane is enforcing the
+        [technical controls](#technical-controls) are working as intended?
+
+-   Source provenance generation
+    -   How does the control plane observe the revision creation to ensure the
+        provenance's accuracy?
+    -   Are there situations in which the control plane will not generate
+        source provenance? What are they?
+    -   What details are included in the source provenance? Are they sufficient
+        to mitigate tampering with other SCS components?
+
+-   VSA generation
+    -   How does the verifier determine what source level a revision meets?
+    -   How does the verifier determine the organization's control expectations
+        and if they are met?
+
+-   Development practices
+    -   How do you track the control plane and verifier's software and
+        configuration?
+        Example: version control.
+    -   How do you build confidence in the control plane's software supply
+        chain? Example: SLSA Build L3+ provenance, built from SLSA Source L4+
+        source.
+    -   How do you secure communications between components? Example: TLS with
+        certificate transparency.
+
+-   Managing cryptographic secrets
+    -   How do you store the control plane and verifier's cryptographic secrets?
+    -   Which parts of the organization have access to the control plane and
+        verifier's cryptographic secrets?
+    -   What controls are in place to detect or prevent SCS administrators from
+        abusing such access? Examples: two-person approvals, audit logging
+    -   How are secrets protected in memory? Examples: secrets are stored in
+        hardware security modules and backed up in secure cold storage
+    -   How frequently are cryptographic secrets rotated? Describe the rotation
+        process.
+    -   What is your plan for remediating cryptographic secret compromise? How
+        frequently is this plan tested?
+
+### Sample prompts for assessing output storage
+
+-   How do you prevent tampering with storage directly?
+-   How do you prevent one project's revisions from affecting another project?
+
+## Source control system evaluation
+
+Organizations can either self-attest to their answers or seek certification from
+a third-party auditor. Evidence for self-attestation should be published on
+the internet and can include information such as the security model used in the
+evaluation. Evidence submitted for third-party certification need not be
+published.

--- a/docs/spec/draft/source-track-basics.md
+++ b/docs/spec/draft/source-track-basics.md
@@ -1,0 +1,182 @@
+---
+title: Source Track: Basics
+description: This page introduces the SLSA source track part of the supply chain, terminology, and the levels of the source security requirements.
+---
+
+# {Source Track: Basics}
+
+**About this page:** the *Source Track: Basics* page introduces the SLSA source track part of the supply chain, terminology, and the levels of the source security requirements.
+
+**Intended audience:** source control system implementers and security engineers
+
+**Topics covered:** source track overview, terminology, and introduction to source track levels of security
+
+**Internet standards:** [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119), {other standards as required}
+
+>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**For more information, see:** {optional}
+
+## Overview
+
+The primary purpose of the SLSA Source track is to provide producers and consumers with increasing levels of trust in the source code they produce and consume. This track describes increasing levels of trustworthiness and completeness of how a source revision was created. This page will show track-level specifics and requirements.
+
+The expected process for creating a new revision is determined solely by that repository's owner (the organization) who also determines the intent of the software in the repository and administers technical controls to enforce the process.
+
+Consumers can review attestations to verify whether a particular revision meets their standards for consuming artifacts. Information on how to use attestations is defined in this document.
+
+## Source Track Terminology
+
+These terms apply to the Source track. See the general terminology [list](terms-generic.md) for terms used throughout the SLSA specification.
+
+### Version Control Systems terminology
+
+A **Version Control System (VCS)** is a system of software and protocols for
+managing the version history of a set of files. Git, Mercurial, and Subversion
+are all examples of version control systems. The following terms apply to Version Control Systems:
+
+| Term | Description |
+| --- | --- |
+| Branch | A Named Reference that moves to track the Change History of a cohesive line of development within a Source Repository; e.g. `main`, `develop`, `feature-x`. |
+| Change | A modification to the state of the Source Repository, such as creation of a new Source Revision based on a previous Source Revision, or creation, deletion, or modification of a Named Reference. |
+| Change History | A record of the history of Source Revisions that preceded a specific revision. |
+| Named Reference | A user-friendly name for a specific source revision, such as `main` or `v1.2.3`. |
+| Source Repository (Repo) | A self-contained unit that holds the content and revision history for a set of files, along with related metadata like Branches and Tags. |
+| Source Revision | A specific, logically immutable snapshot of the repository's tracked files. It is uniquely identified by a revision identifier, such as a cryptographic hash like a Git commit SHA or a path-qualified sequential number like `25@trunk/` in SVN. A Source Revision includes both the content (the files) and its associated version control metadata, such as the author, timestamp, and parent revision(s). Note: Path qualification is needed for version control systems that represent Branches and Tags using paths, such as Subversion and Perforce. |
+| <span id="tag">Tag</span> | A Named Reference that is intended to be immutable. Once created, it is not moved to point to a different revision; e.g. `v1.2.3`, `release-20250722`. |
+
+> **NOTE:** The 'branch' and 'tag' features within version control systems may
+not always align with the 'Branch' and 'Tag' definitions provided in this
+specification. For example, in git and other version control systems, the UX may
+allow 'tags' to be moved. Patterns like `latest` and `nightly` tags rely on this.
+For the purposes of this specification these would be classified as 'Named References' and not as 'Tags'.
+
+### Source Control Systems terminology
+
+A **Source Control System (SCS)** is a platform or combination of services
+(self-hosted or SaaS) that hosts a Source Repository and provides a trusted
+foundation for managing source revisions by enforcing policies for
+authentication, authorization, and change management, such as mandatory code
+reviews or passing status checks. The following terms apply to Source Control Systems:
+
+| Term | Description
+| --- | ---
+| Organization | A set of people who collectively create Source Revisions within a Source Repository. Examples of organizations include open-source projects, a company, or a team within a company. The organization defines the goals of a Source Repository and the methods used to produce new Source Revisions. |
+| Proposed Change | A proposal to make a Change in a Source Repository. |
+| Source Provenance | Information about how a Source Revision came to exist, where it was hosted, when it was generated, what process was used, who the contributors were, and which parent revisions preceded it. |
+
+### Source Roles terminology
+
+| Role | Description
+| --- | ---
+| Administrator | A human who can perform privileged operations on one or more projects. Privileged actions include, but are not limited to, modifying the change history and modifying project- or organization-wide security policies. |
+| Trusted person | A human who is authorized by the organization to propose and approve changes to the source. |
+| Trusted robot | Automation authorized by the organization to act in explicitly defined contexts. The robot’s identity and codebase cannot be unilaterally influenced. |
+| Untrusted person | A human who has limited access to the project. They MAY be able to read the source. They MAY be able to propose or review changes to the source. They MAY NOT approve changes to the source or perform any privileged actions on the project. |
+
+
+## Source Track Level Introduction
+
+NOTE: This table presents a simplified view of the requirements. See the
+[Source Track Requirements](#source-track-requirements) section later in this document for the full list of requirements for each
+level.
+
+| Track/Level | Requirements | Focus
+| ----------- | ------------ | -----
+| [Source L1](#source-l1) | Use a version control system. | Generation of discrete Source Revisions for precise consumption.
+| [Source L2](#source-l2) | Preserve Change History and generate Source Provenance. | Reliable history through enforced controls and evidence.
+| [Source L3](#source-l3) | Enforce organizational technical controls. | Consumer knowledge of guaranteed technical controls.
+| [Source L4](#source-l4) | Require code review. | Improved code quality and resistance to insider threats.
+
+<section id="source-l1">
+
+## Source Track Level Specifics
+
+### Level 1: Version controlled
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+The source is stored and managed through a modern version control system.
+
+<dt>Intended for<dd>
+
+Organizations currently storing source in non-standard ways who want to quickly gain some benefits of SLSA and better integrate with the SLSA ecosystem with minimal impact to their current workflows.
+
+<dt>Benefits<dd>
+
+Migrating to the appropriate tools is an important first step on the road to operational maturity.
+
+</dl>
+</section>
+<section id="source-l2">
+
+### Level 2: History & Provenance
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+Branch history is continuous, immutable, and retained, and the
+SCS issues Source Provenance Attestations for each new Source Revision.
+The attestations provide contemporaneous, tamper-resistant evidence of when
+changes were made, who made them, and which technical controls were enforced.
+
+<dt>Intended for<dd>
+
+All organizations of any size producing software of any kind.
+
+<dt>Benefits<dd>
+
+Reliable history allows organizations and consumers to track changes to software
+over time, enabling attribution of those changes to the actors that made them.
+Source Provenance provides strong, tamper-resistant evidence of the process that
+was followed to produce a Source Revision.
+
+</dl>
+</section>
+<section id="source-l3">
+
+### Level 3: Continuous technical controls
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+The SCS is configured to enforce the Organization's technical controls for specific Named References within the Source Repository.
+
+<dt>Intended for<dd>
+
+Organizations that want to show evidence of their additional technical controls.
+
+<dt>Benefits<dd>
+
+A verifier can use this published data to ensure that a given Source Revision
+was created in the correct way by verifying the Source Provenance or VSA.
+Provides verifiers strong evidence of all technical controls enforced during the update of a Named Reference.
+
+</dl>
+</section>
+<section id="source-l4">
+
+### Level 4: Two-party review
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+The SCS requires two trusted persons to review all changes to protected
+branches.
+
+<dt>Intended for<dd>
+
+Organizations that want strong guarantees that the software they produce is not
+subject to unilateral changes that would subvert their intent.
+
+<dt>Benefits<dd>
+
+Makes it harder for an actor to introduce malicious changes into the software
+and makes it more likely that the source reflects the intent of the
+organization.
+
+</dl>
+</section>

--- a/docs/spec/draft/source-track-controls.md
+++ b/docs/spec/draft/source-track-controls.md
@@ -1,0 +1,294 @@
+---
+title: "Source Track: Example controls"
+description: "This page provides examples of additional controls that
+  organizations may want to implement as they adopt the SLSA Source track." 
+---
+
+# {Source Track: Example Controls}
+
+**About this page:** the *Source Track: Example Controls* page provides examples of additional controls that organizations may want to implement as they adopt the SLSA Source track.
+
+**Intended audience:** {add appropriate audience}
+
+**Topics covered:** examples of source control procedures and requirements explained in detail
+
+**Internet standards:** [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119), {other standards as required}
+
+>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**For more information, see:** {optional}
+
+## Overview of Source Track Example controls
+
+SLSA Source L3+ organizations are allowed and encouraged to define their own
+control procedures that go over and above specific requirements outlined by SLSA. This
+page provides some examples of what these additional control procedures could be.
+
+If an organization has indicated that use of these controls is part of
+their repository's expectations, consumers SHOULD be able to verify that the
+process was followed for the revision they are consuming by examining the
+[summary](./source-requirements#source-verification-summary-attestation) or
+[source provenance](./source-requirements#source-provenance-attestations)
+attestations.
+
+> For example: consumers can look for the related `ORG_SOURCE` properties in
+> the `verifiedLevels` field of the [summary
+> attestation](./source-requirements#source-verification-summary-attestation).
+
+## Source control procedure examples
+
+The following examples provide sample source control procedures that can be adapted for individual use.
+
+### Expert Code Review example
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+All changes to the source are pre-approved by experts.
+
+<dt>Intended for<dd>
+
+Enterprise repositories and mature open source projects.
+
+<dt>Benefits<dd>
+
+Prevents mistakes by developers unfamiliar with the area.
+
+</dl>
+
+#### Requirements
+
+-   **Code ownership**
+
+    Each part of the source MUST have a clearly identified set of experts.
+
+-   **Approvals from all relevant experts**
+
+    For each portion of the source modified by a change proposal, pre-approval
+    MUST be granted by a member of the defined expert set. An approval from an
+    actor that is a member of multiple expert groups may satisfy the
+    requirement for all groups in which they are a member.
+
+### Review Every Single Revision example
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+The final revision was reviewed by experts prior to submission.
+
+<dt>Intended for<dd>
+
+The highest-of-high-security-posture repos.
+
+<dt>Benefits<dd>
+
+Provides maximum chance for experts to spot problems.
+
+</dl>
+
+#### Requirements
+
+-   **Reset votes on all changes**
+
+    If the proposal is modified after receiving expert approval, all previously
+    granted approvals MUST be revoked. A new approval MUST be granted from ALL
+    required reviewers.
+
+    The new approval MAY be granted by an actor who approved a previous
+    iteration.
+
+### Automated testing example
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+The final revision was validated by automated tests.
+
+<dt>Intended for<dd>
+
+All organizations and repositories.
+
+<dt>Benefits<dd>
+
+Improves accuracy, prevents errors, and reduces human load.
+
+</dl>
+
+#### Requirements
+
+The organization MUST configure a branch protection rule to require that only
+revisions with passing test results can be pointed-to by the branch.
+
+Automatic tests SHOULD be executed in a trustworthy environment (see SLSA
+build track).
+
+Results of each test (or an aggregate) MUST be collected by the change review
+tool and made available for verification.
+
+Tests SHOULD be run against a revision created for testing by merging the topic
+branch (containing the proposed changes) into the target branch.
+
+Use of the proposed merge commit should be preferred to using the tip of the
+topic branch.
+
+### Every revision reachable from a branch was approved example
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+New revisions are created based ONLY on approved changes.
+
+<dt>Intended for<dd>
+
+All organizations and repositories.
+
+<dt>Benefits<dd>
+
+Prevents attacks that hide malicious, unreviewed commits.
+
+</dl>
+
+#### Reachable revision context
+
+In many organizations, it is normal to review only the "net difference"
+between the tip of the topic branch and the "best merge base", the closest
+shared commit between the topic and target branches computed at the time of
+review.
+
+The topic branch may contain many commits of which not all were intended to
+represent a shippable state of the repository.
+
+If a repository merges branches with a standard merge commit, all those
+unreviewed commits on the topic branch will become "reachable" from the
+protected branch by virtue of the multi-parent merge commit.
+
+When a repo is cloned, all commits _reachable_ from the main branch are
+fetched and become accessible from the local checkout.
+
+This combination of factors allows attacks where the victim performs a `git
+clone` operation followed by a `git reset --hard <unreviewed revision ID>`.
+
+#### Requirements
+
+-   **Informed Review**
+
+    The reviewer is able and encouraged to make an informed decision about
+    what they're approving. The reviewer MUST be presented with a full,
+    meaningful content diff between the proposed revision and the
+    previously reviewed revision.
+
+    It is not sufficient to indicate that a file changed without showing
+    the contents.
+
+-   **Use only rebase operations on the protected branch**
+
+    Require a squash merge strategy for the protected branch.
+
+    To guarantee that only commits representing reviewed diffs are cloned,
+    the SCS MUST rebase (or "squash") the reviewed diff into a single new
+    commit (the "squashed" commit) that has only a single parent (the
+    revision previously pointed-to by the protected branch). This is
+    different than a standard merge commit strategy which would cause all
+    the user-contributed commits to become reachable from the protected
+    branch via the second parent.
+
+    It is not acceptable to replay the sequence of commits from the topic
+    branch onto the protected branch. The intent is to reduce the accepted
+    changes to the exact diffs that were reviewed. Constituent commits of
+    the topic branch may or may not have been reviewed on an individual
+    basis, and should not become reachable from the protected branch.
+
+### Immutable Change Discussion example
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+The discussion around a change is preserved and immutable.
+
+<dt>Intended for<dd>
+
+Large orgs, or where discussion is vital to change management.
+
+<dt>Benefits<dd>
+
+Enables future education, forensics, and security auditing.
+
+</dl>
+
+#### Requirements
+
+The SCS SHOULD record a description of the proposed change and all discussions
+/ commentary related to it.
+
+The SCS MUST link this discussion to the revision itself. This is regularly
+done via commit metadata.
+
+All collected content SHOULD be made immutable if the change is accepted. It
+SHOULD NOT be possible to edit the discussion around a revision after it has
+been accepted.
+
+### Merge trains example
+
+<dl class="as-table">
+<dt>Summary<dd>
+
+A buffer branch (or "train") collects a certain number of approved changes
+before merging into the protected branch.
+
+<dt>Intended for<dd>
+
+Large organizations with high-velocity repositories where the protected branch
+needs to remain stable for longer periods.
+
+<dt>Benefits<dd>
+
+Allows more time for human and automatic code review by stabilizing the
+protected branch.
+
+</dl>
+
+#### Requirements
+
+Large organizations must keep the number of updates to key protected branches
+under certain limits to allow time for code review to happen. For example, if
+a team tries to merge 60 change requests per hour into the `main` branch, the
+tip of the `main` branch would only be stable for about 1 minute. This would
+leave only 1 minute for a new diff to be both generated and reviewed before
+it becomes stale again.
+
+The normal way to work in this environment is to create a buffer branch
+(sometimes called a "train") to collect a certain number of approved changes.
+In this model, when a change is approved for submission to the protected
+branch, it is added to the train branch instead. After a certain amount of
+time, the train branch will be merged into the protected branch. If there are
+problems detected with the contents on the train branch, it's normal for the
+whole train to be abandoned and a new train to be formed. Approved changes
+will be re-applied to a new train in this scenario.
+
+The key benefit to this approach is that the protected branch remains stable
+for longer, allowing more time for human and automatic code review. A key
+downside to this approach is that organizations will not know the final
+revision ID that represents a change until the entire train process completes.
+
+A change review process will now be associated with multiple distinct
+revisions.
+
+-   ID 1: The revision which was reviewed before concluding the change review
+    process. It represents the ideal state of the protected branch applying
+    only this proposed change.
+-   ID 2: The revision created when the change is applied to the train branch.
+    It represents the state of the protected branch _after other changes have
+    been applied_.
+
+**Note:** No human or automatic review will have the chance
+to pre-approve ID2. This will appear to violate any organization policies that
+require pre-approval of changes before submission. The SCS and the
+organization MUST protect this process in the same way they protect other
+artifact build pipelines.
+
+At a minimum the SCS MUST issue an attestation that the revision ID generated
+by a merged train is identical ("MERGESAME" in git terminology) to the state
+of the protected branch after applying each approved changeset in sequence.
+No other content may be added or removed during this process.

--- a/docs/spec/draft/source-track-provenance.md
+++ b/docs/spec/draft/source-track-provenance.md
@@ -1,0 +1,269 @@
+---
+title: "Source Track: Provenance
+description: This page covers the distribution and verification of provenance metadata in the form of SLSA attestations for the source track. 
+---
+
+# {Source Track: Provenance}
+
+**About this page:** the *Source Track: Provenance* page covers the distribution and verification of provenance metadata in the form of SLSA attestations for the source track. 
+
+**Intended audience:** source control system implementers and security engineers
+
+**Topics covered:** source track provenance and attestations
+
+**Internet standards:** [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119), {other standards as required}
+
+>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**For more information, see:** {optional}
+
+## Overview of Source Track Provenance
+
+<tr id="source-provenance"><td>Source Provenance <a href="#source-provenance">🔗</a><td>
+
+[Source Provenance](#source-provenance-attestations) are attestations that
+contain information about how a specific revision was created and how it came to
+exist on a protected branch or how a tag came to point at it. They are
+associated with the revision identifier delivered to consumers and are a
+statement of fact from the perspective of the SCS. The SCS MUST document the
+format and intent of all Source Provenance attestations it produces.
+
+Source Provenance MUST be created contemporaneously with the branch being
+updated such that they provide a credible, auditable, record of changes.
+
+If a consumer is authorized to access a revision, they MUST be able to access the
+corresponding Source Provenance documents for that revision.
+
+It is possible that an SCS can make no claims about a particular revision.
+
+> For example, this would happen if the revision was created on another SCS,
+on an unprotected branch (such as a `topic` branch), or if the revision was not
+the result of the expected process.
+
+<td><td>✓<td>✓<td>✓
+<tr id="protected-refs"><td>Protected Named References <a href="#protected-refs">🔗</a><td>
+
+The SCS MUST provide the ability for an organization to enforce customized technical controls for Named References.
+
+The SCS MUST provide a mechanism for organizations to indicate which Named
+References should be protected by technical controls.
+
+> For example, the organization may instruct the SCS to protect `main` and
+`refs/heads/releases/*`, but not `refs/heads/experimental/*` using branch
+protection rules (e.g. [GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets),
+[GitLab](https://docs.gitlab.com/ee/user/project/repository/branches/protected.html))
+or via the application and verification of [gittuf](https://github.com/gittuf/gittuf)
+policies.
+
+> For another example, the organization may instruct the SCS to prevent the deletion of
+all `refs/tags/releases/*` using tag protection rules
+(e.g. [GitHub](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets),
+[GitLab](https://docs.gitlab.com/user/project/protected_tags/))
+or via the application and verification of [gittuf](https://github.com/gittuf/gittuf)
+policies.
+
+The SCS MUST
+
+-   Record technical controls enforced on Named References in contemporaneously
+   produced attestations associated with the corresponding Source Revisions.
+-   Allow organizations to provide
+   [organization-specified properties](#additional-properties) to be included in the
+   [Source VSA](#source-verification-summary-attestation) when the corresponding controls are
+   enforced.
+-   Allow organizations to distribute additional attestations related to their
+   technical controls to consumers authorized to access the corresponding Source
+   Revision.
+-   Prevent organization-specified properties from beginning with any value
+   other than `ORG_SOURCE_`.
+
+<td><td><td>✓<td>✓
+<tr id="two-party-review"><td>Two-party review <a href="#two-party-review">🔗</a><td>
+
+Changes in protected branches MUST be agreed to by two or more trusted persons prior to submission.
+The following combinations are acceptable:
+
+-   Uploader and reviewer are two different trusted persons.
+-   Two different reviewers are trusted persons.
+
+Reviews SHOULD cover, at least, security relevant properties of the code.
+
+**[Final revision approved]** This requirement applies to the final revision
+submitted. I.e., if additional changes are made during the review process, those changes MUST
+be reviewed as well.
+
+**[Context-specific approvals]** Approvals are for a specific context, such as a
+repo + branch in git. Moving fully reviewed content from one context to another
+still requires review. The exact definition of “context” depends on the project,
+and this does not preclude well-understood automatic merges, such as cutting a release branch.
+
+**[Informed Review]** The SCS MUST present reviewers with a clear representation of the result of accepting the proposed change. See [Human Readable Changes](#human-readable-diff).
+
+**[Trusted Robot Contributions]** An organization MAY choose to grant a Trusted
+Robot a perpetual exception to a policy (e.g. a bot may be able to merge a change
+that has not been reviewed by two parties).
+
+Examples:
+
+-   Import and migration bots that move code from one repo to another.
+-   Dependabot
+
+<td><td><td><td>✓
+</table>
+
+## Source Track Attestations
+
+SLSA source level details are communicated using attestations.
+These attestations either refer to a source revision itself or provide context needed to evaluate an attestation that _does_ refer to a revision.
+
+There are two broad categories of source attestations within the source track:
+
+1.  Source verification summary attestations (Source VSAs): Used to communicate to downstream users what high level security properties a given source revision meets.
+2.  Source provenance attestations: Provide trustworthy, tamper-proof, metadata with the necessary information to determine what high level security properties a given source revision has.
+
+To provide interoperability and ensure ease of use, it's essential that the Source VSAs are applicable across all Source Control Systems.
+However, due to the significant differences in how SCSs operate and how they may choose to meet the Source Track requirements, it is preferable to
+allow for flexibility with the full source provenance attestations. To that end, SLSA leaves source provenance attestations undefined and up to the SCSs to determine
+what works best in their environment.
+
+### Source verification summary attestation
+
+Source verification summary attestations (Source VSAs) are issued by some authority that has sufficient evidence to make the determination of a given
+revision's source level.  Source VSAs convey properties about the revision as a whole and summarize properties computed over all
+the changes that contributed to that revision over its history.
+
+The source track issues Source VSAs using the [Verification Summary Attestations](./verification_summary.md) format as follows:
+
+1.  `subject.uri` SHOULD be set to a URI where a human can find details about
+    the revision. This field is not intended for policy decisions. Instead, it
+    is only intended to direct a human investigating verification failures.
+    -   For example: `https://github.com/slsa-framework/slsa/commit/6ff3cd75c8c9e0fcedc62bd6a79cf006f185cedb`
+2.  `subject.digest` MUST include the revision identifier (e.g. `gitCommit`) and MAY include other digests over the contents of the revision (e.g. `gitTree`, `dirHash`, etc.).
+SCSs that do not use cryptographic digests MUST define a canonical type that is used to identify immutable revisions and MUST include the repository within the type[^1].
+    -   For example: `svn_revision_id: svn+https://svn.myproject.org/svn/MyProject/trunk@2019`
+3.  `subject.annotations.sourceRefs` SHOULD be set to a list of references that pointed to this revision when the attestation was created. The list MAY be non-exhaustive.
+    -   git references MUST be fully qualified (e.g. `refs/heads/main` or `refs/tags/v1.0`) to reduce the likelihood of confusing downstream tooling.
+4.  `resourceUri` MUST be set to the URI of the repository, preferably using [SPDX Download Location](https://spdx.github.io/spdx-spec/v2.3/package-information/#77-package-download-location-field).
+E.g. `git+https://github.com/foo/hello-world`.
+5.  `verifiedLevels` MUST include the SLSA source track level the SCS asserts the revision meets. One of `SLSA_SOURCE_LEVEL_0`, `SLSA_SOURCE_LEVEL_1`, `SLSA_SOURCE_LEVEL_2`, `SLSA_SOURCE_LEVEL_3`.
+MAY include additional properties as asserted by the SCS.  The SCS MUST include _only_ the highest SLSA source level met by the revision.
+6.  `dependencyLevels` MAY be empty as source revisions are typically terminal nodes in a supply chain. For example, this could be used to indicate the source level of any git submodules present in the revision.
+
+#### Additional properties
+
+The SLSA source track MAY create additional properties to include in
+`verifiedLevels` which attest to other claims concerning a revision.
+
+The SCS MAY embed additional properties within `verifiedLevels` provided by the
+organization as long as they are prefixed by `ORG_SOURCE_`  to distinguish them
+from other properties the SCS may wish to use. The SCS MUST enforce the use of
+this prefix for such properties. An organization MAY further differentiate
+properties using:
+
+-   `ORG_SOURCE_` to indicate a property that is meant for consumption by
+   external consumers.
+-   `ORG_SOURCE_INTERNAL_` to indicate a property that is not meant for
+   consumption by external consumers.
+
+The meaning of the properties is left entirely to the organization.
+
+#### Populating sourceRefs
+
+The Source VSA issuer may choose to populate `sourceRefs` in any way they wish.
+Downstream users are expected to be familiar with the method used by the issuer.
+
+Example implementations:
+
+-   Issue a new VSA for each merged Pull Request and add the destination branch to `sourceRefs`.
+-   Issue a new VSA each time a Named Reference is updated to point to a new revision.
+
+#### Example
+
+```json
+"_type": "https://in-toto.io/Statement/v1",
+"subject": [{
+  "uri": "https://github.com/foo/hello-world/commit/9a04d1ee393b5be2773b1ce204f61fe0fd02366a",
+  "digest": {"gitCommit": "9a04d1ee393b5be2773b1ce204f61fe0fd02366a"},
+  "annotations": {"sourceRefs": ["refs/heads/main", "refs/heads/release_1.0"]}
+}],
+
+"predicateType": "https://slsa.dev/verification_summary/v1",
+"predicate": {
+  "verifier": {
+    "id": "https://example.com/source_verifier",
+  },
+  "timeVerified": "1985-04-12T23:20:50.52Z",
+  "resourceUri": "git+https://github.com/foo/hello-world",
+  "policy": {
+    "uri": "https://example.com/slsa_source.policy",
+  },
+  "verificationResult": "PASSED",
+  "verifiedLevels": ["SLSA_SOURCE_LEVEL_3"],
+}
+```
+
+#### How to verify
+
+See [Verifying Source](./verifying-source.md) for instructions how to verify
+VSAs for Source Revisions.
+
+### Source provenance attestations
+
+Source provenance attestations provide tamper-proof evidence ([attestation model](attestation-model))
+that can be used to determine what SLSA Source Level or other high-level properties a given revision meets.
+This evidence can be used by:
+
+-   an authority as the basis for issuing a [Source VSA](#source-verification-summary-attestation)
+-   a consumer to cross-check a [Source VSA](#source-verification-summary-attestation) they received for a revision
+-   a consumer to enforce a more detailed policy than the organization's own process
+
+SCSs may have different methods of operating that necessitate different forms of evidence.
+E.g. GitHub-based workflows may need different evidence than Gerrit-based workflows, which would both likely be different from workflows that
+operate over Subversion repositories.
+
+These differences also mean that, depending on the configuration, the issuers of provenance attestations may vary from implementation to implementation, often because entities with the knowledge to issue them may vary.
+The authority that issues [Source VSAs](#source-verification-summary-attestation) MUST understand which entity should issue each provenance attestation type, and ensure all source provenance attestations come from their expected issuers.
+
+'Source provenance attestations' is a generic term used to refer to any type of attestation that provides evidence of the process used to create a revision.
+
+Example source provenance attestations:
+
+-   A TBD attestation which describes the revision's parents and the actors involved in creating this revision.
+-   A "code review" attestation which describes the basics of any code review that took place.
+-   An "authentication" attestation which describes how the actors involved in any revision were authenticated.
+-   A [Vuln Scan attestation](https://github.com/in-toto/attestation/blob/main/spec/predicates/vuln.md)
+    which describes the results of a vulnerability scan over the contents of the revision.
+-   A [Test Results attestation](https://github.com/in-toto/attestation/blob/main/spec/predicates/test-result.md)
+ which describes the results of any tests run on the revision.
+-   An [SPDX attestation](https://github.com/in-toto/attestation/blob/main/spec/predicates/spdx.md)
+ which provides a software bill of materials for the revision.
+-   A [SCAI attestation](https://github.com/in-toto/attestation/blob/main/spec/predicates/scai.md) used to
+ describe which source quality tools were run on the revision.
+
+Irrespective of the types of provenance attestations generated by an SCS and
+their implementations, the SCS MUST document provenance
+formats, and how each provenance attestation can be used to reason about the
+revision's properties recorded in the summary attestation.
+
+[^1]: in-toto attestations allow non-cryptographic digest types: https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md#supported-algorithms.
+
+## Disclaimer
+
+When onboarding a branch to the SLSA Source Track or increasing the level of
+that branch, organizations are making claims about how the branch is managed
+from that revision forward. This establishes [continuity](#continuity).
+
+No claims are made for prior revisions.
+
+## Future Considerations
+
+### Authentication
+
+-   Better protection against phishing by forbidding second factors that are not
+  phishing resistant.
+-   Protect against authentication token theft by forbidding bearer tokens
+  (e.g. PATs).
+-   Including length of continuity in the VSAs
+
+

--- a/docs/spec/draft/source-track-requirements.md
+++ b/docs/spec/draft/source-track-requirements.md
@@ -1,0 +1,252 @@
+---
+title: "Source Track: Requirements
+description: "This page covers the technical requirements for producing source revisions at each SLSA level." 
+---
+
+# {Source Track: Requirements}
+
+**About this page:** the *Source Track: Requirements* page covers the detailed requirements for producing source revisions at each SLSA level.
+
+**Intended audience:** source control system implementers and security engineers
+
+**Topics covered:** detailed source track-level specifics and requirements, source track systems and attestations
+
+**Internet standards:** [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119), {other standards as required}
+
+>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**For more information, see:** {optional}
+
+## Source Track Requirements Overview
+
+Many examples in this document use the
+[git version control system](https://git-scm.com/), but use of git is not a
+requirement to meet any level on the SLSA source track.
+
+### Organization Requirements
+
+[Organization]: #organization
+
+<table>
+<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
+
+<tr id="choose-scs"><td>Choose an appropriate Source Control System <a href="#choose-scs">🔗</a><td>
+
+An organization producing Source Revisions MUST select an SCS capable of reaching
+their desired SLSA Source Level.
+
+> For example, if an organization wishes to produce revisions at Source Level 3,
+they MUST choose a Source Control System capable of producing Source Level 3
+attestations.
+
+<td>✓<td>✓<td>✓<td>✓
+
+<tr id="access-and-history"><td>Configure the SCS to control access and enforce history <a href="#access-and-history">🔗</a><td>
+
+The organization MUST configure access controls to restrict sensitive operations
+on the Source Repository. These controls MUST be implemented using the
+SCS-provided [Identity Management capability](#identity-management).
+
+> For example, an organization may configure the SCS to assign users to a
+`maintainers` role and only allow users in `maintainers` to make updates to
+`main`.
+
+The SCS MUST be configured to produce a reliable [Change History](#history) for
+its consumable Source Revisions.
+If the SCS provides this capability by design, no additional controls are needed.
+Otherwise the organization MUST provide evidence of [continuous enforcement](#continuity).
+
+If the SCS supports [Tags](#tag), the SCS MUST be configured to prevent them
+from being moved or deleted.
+
+> For example, if a git tag `release1` is used to indicate a release revision
+with ID `abc123`, controls must be configured to prevent that tag from being
+updated to any other revision in the future.
+Evidence of these controls (and their continuity) will appear in the Source
+Provenance documents for revision `abc123`.
+
+<td><td>✓<td>✓<td>✓
+<tr id="safe-expunging-process"><td>Safe Expunging Process <a href="#safe-expunging-process">🔗</a><td>
+
+SCSs MAY allow the organization to expunge (remove) content from a repository
+and its change history without leaving a public record of the removed content,
+but the organization MUST only allow these changes in order to meet legal or
+privacy compliance requirements. Content changed under this process includes
+changing files, history, references, or any other metadata stored by the SCS.
+
+#### Warning: Revision Removal
+
+Removing a revision from a repository is similar to deleting a package version
+from a registry: it's almost impossible to estimate the amount of downstream
+supply chain impact.
+
+> For example, in Git, each revision ID is based on the ones before it.
+When you remove a revision, you must generate new revisions (and new revision IDs)
+for any revisions that were built on top of it. Consumers who took a dependency
+on the old revisions may now be unable to refer to the revision they've already
+integrated into their products.
+
+It may be the case that the specific set of changes targeted by a legal takedown
+can be expunged in ways that do not impact consumed revisions, which can mitigate
+these problems.
+
+It is also the case that removing content from a repository won't necessarily
+remove it everywhere.
+The content may still exist in other copies of the repository, either in backups
+or on developer machines.
+
+#### Documentation Process Requirements
+
+An organization MUST document the Safe Expunging Process and describe how
+requests and actions are tracked and SHOULD log the fact that content was
+removed. Different organizations and tech stacks may have different approaches
+to the problem.
+
+SCSs SHOULD have technical mechanisms in place which require an Administrator
+plus at least one additional 'trusted person' to trigger any expunging
+(removals) made under this process.
+
+The application of the Safe Expunging Process and the resulting logs MAY be
+private to prevent calling attention to potentially sensitive data or to comply
+with local laws and regulations. Organizations SHOULD prefer to make logs public
+if possible.
+
+<td><td>✓<td>✓<td>✓
+<tr id="technical-controls"><td>Continuous technical controls <a href="#technical-controls">🔗</a><td>
+
+The organization MUST provide evidence of continuous enforcement via technical
+controls for any claims made in the Source Provenance attestations or VSAs (see
+[control continuity](#continuity)).
+
+The organization MUST document the meaning of their enforced technical controls.
+
+> For example, if an organization implements a technical control via a custom
+tool (such as required GitHub Actions workflow), it must indicate the name of
+this tool, what it accomplishes, and how to find its evidence in the provenance
+attestation.
+
+> For another example, if the organization claims that all consumable Source
+Revisions on the `main` branch were tested prior to acceptance, this MUST be
+explicitly enforced in the SCS.
+
+<td><td><td>✓<td>✓
+
+</table>
+
+### Source Control System Requirements
+
+<table>
+<tr><th>Requirement<th>Description<th>L1<th>L2<th>L3<th>L4
+
+<tr id="repository-ids"><td>Repositories are uniquely identifiable <a href="#repository-ids">🔗</a><td>
+
+The repository ID is defined by the SCS and MUST be uniquely identifiable within
+the context of the SCS with a stable locator, such as a URI.
+
+<td>✓<td>✓<td>✓<td>✓
+<tr id="revision-ids"><td>Revisions are immutable and uniquely identifiable <a href="#revision-ids">🔗</a><td>
+The revision ID is defined by the SCS and MUST be uniquely identifiable within the context of the repository.
+When the revision ID is a digest of the content of the revision (as in git) nothing more is needed.
+When the revision ID is a number or otherwise not a digest, then the SCS MUST document how the immutability of the revision is established.
+The same revision ID MAY be present in multiple repositories.
+
+See also [Use cases for non-cryptographic, immutable, digests](https://github.com/in-toto/attestation/blob/main/spec/v1/digest_set.md#use-cases-for-non-cryptographic-immutable-digests).
+
+<td>✓<td>✓<td>✓<td>✓
+<tr id="human-readable-diff"><td>Human readable changes <a href="#human-readable-diff">🔗</a><td>
+
+The SCS MUST provide tooling to display Changes between one Source Revision and
+another in a human readable form (e.g. 'diffs') for all plain-text changes and
+SHOULD provide mechanisms to provide human understandable interpretations of
+non-plain-text changes (e.g. render images, verify and display provenance for
+binaries, etc.).
+
+<td>✓<td>✓<td>✓<td>✓
+<tr id="source-summary"><td>Source Verification Summary Attestations <a href="#source-summary">🔗</a><td>
+
+The SCS MUST generate a
+[source verification summary attestation](#source-verification-summary-attestation) (Source VSA)
+to indicate the SLSA Source Level of any revision at Level 1 or above.
+
+If a consumer is authorized to access a revision, they MUST be able to fetch the
+corresponding Source VSA.
+
+If the SCS DOES NOT generate a VSA for a revision, the revision has Source Level
+0.
+
+At Source Levels 1 and 2 the SCS MAY issue these attestations based on its
+understanding of the underlying system (e.g. based on design docs, security
+reviews, etc.), but at Level 2+ the SCS MUST use the SCS-issued
+[source provenance](#source-provenance) when issuing the VSAs.
+
+<td>✓<td>✓<td>✓<td>✓
+
+<tr id="history"><td>History <a href="#history">🔗</a><td>
+
+There are three key aspects to change history:
+
+1.  What were all the previous states of a Branch?
+2.  How and when did they change?
+3.  How does the current revision relate to previous revisions?
+
+To answer these questions, the SCS MUST record all changes to Named References,
+including when they occurred, who made them, and the new Source Revision ID.
+
+If Source Revisions have ancestry relationships in the VCS, the SCS MUST ensure
+that a Branch can only be updated to point to revisions that descend from the
+current revision.
+In git, this requires a technical control to prohibit `git push --force`.
+
+This requirement captures evidence that the organization intended to make the
+changes captured by the new revision.
+
+> For example, if a branch currently points to revision `a`, it may only be
+moved to a new revision `b` if `a` is an ancestor of `b`.
+
+<td><td>✓<td>✓<td>✓
+<tr id="continuity"><td>Continuity <a href="#continuity">🔗</a><td>
+
+Technical Controls are only effective if they are used continuously in the
+history of a Branch.
+'Control continuity' reflects an organization's ongoing commitment to a
+technical control.
+
+For each technical control claimed in a VSA, continuity MUST be established and
+tracked from a specific start revision.
+If there is a lapse in continuity for a specific control, continuity of that
+control MUST be re-established from a new revision.
+
+Exceptions to the continuity requirement are allowed via the [safe expunging process](#safe-expunging-process).
+
+> For example, the `main` branch currently points to revision `a` when a new
+technical control `t` is configured.
+The next revision on the `main` branch, `b` will be the first revision that was
+protected by `t` and `b` is the first revision in the "continuity" of `t`.
+Any revisions added to `main` while `t` is disabled will reset the continuity of `t`.
+
+<td><td>✓<td>✓<td>✓
+
+<tr id="identity-management"><td>Identity Management <a href="#identity-management">🔗</a><td>
+
+The SCS MUST provide an identity management system or some other means of
+identifying and authenticating actors.
+
+The SCS MUST allow organizations to specify which actors and roles are allowed
+to perform sensitive actions within a repository (e.g. creation or updates of
+branches, approval of changes).
+
+Depending on the SCS, identity management may be provided by source control
+services (e.g., GitHub, GitLab), implemented using cryptographic signatures
+(e.g., using gittuf to manage public keys for actors), or extending existing
+authentication systems used by the organization (e.g., Active Directory, Okta,
+etc.).
+
+The SCS MUST document how actors are identified for the purposes of attribution.
+
+Activities conducted on the SCS SHOULD be attributed to authenticated
+identities.
+
+<td><td>✓<td>✓<td>✓
+

--- a/docs/spec/draft/source-track-verification.md
+++ b/docs/spec/draft/source-track-verification.md
@@ -1,0 +1,184 @@
+---
+title: "Source Track: Verification"
+description:  This page describes how to verify properties of source revisions using their SLSA source provenance attestations. 
+---
+
+# {Source Track: Verification}
+
+**About this page:** the *Source Track: Verification* page describes how to verify properties of source revisions using their SLSA source provenance attestations. 
+
+**Intended audience:** platform implementers, security engineers, and software consumers
+
+**Topics covered:** verification criteria and steps, forming expectations, architecture options
+
+**Internet standards:** [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119), {other standards as required}
+
+>The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119](https://www.rfc-editor.org/rfc/rfc2119).
+
+**For more information, see:** {optional}
+
+## Overview of Source Track Verification
+
+SLSA uses attestations to indicate security claims associated with a repository
+revision, but attestations don't do anything unless somebody inspects them. SLSA
+calls that inspection *verification*. This page describes how to verify
+properties of source revisions using
+[the attestations](source-requirements#communicating-source-levels) associated
+with those revisions.
+
+When verifications reach Source L3+, Source Control Systems (SCSs) issue detailed
+[provenance attestations](source-requirements#source-provenance-attestations) of
+the process that was used to create specific revisions of a repository. These
+provenance attestations are issued in bespoke formats and may be too burdensome
+to use in some use cases. However, [Source Verification Summary Attestations](source-requirements#source-verification-summary-attestation)
+(Source VSAs) address this, making verification more efficient and ergonomic by
+recording the result of prior verifications. Source VSAs may be issued by a VSA
+provider to make a SLSA source level determination based on the content of those
+attestations.
+
+## What needs to be verified
+
+The source consumer needs to check and confirm the following:
+
+1.  If they trust the SCS that issued the VSA and if the VSA applies to the
+   revision they've fetched.
+2.  If the claims made in the VSA match their expectations for how the source
+   should be managed.
+3.  (Optional): If the evidence presented in the source provenance matches the
+   claims made in the VSA.
+   
+## How to verify a source revision
+
+### Step 1: Check the SCS
+
+First, confirm the SLSA Source level by comparing the artifact to its VSA and the
+VSA to a preconfigured root of trust. The goal is to ensure that the VSA
+actually applies to the artifact in question and to assess the trustworthiness
+of the VSA. This mitigates threats within "B" and "C", depending on SLSA Source
+level.
+
+Once, when bootstrapping the verifier:
+
+-   Configure the verifier's roots of trust, meaning the recognized SCS
+    identities and the maximum SLSA Source level each SCS is trusted up to.
+    Different verifiers MAY use different roots of trust for repositories. The
+    root of trust configuration is likely in the form of a map from (SCS public
+    key identity, VSA `verifier.id`) to (SLSA Source level).
+
+    <details>
+    <summary>Example root of trust configuration</summary>
+
+    The following snippet shows conceptually how a verifier's roots of trust
+    might be configured using made-up syntax.
+
+    ```jsonc
+    "slsaSourceRootsOfTrust": [
+        // A SCS trusted at SLSA Source L3, using a fixed public key.
+        {
+            "publicKey": "HKJEwI...",
+            "scsId": "https://somescs.example.com/slsa/l3",
+            "slsaSourceLevel": 3
+        },
+        // A different SCS that claims to be SLSA Source L3,
+        // but this verifier only trusts it to L2.
+        {
+            "publicKey": "tLykq9...",
+            "scsId": "https://differentscs.example.com/slsa/l3",
+            "slsaSourceLevel": 2
+        },
+        // A SCS that uses Sigstore for authentication.
+        {
+            "sigstore": {
+                "root": "global",  // identifies fulcio/rekor roots
+                "subjectAlternativeNamePattern": "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@refs/tags/v*.*.*"
+            },
+            "scsId": "https://github.com/slsa-framework/slsa-source-poc/.github/workflows/compute_slsa_source.yml@refs/tags/v*.*.*",
+            "slsaSourceLevel": 3,
+        }
+        ...
+    ],
+    ```
+
+    </details>
+
+Given a revision and its VSA follow the
+[VSA verification instructions](./verification_summary.md#how-to-verify) and the
+[validation-model] using the revision identifier to perform subject matching and
+checking the `verifier.id` against the root-of-trust described above.
+
+### Step 2: Check Expectations
+
+Next, confirm that the revision's VSA meets your expectations in order to mitigate
+[threat "B"].
+
+In our threat model, the adversary has the ability to create revisions within
+the repository and get consumers to fetch that revision.  The adversary is not
+able to subvert controls implemented by the Producer and enforced by the SCS.
+Your expectations SHOULD be sufficient to detect an un-official revision and
+SHOULD make it more difficult for an adversary to create a malicious official
+revision.
+
+You SHOULD compare the VSA against expected values for at least the following
+fields:
+
+| What | Why
+| ---- | ---
+| `verifier.id` identity from [Step 1] | To prevent an adversary from substituting a VSA making false claims from an unintended SCS.
+| `subject.digest` from [Step 1] | To prevent an adversary from substituting a VSA from another revision.
+| `verificationResult` | To prevent an adversary from providing a VSA for a revision that failed some aspect of the organization's expectations.
+| `predicate.resourceUri` | To prevent an adversary from substituting a VSA for the intended repository (e.g. `git+https://github.com/IntendedOrg/hello-world`) for another (e.g. `git+https://github.com/AdversaryOrg/hello-world`)
+| `subject.annotations.sourceRefs` | To prevent an adversary from substituting the intended revision from one branch (e.g. `release`) with another (e.g. `experimental_auth`).
+| `verifiedLevels` | To ensure the expected controls were in place for the creation of the revision. E.g. `SLSA_SOURCE_LEVEL_3`, `ORG_SOURCE_STATIC_ANALYSIS`, etc...
+
+[Threat "B"]: threats#b-modifying-the-source
+[validation-model]: https://github.com/in-toto/attestation/blob/main/docs/validation.md#validation-model
+
+### Step 3: Verify Evidence using Source Provenance [optional]
+
+Optionally, at SLSA Source Level 3 and up, check the [source provenance
+attestations](source-requirements#source-provenance-attestations) directly.
+
+As the format and implementation of source provenance attestations are left to
+the SCS, you SHOULD form expectations about the claims in source provenance
+attestations and how they map to a revision's properties claimed in its VSA in
+conjunction with the SCS and the producer.
+
+## Forming Expectations
+
+<dfn>Expectations</dfn> are known values that indicate the corresponding
+revision is authentic. For example, an SCS may maintain a mapping between
+repository branches & tags and the controls they claim to implement. That
+mapping constitutes a set of expectations.
+
+Possible models for forming expectations include:
+
+-   **Trust on first use:** Accept the first version of the revision as-is. On
+    each update, compare the old VSA to the new VSA and alert on any
+    differences.
+
+-   **If defined by producer:** The revision producer tells the verifier what their
+    expectations ought to be. In this model, the verifier SHOULD provide an
+    authenticated communication mechanism for the producer to set the revision's
+    expectations, and there SHOULD be some protection against an adversary
+    unilaterally modifying them. For example, modifications might require
+    two-party control, or consumers might have to accept each policy change
+    (another form of trust on first use).
+
+It is important to note that expectations are tied to a *repository branch or
+tag*, whereas a VSA is tied to an *revision*. Different revisions will have
+different VSAs and the claims made by those VSAs may differ.
+
+## Architecture options
+
+There are several options (non-mutually exclusive) for where VSA verification
+can happen: the build system at source fetch time, the package ecosystem at
+build artifact upload time, the consumers at download time, or
+via a continuous monitoring system. Each option comes with its own set of
+considerations, but all are valid and at least one SHOULD be used.
+
+More than one component can verify VSAs. For example, even if a builder verifies
+source VSAs, package ecosystems may wish to verify the source VSAs for the
+artifacts they host that claim to be built from that source (as indicated by the
+build provenance).


### PR DESCRIPTION
The new content of the SLSA Specification needed to be recombined to include additional content categories that had clearly defined heads that facilitated navigation and provided consistency for both users and contributors. 

Some of the Source Track has been redistributed, terminology rearranged, headings clarified to reduce misunderstandings, new transitions and introductions added to existing content to enhance the flow of information.

A SLSA Track Specification Template has been created and submitted as Issue #1554 and this can assist contributors to add new content in the right places.

To create consistency in the filenames across all tracks, I have changed them to match the concepts of what each track must do:

- Basics - introduction to track, track-specific terminology, and brief listing of the levels
- Requirements - explains the detailed security requirements to achieve each level
- Provenance - covers the distribution and verification of provenance metadata in the form of SLSA attestations
- Verification -  recommendations for how to verify artifacts and their SLSA provenance by human inspection
- Assessment - describes the parts of the underlying platform that consumers should access with relevant questions

The new filenames are listed below with the original filenames in parentheses:

source-track-basics.md (source-requirements.md)
source-track-requirements.md (source-requirements.md)
source-track-provenance.md (source-requirements.md)
source-track-verification.md (verifying-source.md)
source-track-assessment.md (assessing-source-systems.md)
source-track-controls.md (source-example-controls.md)

All the information from the original track (source-requirements.md) was kept in source-track-requirements.md or copied to source-track-basics.md or source-track-provenance.md. The remaining files had their names changed for consistenacy with other tracks.

The old branch was source-track and the new branch is new-source-track.	
