### PR TITLE
impl: Add build to the list of types allowed in PR title

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -27,3 +27,4 @@ jobs:
             fix
             style
             impl
+            build


### PR DESCRIPTION
Dependabot now produces PRs with a title a la "build(deps): ...." which is flagged as invalid by our PR title checker. This PR adds "build" as a valid type to be found in a PR title.