### PR TITLE
impl: Generate onepage automatically

### DIFF
--- a/spec/onepage.md
+++ b/spec/onepage.md
@@ -1,13 +1,15 @@
 ---
 title: SLSA Specification
-description: A one-page rendering of all that is included in the SLSA Working Draft.
+description: A one-page rendering of all that is included in the SLSA spec.
 noindex: true
 ---
 {%- comment -%}
 A single page containing all the following files as different sections
 {%- endcomment -%}
 
-{% assign dir = "/spec/draft/" %}
-{% assign filenames = "whats-new,about,threats-overview,use-cases,principles,faq,future-directions,tracks,build-track-basics,terminology,build-requirements,distributing-provenance,verifying-artifacts,assessing-build-platforms,build-env-track-basics,source-requirements,verifying-source,assessing-source-systems,source-example-controls,threats,verified-properties,attestation-model,provenance,build-provenance,verification_summary" %}
+{%- capture files %}
+{%- include onepage-files.liquid %}
+{%- endcapture %}
+{% assign filenames = files | strip %}
 
-{% include onepage.liquid dir=dir filenames=filenames %}
+{% include onepage.liquid dir=page.dir filenames=filenames %}

--- a/spec/zonepage.md
+++ b/spec/zonepage.md
@@ -5,6 +5,8 @@ noindex: true
 ---
 {%- comment -%}
 A single page containing all the following files as different sections
+This file needs to be processed last so make sure its filename is last in
+alphabetical order (that seems to do the trick with Jekyll).
 {%- endcomment -%}
 
 {%- capture files %}

--- a/www/_data/nav/draft.yml
+++ b/www/_data/nav/draft.yml
@@ -136,5 +136,5 @@
   url: /blog
 
 - title: Single-page view
-  url: /spec/draft/onepage
+  url: /spec/draft/zonepage
   skip_next_prev: true  # don't show as a next/prev link

--- a/www/_data/nav/main.yml
+++ b/www/_data/nav/main.yml
@@ -398,7 +398,7 @@
       description: Suggested VSA format and explanation
 
   - title: Single-page view
-    url: /spec/draft/onepage
+    url: /spec/draft/zonepage
     skip_next_prev: true  # don't show as a next/prev link
 
 - title: How to SLSA

--- a/www/_data/nav/main.yml
+++ b/www/_data/nav/main.yml
@@ -141,7 +141,7 @@
       description: Suggested VSA format and explanation
 
   - title: Single-page view
-    url: /spec/v1.2/onepage
+    url: /spec/v1.2/zonepage
     skip_next_prev: true  # don't show as a next/prev link
 
 - title: SLSA v1.1
@@ -242,7 +242,7 @@
       description: Suggested VSA format and explanation
 
   - title: Single-page view
-    url: /spec/v1.1/onepage
+    url: /spec/v1.1/zonepage
     skip_next_prev: true  # don't show as a next/prev link
 
 - title: SLSA Working Draft

--- a/www/_data/nav/v0.1.yml
+++ b/www/_data/nav/v0.1.yml
@@ -30,7 +30,7 @@
         url: /spec/v0.1/faq
 
       - title: Single-page view
-        url: /spec/v0.1/onepage
+        url: /spec/v0.1/zonepage
         skip_next_prev: true  # don't show as a next/prev link
 
     - title: Attestations

--- a/www/_data/nav/v0.2.yml
+++ b/www/_data/nav/v0.2.yml
@@ -30,7 +30,7 @@
         url: /spec/v0.1/faq
 
       - title: Single-page view
-        url: /spec/v0.1/onepage
+        url: /spec/v0.1/zonepage
         skip_next_prev: true  # don't show as a next/prev link
 
     - title: Attestations

--- a/www/_data/nav/v1.0-rc1.yml
+++ b/www/_data/nav/v1.0-rc1.yml
@@ -42,7 +42,7 @@
         url: /spec/v1.0-rc1/future-directions
 
       - title: Single-page view
-        url: /spec/v1.0-rc1/onepage
+        url: /spec/v1.0-rc1/zonepage
         skip_next_prev: true  # don't show as a next/prev link
 
     - title: Attestations

