### PR TITLE
nonspec: Update active workstreams in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ See https://slsa.dev/community for ways to get involved in SLSA development.
 | [Build Level 4] | Andrew McNamara (@arewm)
 | [Attested Build Environments Track] | Marcela Melara (@marcelamelara), Pavel Iakovenko (@paveliak)
 | [Dependency Ingestion Track] | Mike Lieberman (@mlieberman85)
-| [Tooling] | Adolfo García Veytia (@puerco)
+| [SLSA Tooling Modernization] | Adolfo García Veytia (@puerco)
 
 [Shepherd]: CONTRIBUTING.md#workstream-lifecycle
 [Build Level 4]: https://github.com/slsa-framework/slsa/issues/977
 [Attested Build Environments Track]: https://github.com/slsa-framework/slsa/labels/build-environment-track
 [Dependency Ingestion Track]: https://github.com/slsa-framework/slsa/pull/1627
-[Tooling]: https://github.com/ossf/tac/issues/537
+[SLSA Tooling Modernization]: https://github.com/ossf/tac/issues/537
 
 ## URL Aliases
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,16 @@ See https://slsa.dev/community for ways to get involved in SLSA development.
 
 | Workstream | [Shepherd]
 | ---------- | ----------
-| [Build Level 4] | David A Wheeler (@david-a-wheeler)
+| [Build Level 4] | Andrew McNamara (@arewm)
 | [Attested Build Environments Track] | Marcela Melara (@marcelamelara), Pavel Iakovenko (@paveliak)
-| [Source Track] | Tom Hennen (@TomHennen)
-| [Version 1.2 release] | Arnaud J Le Hors (@lehors)
+| [Dependency Ingestion Track] | Mike Lieberman (@mlieberman85)
+| [Tooling] | Adolfo García Veytia (@puerco)
 
 [Shepherd]: CONTRIBUTING.md#workstream-lifecycle
 [Build Level 4]: https://github.com/slsa-framework/slsa/issues/977
 [Attested Build Environments Track]: https://github.com/slsa-framework/slsa/labels/build-environment-track
-[Source Track]: https://github.com/orgs/slsa-framework/projects/5
-[Version 1.2 release]: https://github.com/slsa-framework/slsa/labels/slsa%201.2
+[Dependency Ingestion Track]: https://github.com/slsa-framework/slsa/pull/1627
+[Tooling]: https://github.com/ossf/tac/issues/537
 
 ## URL Aliases
 


### PR DESCRIPTION
Updates the **Active workstreams** table to reflect the current state agreed in the SLSA community meeting.

Changes:
- **Build Level 4** — shepherd handed off from David A. Wheeler to [Andrew McNamara](https://github.com/arewm) (`@arewm`)
- **Attested Build Environments Track** — ongoing, unchanged
- **Source Track** — completed, removed
- **Version 1.2 release** — completed, removed
- **Dependency Ingestion Track** (new) — shepherded by [Mike Lieberman](https://github.com/mlieberman85) (`@mlieberman85`), linked to #1627
- **SLSA Tooling Modernization** (new) — shepherded by [Adolfo García Veytia](https://github.com/puerco) (`@puerco`), linked to [ossf/tac#537](https://github.com/ossf/tac/issues/537)

A 1.3 release-cut workstream is expected in the future and can be added when it kicks off.