### PR TITLE
fix: Simplify netlify ignore command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
   command = "../tools/combine-versions.sh && bundle exec jekyll build"
   # Monitor changes in spec/ and tools/ directories outside base directory
   # Exit 0 (skip build) if no changes, exit 1 (build) if changes detected
-  ignore = "bash -c 'git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../spec/ ../tools/ && exit 0 || exit 1'"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../spec/ ../tools/"
 
   [build.environment]
     BUNDLE_GEMFILE = "Gemfile"
@@ -15,4 +15,4 @@
   command = "../tools/combine-versions.sh && bundle exec jekyll build --drafts --future"
   # Monitor changes in spec/ and tools/ directories outside base directory
   # Exit 0 (skip build) if no changes, exit 1 (build) if changes detected
-  ignore = "bash -c 'git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../spec/ ../tools/ && exit 0 || exit 1'"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../spec/ ../tools/"


### PR DESCRIPTION
Investigating the deployment failure of #1611 has put the focus on the ignore command specified in `netlify.toml`.

The current command is unnecessarily complicated, calling bash and explicitly setting the exit code when this will all happen when calling the git command directly.

So this change trims down the ignore command to what's really necessary, in line with [the Netlify documentation](https://docs.netlify.com/build/configure-builds/ignore-builds/).