--- a/www/_data/nav/v1.0-rc2.yml
+++ b/www/_data/nav/v1.0-rc2.yml
@@ -124,5 +124,5 @@
   url: /blog
 
 - title: Single-page view
-  url: /spec/v1.0-rc2/onepage
+  url: /spec/v1.0-rc2/zonepage
   skip_next_prev: true  # don't show as a next/prev link

--- a/www/_data/nav/v1.0.yml
+++ b/www/_data/nav/v1.0.yml
@@ -128,5 +128,5 @@
   url: /blog
 
 - title: Single-page view
-  url: /spec/v1.0/onepage
+  url: /spec/v1.0/zonepage
   skip_next_prev: true  # don't show as a next/prev link

--- a/www/_data/nav/v1.1-rc1.yml
+++ b/www/_data/nav/v1.1-rc1.yml
@@ -128,5 +128,5 @@
   url: /blog
 
 - title: Single-page view
-  url: /spec/v1.1-rc1/onepage
+  url: /spec/v1.1-rc1/zonepage
   skip_next_prev: true  # don't show as a next/prev link

--- a/www/_data/nav/v1.1-rc2.yml
+++ b/www/_data/nav/v1.1-rc2.yml
@@ -128,5 +128,5 @@
   url: /blog
 
 - title: Single-page view
-  url: /spec/v1.1-rc2/onepage
+  url: /spec/v1.1-rc2/zonepage
   skip_next_prev: true  # don't show as a next/prev link

--- a/www/_data/nav/v1.2-rc1.yml
+++ b/www/_data/nav/v1.2-rc1.yml
@@ -130,7 +130,7 @@
       description: Suggested VSA format and explanation
 
   - title: Single-page view
-    url: /spec/v1.2-rc1/onepage
+    url: /spec/v1.2-rc1/zonepage
     skip_next_prev: true  # don't show as a next/prev link
 
 - title: How to SLSA

--- a/www/_data/nav/v1.2-rc2.yml
+++ b/www/_data/nav/v1.2-rc2.yml
@@ -134,7 +134,7 @@
       description: Suggested VSA format and explanation
 
   - title: Single-page view
-    url: /spec/v1.2-rc2/onepage
+    url: /spec/v1.2-rc2/zonepage
     skip_next_prev: true  # don't show as a next/prev link
 
 - title: How to SLSA

--- a/www/_includes/nav.html
+++ b/www/_includes/nav.html
@@ -1,8 +1,7 @@
 {%- comment %}
   Look up the nav bar using the version from the URL. We need to assign
   temporary variables because liquid does not support nested []'s.
-
-  Remember to update pagination.html if you update this.
+  Remember to update pagination.html and onepage-files.liquid if you update this.
 {%- endcomment %}
 
 {%- comment %}Find the right collection from the navigation data{% endcomment %}

--- a/www/_includes/onepage-files.liquid
+++ b/www/_includes/onepage-files.liquid
@@ -1,16 +1,15 @@
 {%- comment %}
-  Render next/previous links based on the nav bar.
-  Remember to update nav.html and onepage-files.liquid if you update the top part.
+  Find the right collection from the navigation data and return the list of associated files
+  Remember to update pagination.html and nav.html if you update the top part.
 {% endcomment %}
 
-{%- comment %}Find the right collection from the navigation data{% endcomment %}
 {%- assign nav = site.data.nav["main"] %}
 {%- for item in nav %}
-  {% if item.url == page.dir or item.url == page.url %}
-    {% assign this = item %}
-    {% break %}
-  {% endif %}
-{% endfor %}
+  {%- if item.url == page.dir or item.url == page.url %}
+    {%- assign this = item %}
+    {%- break %}
+  {%- endif %}
+{%- endfor %}
 {%- if this %}
   {%- comment %}matching_pages = array of "[URL] [TITLE]"{% endcomment %}
   {%- capture matching_pages_newline_separated %}
@@ -32,37 +31,17 @@
   {%- capture matching_pages_newline_separated %}
   {%- include pagination-parse.liquid collection=this %}
   {%- endcapture %}
