### PR TITLE
fix: Use git archive to avoid clobbering working tree in combine-versions.sh

### DIFF
--- a/tools/combine-versions.sh
+++ b/tools/combine-versions.sh
@@ -41,12 +41,6 @@ for arg in "$@"; do
   esac
 done
 
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-if [ "$CURRENT_BRANCH" = "HEAD" ]; then
-    # If detached, store commit SHA
-    CURRENT_BRANCH=$(git rev-parse HEAD)
-fi
-
 REPO_ROOT=$(git rev-parse --show-toplevel)
 
 # clean spec dir
@@ -71,17 +65,11 @@ fi
 # Then, populate every remote release branch
 for FULLNAME_BRANCH in $(git branch -r --list 'origin/releases/*'); do
     VERSION="$(basename $FULLNAME_BRANCH)"
-    RELEASE_BRANCH=releases/$VERSION
     echo Populating spec/$VERSION
-    git -C "$REPO_ROOT" reset --hard
-    git -C "$REPO_ROOT" checkout $RELEASE_BRANCH
     mkdir spec/$VERSION
-    cp -r "$REPO_ROOT/spec"/* spec/$VERSION/
+    git -C "$REPO_ROOT" archive "$FULLNAME_BRANCH" -- spec/ | tar -x --strip-components=1 -C spec/$VERSION
 done
 
-# back to the original branch
-git reset --hard
-git checkout $CURRENT_BRANCH
 echo '
 The spec folder is now ready:'
 ls -F spec


### PR DESCRIPTION
## Summary

The `combine-versions.sh` script used `git checkout` to switch to each release branch in order to copy spec files, then switched back to the original branch. This modified the entire working tree during the loop — including `www/` content like blog posts and layout files. The restore step (`git checkout $CURRENT_BRANCH`) ran without `set -e`, so a silent failure in Netlify's shallow-clone environment could leave the working tree on the wrong branch. Netlify would then detect "no change" vs. the previous deploy and skip publishing.

This is the likely explanation for the production deploy failing with "no change detected" after #1611 was merged, though we don't have access to the Netlify build logs to confirm definitively.

Replaces the checkout+copy pattern with `git archive | tar`, which reads spec files directly from each branch's tree object without touching the working tree.

## Test plan

- [x] Ran `combine-versions.sh --nofetch` locally using upstream release refs
- [x] `git status` shows zero modifications to tracked files in `www/` after the script runs
- [x] `www/spec/` populated with 12 version subdirectories (`draft/`, `v0.1/` through `v1.2-rc2/`)
- [ ] End-to-end Netlify deploy (will be confirmed by deploy preview on this PR)

🤖 Generated with the help of [Claude Code](https://claude.ai/code)