### PR TITLE
fix: broken links in spec docs

### DIFF
--- a/spec/build-requirements.md
+++ b/spec/build-requirements.md
@@ -85,7 +85,7 @@ software. It might be an open-source project, a company, a team within a
 company, or even an individual.
 
 NOTE: There were more requirements for producers in the initial
-[draft version (v0.1)](../v0.1/requirements.md#scripted-build) which impacted
+[draft version (v0.1)](https://github.com/slsa-framework/slsa/blob/v0.1/requirements.md#scripted-build) which impacted
 how a package can be built. These were removed in the v1.0 specification and
 will be reassessed and re-added as indicated in the
 [future directions](future-directions.md).
@@ -257,7 +257,7 @@ build platform (i.e. outside the trust boundary), except as noted below.
 -   Completeness of resolved dependencies is best effort.
 
 Note: This requirement was called "non-falsifiable" in the initial
-[draft version (v0.1)](../v0.1/requirements.md#non-falsifiable).
+[draft version (v0.1)](https://github.com/slsa-framework/slsa/blob/v0.1/requirements.md#non-falsifiable).
 
 <td> <td> <td>✓
 </table>
@@ -324,7 +324,7 @@ out to a remote execution service or a "self-hosted runner" that is outside the
 trust boundary of the build platform.
 
 NOTE: This requirement was split into "Isolated" and "Ephemeral Environment"
-in the initial [draft version (v0.1)](../v0.1/requirements.md).
+in the initial [draft version (v0.1)](https://github.com/slsa-framework/slsa/blob/v0.1/requirements.md).
 
 NOTE: This requirement is not to be confused with "Hermetic", which roughly
 means that the build ran with no network access. Such a requirement requires

--- a/spec/faq.md
+++ b/spec/faq.md
@@ -16,8 +16,7 @@ any progress further downstream. By making each artifact's SLSA rating
 independent from one another, it allows parallel progress and prioritization
 based on risk. (This is a lesson we learned when deploying other security
 controls at scale throughout Google.) We expect SLSA ratings to be composed to
-describe a supply chain's overall security stance, as described in the case
-study [vision](../../example.md#vision-case-study).
+describe a supply chain's overall security stance.
 
 ## Q: What about reproducible builds?
 

--- a/spec/future-directions.md
+++ b/spec/future-directions.md
@@ -40,7 +40,7 @@ A Platform Operations track could provide assurances around the hardening of
 platforms (e.g. build or source platforms) as they are operated.
 
 The initial [draft version (v0.1)] of SLSA included a section on
-[common requirements](../v0.1/requirements.md#common-requirements) that formed
+[common requirements](https://github.com/slsa-framework/slsa/blob/v0.1/requirements.md#common-requirements) that formed
 the foundation of the guidance for
 [assessing build platforms](assessing-build-platforms.md), which **may or may not** form
 the basis for a future Build Platform Operations track:

--- a/spec/use-cases.md
+++ b/spec/use-cases.md
@@ -122,8 +122,6 @@ Example ways a consumer might use SLSA for vendor-provided software:
 
 </div>
 
-For a look at how SLSA might be applied to open source in the future, see the
-[hypothetical curl example](../../example.md).
 
 </div>
 </section>

--- a/www/current-activities.md
+++ b/www/current-activities.md
@@ -15,7 +15,7 @@ Learn how you can [get involved](/community#get-involved)!
 The goal of a Build Environment track is to enable the detection of tampering
 with core components of the compute environment executing builds.
 
-The current [draft version](/spec/draft/build-env-track-basics.md)
+The current [draft version](/spec/build-env-track-basics.md)
 of the Build Environment track includes the following requirements:
 
 -   Generation and verification of SLSA Build Provenance for build images.


### PR DESCRIPTION
## Summary

Fix broken documentation links across multiple spec files:

- **spec/build-requirements.md** — Fixed 3 broken links to `../v0.1/requirements.md` (directory no longer exists). Updated to point to the v0.1 tag on GitHub.
- **spec/future-directions.md** — Fixed 1 broken link to `../v0.1/requirements.md#common-requirements`. Updated to point to the v0.1 tag on GitHub.
- **spec/faq.md** — Removed broken link to non-existent `example.md#vision-case-study`.
- **spec/use-cases.md** — Removed broken link to non-existent `example.md`.
- **www/current-activities.md** — Fixed link to `build-env-track-basics.md` (was pointing to non-existent `spec/draft/` directory).

Fixes #938