-{% endif %}
-
+{%- endif %}
 
 {%- assign matching_pages = matching_pages_newline_separated | split: "<ENDTITLE>" %}
 
 {%- for entry in matching_pages %}
   {%- assign url = entry | split: "<ENDURL>" | first %}
-  {%- if url == page.url %}
-    {%- unless forloop.first %}
-      {%- assign prev_index = forloop.index0 | minus: 1 %}
-      {%- assign prev_entry = matching_pages[prev_index] | strip %}
-    {%- endunless %}
-    {%- unless forloop.last %}
-      {%- assign next_index = forloop.index0 | plus: 1 %}
-      {%- assign next_entry = matching_pages[next_index] | strip %}
-    {%- endunless %}
-    {%- break %}
+  {%- assign file = url | split: page.dir | last %}
+  {%- if files.size > 0 %}
+    {%- assign files = files | append: "," %}
   {%- endif %}
+  {%- assign files = files | append: {{file}} %}
 {%- endfor %}
 
-{%- if prev_entry or next_entry%}
-  <div class="mt-10 pt-10 border-t flex flex-col sm:flex-row space-between gap-5">
-    {%- if prev_entry %}
-      {%- assign url = prev_entry | split: "<ENDURL>" | first %}
-      {%- assign title = prev_entry | split: "<ENDURL>" | last | escape_once %}
-      <a href="{{ url }}" class="border rounded px-4 py-2 text-left">&lsaquo; {{ title }}</a>
-    {%- endif %}
-    {%- if next_entry %}
-      {%- assign url = next_entry | split: "<ENDURL>" | first %}
-      {%- assign title = next_entry | split: "<ENDURL>" | last | escape_once %}
-      <a href="{{ url }}" class="sm:ml-auto border rounded px-4 py-2 text-right">{{ title }} &rsaquo;</a>
-    {%- endif %}
-  </div>
-{% endif %}
+{{files}}

--- a/www/_includes/onepage.liquid
+++ b/www/_includes/onepage.liquid
@@ -1,5 +1,5 @@
 {% comment %}
-This code turns a set of pages contained in a directory into one single page.
+This code turns a set of pages into one single page.
 {% endcomment %}
 
 {% assign filenames = include.filenames %}
@@ -19,7 +19,7 @@ This code turns a set of pages contained in a directory into one single page.
    {% capture pattern %}page.url == "{{dir}}{{file}}"{% endcapture %}
    {% assign p = pages | where_exp: "page", pattern | first %}
    <!-- {{p.url}} begins -->
-   <h2 id="onepage-{{file}}">{{p.title}}</h2>
+   <h2 id="{{file}}">{{p.title}}</h2>
    {% include section.liquid content=p.content files=files baseurl=dir noshift=false %}
    <!-- {{p.url}} ends -->
 {% endfor %}

--- a/www/_includes/onepage.liquid
+++ b/www/_includes/onepage.liquid
@@ -20,6 +20,6 @@ This code turns a set of pages into one single page.
    {% assign p = pages | where_exp: "page", pattern | first %}
    <!-- {{p.url}} begins -->
    <h2 id="{{file}}">{{p.title}}</h2>
-   {% include section.liquid content=p.content files=files baseurl=dir noshift=false %}
+   {% include section.liquid content=p.content file=file files=files baseurl=dir noshift=false %}
    <!-- {{p.url}} ends -->
 {% endfor %}

--- a/www/_includes/section.liquid
+++ b/www/_includes/section.liquid
@@ -29,7 +29,6 @@ sure it is.
    {% capture pattern %}<section id="{% endcapture %}
    {% capture anchor %}<section id="{{include.file}}-{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: "</h1>", "</h2>"}}{% endcapture %}
 {% else %}
    {% assign fixedcontent = include.content %}
 {% endunless %}

--- a/www/_includes/section.liquid
+++ b/www/_includes/section.liquid
@@ -26,6 +26,10 @@ sure it is.
    {% capture anchor %}<h2 id="{{include.file}}-{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: "</h1>", "</h2>"}}{% endcapture %}
