### PR TITLE
impl: Revert "Update mcr.microsoft.com/devcontainers/ruby Docker tag to v4"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "Jekyll and Netlify",
-  "image": "mcr.microsoft.com/devcontainers/ruby:4.0",
+  "image": "mcr.microsoft.com/devcontainers/ruby:2.7",
   "containerUser": "vscode",
   "remoteUser": "vscode",
   "features": {


### PR DESCRIPTION
Reverts slsa-framework/slsa#1561

I merged this PR but starting the devcontainer now fails with the following error.
Since PR #1535 also fails I think we should delay moving to Ruby 4.0 to later on when it is better supported.

```
Running the postCreateCommand from devcontainer.json...

[6884 ms] Start: Run in container: /bin/sh -c ./.devcontainer/post-create.sh
/workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/error.rb:105:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)

    DidYouMean::SPELL_CHECKERS.merge!(
              ^^^^^^^^^^^^^^^^
Did you mean?  DidYouMean::SpellChecker
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/error.rb:1:in '<top (required)>'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:3:in 'Kernel#require_relative'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor/base.rb:3:in '<top (required)>'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:2:in 'Kernel#require_relative'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/vendor/thor/lib/thor.rb:2:in '<top (required)>'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/vendored_thor.rb:8:in 'Kernel#require_relative'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/vendored_thor.rb:8:in '<top (required)>'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:3:in 'Kernel#require_relative'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:3:in '<top (required)>'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/exe/bundle:29:in 'Kernel#require_relative'
        from /workspaces/slsa-test/docs/vendor/bundle/ruby/4.0.0/gems/bundler-2.1.4/exe/bundle:29:in '<top (required)>'
        from /usr/local/lib/ruby/4.0.0/rubygems.rb:303:in 'Kernel#load'
        from /usr/local/lib/ruby/4.0.0/rubygems.rb:303:in 'Gem.activate_and_load_bin_path'
        from /usr/local/bin/bundle:25:in '<main>'
[7541 ms] postCreateCommand from devcontainer.json failed with exit code 1. Skipping any further user-provided commands.
```