+   {% capture pattern %}<section id="{% endcapture %}
+   {% capture anchor %}<section id="{{include.file}}-{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: "</h1>", "</h2>"}}{% endcapture %}
 {% else %}
    {% assign fixedcontent = include.content %}
 {% endunless %}

--- a/www/_includes/section.liquid
+++ b/www/_includes/section.liquid
@@ -1,50 +1,51 @@
 {% comment %}
 This code includes the content of a page after massaging it to fix the
-header levels to shift them down one level, make the links relative,
-and change "section" to "sub-section" and "page" to "section" in the content.
+header levels to shift them down one level, make the links relative and
+unique by prefixing them with the filename, and change "section" to
+"sub-section" and "page" to "section" in the content.
 Note: This last step is fragile. It could have adverse effects since
 this is merely text based.
+Note: This only works if the content is already rendered (i.e., HTML) so make
+sure it is.
 {% endcomment %}
 
 {% unless include.noshift %}
-   {% assign fixedcontent = include.content | replace: "# ", "## " %}
-   {% capture fixedcontent %}{{fixedcontent | replace: "<h4", "<h5"}}{% endcapture %}
+   {% capture pattern %}<h4 id="{% endcapture %}
+   {% capture anchor %}<h5 id="{{include.file}}-{% endcapture %}
+   {% capture fixedcontent %}{{include.content | replace: pattern, anchor}}{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: "</h4>", "</h5>"}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: "<h3", "<h4"}}{% endcapture %}
+   {% capture pattern %}<h3 id="{% endcapture %}
+   {% capture anchor %}<h4 id="{{include.file}}-{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: "</h3>", "</h4>"}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: "<h2", "<h3"}}{% endcapture %}
+   {% capture pattern %}<h2 id="{% endcapture %}
+   {% capture anchor %}<h3 id="{{include.file}}-{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: "</h2>", "</h3>"}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: "<h1", "<h2"}}{% endcapture %}
+   {% capture pattern %}<h1 id="{% endcapture %}
+   {% capture anchor %}<h2 id="{{include.file}}-{% endcapture %}
+   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: "</h1>", "</h2>"}}{% endcapture %}
 {% else %}
    {% assign fixedcontent = include.content %}
 {% endunless %}
 
+{%comment%}href="#anchor -> href="#file-anchor{%endcomment%}
+{% capture pattern %}href="#{% endcapture %}
+{% capture anchor %}href="#{{include.file}}-{% endcapture %}
+{% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+
+{%comment%}Links to index page / baseurl{%endcomment%}
+{%comment%}href="index -> href="thispage{%endcomment%}
+{% capture pattern %}href="index{% endcapture %}
+{% capture anchor %}href="{{page.url}}{% endcapture %}
+{% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+{%comment%}href="baseurl" -> href="thispage"{%endcomment%}
+{% capture pattern %}href="{{include.baseurl}}"{% endcapture %}
+{% capture anchor %}href="{{page.url}}"{% endcapture %}
+{% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+
 {% for file in include.files %}
-   {%comment%}[Link](baseurl/file) -> [Link](#file){%endcomment%}
-   {% capture pattern %}]({{include.baseurl}}{{file}}{% endcapture %}
-   {% capture anchor %}](#{{file}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-   {%comment%}[Link](file) -> [Link](#file){%endcomment%}
-   {% capture pattern %}]({{file}}{% endcapture %}
-   {% capture anchor %}](#{{file}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-   {%comment%}[Link](#file#) -> [Link](#){%endcomment%}
-   {% capture pattern %}](#{{file}}#{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, "](#"}}{% endcapture %}
-
-   {%comment%}[Link]: baseurl/file -> [Link]: #file{%endcomment%}
-   {% capture pattern %}]: {{include.baseurl}}{{file}}{% endcapture %}
-   {% capture anchor %}]: #{{file}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-   {%comment%}[Link]: file -> [Link]: #file{%endcomment%}
-   {% capture pattern %}]: {{file}}{% endcapture %}
-   {% capture anchor %}]: #{{file}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-   {%comment%}[Link]: #file# -> [Link]: #{%endcomment%}
-   {% capture pattern %}]: #{{file}}#{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, "]: #"}}{% endcapture %}
-
    {%comment%}href="baseurl/file -> href="#file{%endcomment%}
    {% capture pattern %}href="{{include.baseurl}}{{file}}{% endcapture %}
    {% capture anchor %}href="#{{file}}{% endcapture %}
@@ -53,29 +54,10 @@ this is merely text based.
    {% capture pattern %}href="{{file}}{% endcapture %}
    {% capture anchor %}href="#{{file}}{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-   {%comment%}href="#file# -> href="#{%endcomment%}
-   {% capture pattern %}href="#{{file}}#{% endcapture %}
-   {% capture anchor %}href="#{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-
-   {%comment%}Links to index page / baseurl{%endcomment%}
-   {%comment%}[Link](baseurl){%endcomment%}
-   {% capture pattern %}]({{include.baseurl}}){% endcapture %}
-   {% capture anchor %}]({{page.url}}){% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-   {%comment%}We do not know how to handle this form: [Link]: baseurl
-   Changing this will screw up all other links starting with baseurl
-   {% capture pattern %}]: {{include.baseurl}}{% endcapture %}
-   {% capture anchor %}]: {{page.url}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
+   {%comment%}href="#file#anchor -> href="#file-anchor - this patterns happens after the above replacement
    {%endcomment%}
-   {%comment%}href="index -> href="thispage{%endcomment%}
-   {% capture pattern %}href="index{% endcapture %}
-   {% capture anchor %}href="{{page.url}}{% endcapture %}
-   {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
-   {%comment%}href="baseurl" -> href="thispage"{%endcomment%}
-   {% capture pattern %}href="{{include.baseurl}}"{% endcapture %}
-   {% capture anchor %}href="{{page.url}}"{% endcapture %}
+   {% capture pattern %}href="#{{file}}#{% endcapture %}
+   {% capture anchor %}href="#{{file}}-{% endcapture %}
    {% capture fixedcontent %}{{fixedcontent | replace: pattern, anchor}}{% endcapture %}
 {% endfor %}
 {% capture fixedcontent %}{{fixedcontent | replace: " section", " subsection" | replace: "Section", "Subsection" }}{% endcapture %}

--- a/www/_redirects
+++ b/www/_redirects
@@ -98,3 +98,15 @@
 /get-started            /how-to/get-started         301
 /how-to-infra           /how-to/how-to-infra        301
 /how-to-orgs            /how-to/how-to-orgs         301
+
+/spec/v0.1/onepage	/spec/v0.1/zonepage	    301
+/spec/v0.2/onepage	/spec/v0.2/zonepage	    301
+/spec/v1.0/onepage	/spec/v1.0/zonepage	    301
+/spec/v1.0-rc1/onepage	/spec/v1.0-rc1/zonepage	    301
+/spec/v1.0-rc2/onepage	/spec/v1.0-rc2/zonepage	    301
+/spec/v1.1/onepage	/spec/v1.1/zonepage	    301
+/spec/v1.1-rc1/onepage	/spec/v1.1-rc1/zonepage	    301
+/spec/v1.1-rc2/onepage	/spec/v1.1-rc2/zonepage	    301
+/spec/v1.2/onepage	/spec/v1.2/zonepage	    301
+/spec/v1.2-rc1/onepage	/spec/v1.2-rc1/zonepage	    301
+/spec/v1.2-rc2/onepage	/spec/v1.2-rc2/zonepage	    301


### PR DESCRIPTION
Maintaining the single page view of the spec has been an ongoing challenge because it relied on maintaining the list of files to be included. Invariably when a file is added we forget to update `onepage.md`. This PR makes `onepage.md` entirely automatic and version independent. Its content is drawn from the navigation menus (`/www/_data/na/*yaml`), reducing the number of files we need to maintain.

Incidentally, I found out that the current draft specification is missing dependency-track which is now included automatically. I rest my case. ;-)

This also fixes how the links within the spec are changed to relative links. In particular, as the spec grows we have more and more anchors with the same name in different files which creates collisions. To prevent this relative links are now prefixed with the filename to ensure uniqueness.